### PR TITLE
Register datacore-mail module

### DIFF
--- a/.datacore/CATALOG.md
+++ b/.datacore/CATALOG.md
@@ -73,6 +73,7 @@ Modules extend Datacore with specialized functionality. They can be installed in
 |--------|-------------|------|------------|
 | trading | Position management, performance tracking, trading workflows | [datacore-one/datacore-trading](https://github.com/datacore-one/datacore-trading) | Private |
 | campaigns | Landing pages, deployment, analytics, A/B testing | [datacore-one/datacore-campaigns](https://github.com/datacore-one/datacore-campaigns) | Private |
+| mail | Email integration - Gmail adapter, classification, processing | [datacore-one/datacore-mail](https://github.com/datacore-one/datacore-mail) | Private |
 
 ### Installing Modules
 
@@ -202,4 +203,4 @@ Want to propose a new module? See [DIPs](../dips/README.md).
 
 ---
 
-*Last updated: 2025-12-01*
+*Last updated: 2025-12-10*


### PR DESCRIPTION
## Summary

- Adds mail module to CATALOG.md
- Email integration for Datacore with Gmail adapter
- Provides email classification and GTD task creation

## Module Details

| Field | Value |
|-------|-------|
| Name | mail |
| Repository | [datacore-one/datacore-mail](https://github.com/datacore-one/datacore-mail) |
| Visibility | Private |

## Features

- Gmail API adapter with OAuth2 authentication
- AI-powered email classification
- Automatic GTD task creation from emails
- GitHub notification processing
- Newsletter aggregation for research

## Checklist

- [x] Module structure validated
- [x] No secrets in codebase
- [x] module.yaml complete
- [x] CLAUDE.md complete
- [x] Repository created and accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)