### PR TITLE
fix(boundaries): unbreak CI gate + sanitize 7 PII files in public OSS framework repo

### DIFF
--- a/.datacore/githooks/pre-push
+++ b/.datacore/githooks/pre-push
@@ -5,9 +5,9 @@
 # reactive) and the audit script (which runs post-hoc on heartbeat).
 #
 # Activate by setting in any local clone:
-#     git config --local core.hooksPath /Users/gregor/Data/.githooks
-# OR globally:
-#     git config --global core.hooksPath /Users/gregor/Data/.githooks
+#     git config --local core.hooksPath "$(git rev-parse --show-toplevel)/.githooks"
+# OR globally (pointing at your primary Datacore checkout):
+#     git config --global core.hooksPath "$HOME/Data/.githooks"
 #
 # Reads denylist from .datacore/config/public-repo-denylist.yaml.
 # Skips silently for non-protected remotes.

--- a/.datacore/hooks/pre-commit
+++ b/.datacore/hooks/pre-commit
@@ -161,7 +161,12 @@ if [ -n "$ALL_STAGED" ]; then
         esac
         DIFF_CONTENT=$(get_staged_additions "$staged_file")
         [ -z "$DIFF_CONTENT" ] && continue
-        PATH_HITS=$(echo "$DIFF_CONTENT" | grep -E '/Users/[a-zA-Z]|/home/[a-zA-Z]' | grep -v '^\+\s*#' || true)
+        # Match /Users/<user>/ and /home/<user>/ but exclude template/CI usernames:
+        #   - /home/deploy   = server deploy template (per ENG-2026-0511-083)
+        #   - /home/runner   = GitHub Actions runner
+        #   - /home/user     = generic doc example
+        #   - /Users/runner  = macOS GitHub Actions runner
+        PATH_HITS=$(echo "$DIFF_CONTENT" | grep -P '/Users/(?!runner/)[a-zA-Z]|/home/(?!deploy/|runner/|user/)[a-zA-Z]' | grep -v '^\+\s*#' || true)
         if [ -n "$PATH_HITS" ]; then
             echo "  WARNING: Absolute personal path(s) in $staged_file:"
             echo "$PATH_HITS" | head -3 | while read -r line; do echo "    $line"; done

--- a/.datacore/hooks/pre-commit
+++ b/.datacore/hooks/pre-commit
@@ -166,7 +166,7 @@ if [ -n "$ALL_STAGED" ]; then
         #   - /home/runner   = GitHub Actions runner
         #   - /home/user     = generic doc example
         #   - /Users/runner  = macOS GitHub Actions runner
-        PATH_HITS=$(echo "$DIFF_CONTENT" | grep -P '/Users/(?!runner/)[a-zA-Z]|/home/(?!deploy/|runner/|user/)[a-zA-Z]' | grep -v '^\+\s*#' || true)
+        PATH_HITS=$(echo "$DIFF_CONTENT" | grep -P '/Users/(?!runner\b)[a-zA-Z]|/home/(?!(?:deploy|runner|user)\b)[a-zA-Z]' | grep -v '^\+\s*#' || true)
         if [ -n "$PATH_HITS" ]; then
             echo "  WARNING: Absolute personal path(s) in $staged_file:"
             echo "$PATH_HITS" | head -3 | while read -r line; do echo "    $line"; done

--- a/.datacore/lib/gitea_pull_webhook.py
+++ b/.datacore/lib/gitea_pull_webhook.py
@@ -2,7 +2,7 @@
 matched repo when Gitea POSTs a push event.
 
 Routes:
-  POST /pull/<space-name>  — pulls /home/gregor/Data/<space-name>
+  POST /pull/<space-name>  — pulls $DATACORE_ROOT/<space-name>
                             Body can be the Gitea push payload (ignored)
                             or empty.
 
@@ -25,7 +25,7 @@ from urllib.parse import urlparse, parse_qs
 BIND = os.environ.get("PULL_WEBHOOK_BIND", "100.101.159.42")
 PORT = int(os.environ.get("PULL_WEBHOOK_PORT", "8765"))
 SECRET = os.environ.get("PULL_WEBHOOK_SECRET", "")
-DATA_DIR = Path("/home/gregor/Data")
+DATA_DIR = Path(os.environ.get("DATACORE_ROOT", str(Path.home() / "Data")))
 ALLOWED_SPACES = {"0-personal", "1-datafund", "2-datacore", "3-fds",
                   "4-forge", "5-plur", "6-meridian", "7-megaphone", "8-firm"}
 

--- a/.datacore/modules/outbox/lib/archive_sync.py
+++ b/.datacore/modules/outbox/lib/archive_sync.py
@@ -209,11 +209,7 @@ class ServerArchiver:
         """Get remote home directory path."""
         if not hasattr(self, '_remote_home'):
             success, output = self._ssh_command("echo $HOME")
-<<<<<<< Updated upstream
             self._remote_home = output.strip() if success else os.path.expanduser("~")
-=======
-            self._remote_home = output.strip() if success else "/home/gregor"
->>>>>>> Stashed changes
         return self._remote_home
 
     def archive_item(self, item: ArchiveItem) -> Tuple[bool, str]:

--- a/.datacore/modules/ventures/server/venture-heartbeat.service
+++ b/.datacore/modules/ventures/server/venture-heartbeat.service
@@ -5,13 +5,13 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-User=gregor
-Group=gregor
-WorkingDirectory=/home/gregor/Data
-Environment="HOME=/home/gregor"
+User=deploy
+Group=deploy
+WorkingDirectory=/home/deploy/Data
+Environment="HOME=/home/deploy"
 Environment="PATH=/usr/local/bin:/usr/bin:/bin"
-EnvironmentFile=/home/gregor/config/nightshift.env
-ExecStart=/bin/bash /home/gregor/Data/.datacore/modules/ventures/server/venture-heartbeat.sh
+EnvironmentFile=/home/deploy/config/nightshift.env
+ExecStart=/bin/bash /home/deploy/Data/.datacore/modules/ventures/server/venture-heartbeat.sh
 Restart=always
 RestartSec=60
 

--- a/.datacore/modules/ventures/server/venture-heartbeat.sh
+++ b/.datacore/modules/ventures/server/venture-heartbeat.sh
@@ -2,7 +2,7 @@
 # Venture heartbeat wrapper — Miles (Chief of Operations)
 # Uses OAuth/subscription auth (NOT API key) to avoid burning credits.
 # Claude Code finds credentials at ~/.claude/.credentials.json
-export HOME=/home/gregor
+export HOME=/home/deploy
 export PATH=/usr/local/bin:/usr/bin:/bin
 
 # Source nightshift env for non-Claude vars (TELEGRAM_BOT_TOKEN etc.)

--- a/.datacore/settings.json
+++ b/.datacore/settings.json
@@ -348,17 +348,11 @@
   "mcpServers": {
     "plur": {
       "command": "plur-mcp",
-      "args": [],
-      "env": {
-        "PLUR_PATH": "/home/gregor/.plur"
-      }
+      "args": []
     },
     "datacore": {
       "command": "datacore-mcp",
-      "args": [],
-      "env": {
-        "DATACORE_ROOT": "/home/gregor/Data"
-      }
+      "args": []
     }
   }
 }

--- a/.github/workflows/validate-boundaries.yml
+++ b/.github/workflows/validate-boundaries.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           echo "Checking all tracked files against root-level allowlist..."
 
-          ALLOWED_ROOT_DIRS="^(\\.datacore|\\.github)/"
+          ALLOWED_ROOT_DIRS="^(\\.datacore|\\.github|\\.plur)/"
           ALLOWED_ROOT_FILES="^(\\.|CLAUDE\\.base\\.md|README\\.md|INSTALL\\.md|CONTRIBUTING\\.md|GETTING_STARTED\\.md|CHANGELOG\\.md|ROADMAP\\.md|CODE_OF_CONDUCT\\.md|SECURITY\\.md|LICENSE|CODEOWNERS|sync|install\\.yaml.*example|\\.mcp\\.json\\.example|\\.gitignore|\\.gitmodules|\\.gitattributes|\\.claude)$"
 
           VIOLATIONS=""
@@ -81,7 +81,7 @@ jobs:
         run: |
           echo "Scanning tracked markdown files for personal emails..."
 
-          ALLOWED='@example\.com|dev@datacore\.one|nightshift@datacore\.one|security@datacore\.one|noreply@|git@github\.com'
+          ALLOWED='@example\.com|dev@datacore\.one|nightshift@datacore\.one|security@datacore\.one|module-bot@datacore\.one|noreply@|git@github\.com'
 
           HITS=$(git ls-files '*.md' '*.yaml' '*.yml' -z | xargs -0 grep -oEh '[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}' 2>/dev/null | grep -vE "$ALLOWED" | grep -vE 'REDACTED' | sort -u || true)
 

--- a/.github/workflows/validate-boundaries.yml
+++ b/.github/workflows/validate-boundaries.yml
@@ -97,8 +97,14 @@ jobs:
         run: |
           echo "Scanning tracked files for absolute personal paths..."
 
-          PATH_PATTERN='/Users/[a-zA-Z]|/home/[a-zA-Z]'
-          HITS=$(git ls-files -z | xargs -0 grep -lE "$PATH_PATTERN" 2>/dev/null | grep -v '.example$' | grep -v '.github/workflows/' | grep -v '.datacore/hooks/' || true)
+          # Match /Users/<user>/ and /home/<user>/ but EXCLUDE template/CI
+          # usernames that are legitimate in a public OSS repo:
+          #   - /home/deploy   = server deploy template (per ENG-2026-0511-083)
+          #   - /home/runner   = GitHub Actions runner
+          #   - /home/user     = generic doc example
+          #   - /Users/runner  = macOS GitHub Actions runner
+          PATH_PATTERN='/Users/(?!runner/)[a-zA-Z]|/home/(?!deploy/|runner/|user/)[a-zA-Z]'
+          HITS=$(git ls-files -z | xargs -0 grep -lP "$PATH_PATTERN" 2>/dev/null | grep -v '.example$' | grep -v '.github/workflows/' | grep -v '.datacore/hooks/' || true)
 
           if [ -n "$HITS" ]; then
             echo "::error::Absolute personal paths found in tracked files"
@@ -106,7 +112,7 @@ jobs:
             # Show the offending lines
             for f in $HITS; do
               echo "--- $f ---"
-              grep -nE '/Users/[a-zA-Z]|/home/[a-zA-Z]' "$f" | head -3
+              grep -nP "$PATH_PATTERN" "$f" | head -3
             done
             exit 1
           fi

--- a/.github/workflows/validate-boundaries.yml
+++ b/.github/workflows/validate-boundaries.yml
@@ -103,7 +103,7 @@ jobs:
           #   - /home/runner   = GitHub Actions runner
           #   - /home/user     = generic doc example
           #   - /Users/runner  = macOS GitHub Actions runner
-          PATH_PATTERN='/Users/(?!runner/)[a-zA-Z]|/home/(?!deploy/|runner/|user/)[a-zA-Z]'
+          PATH_PATTERN='/Users/(?!runner\b)[a-zA-Z]|/home/(?!(?:deploy|runner|user)\b)[a-zA-Z]'
           HITS=$(git ls-files -z | xargs -0 grep -lP "$PATH_PATTERN" 2>/dev/null | grep -v '.example$' | grep -v '.github/workflows/' | grep -v '.datacore/hooks/' || true)
 
           if [ -n "$HITS" ]; then


### PR DESCRIPTION
## Summary

Unbreaks the **Validate Boundaries** workflow which has been failing daily on `main` for 3+ days, AND sanitizes the underlying PII drift the workflow was actually catching.

This is a *public OSS framework repo* — `/home/gregor/Data` hardcoded in source is real (small) leakage. Per ENG-2026-0511-083: public Datacore module repos sanitize to `/home/deploy/` template form.

## Changes (8 files)

### Workflow + hook regex
- `.github/workflows/validate-boundaries.yml` — three updates:
  1. `.plur` added to `ALLOWED_ROOT_DIRS` (mirrors pre-commit hook line 237; project engram store has been tracked since 2026-05-16)
  2. `module-bot@datacore.one` added to PII email allowlist (datacore.one service account, same category as the already-allowed `dev@`/`nightshift@`/`security@`)
  3. Personal-path regex tightened: switch to PCRE with negative-lookahead to allow `/home/deploy/`, `/home/runner/`, `/home/user/`, `/Users/runner/` (template + CI usernames)
- `.datacore/hooks/pre-commit` — same path regex update so local hook stays aligned with CI

### PII sanitization
- `.datacore/githooks/pre-push` — doc-example `/Users/gregor/Data/.githooks` → use `$(git rev-parse --show-toplevel)` or `$HOME/Data`
- `.datacore/lib/gitea_pull_webhook.py` — `DATA_DIR = Path("/home/gregor/Data")` → `Path(os.environ.get("DATACORE_ROOT", str(Path.home() / "Data")))` (matches the convention at `.datacore/lib/state_store.py:12`)
- `.datacore/modules/outbox/lib/archive_sync.py` — **resolved long-standing merge conflict** committed at `1f97da1` (2026-04-16). Kept the upstream side `os.path.expanduser("~")` instead of `/home/gregor`. File was syntactically broken since April due to live `<<<<<<<` conflict markers in the tree.
- `.datacore/modules/ventures/server/venture-heartbeat.service` — `/home/gregor` → `/home/deploy`, `User/Group=gregor` → `User/Group=deploy`
- `.datacore/modules/ventures/server/venture-heartbeat.sh` — `/home/gregor` → `/home/deploy`
- `.datacore/settings.json` — dropped `mcpServers` env blocks that hardcoded `/home/gregor` paths. Both `plur-mcp` and `datacore-mcp` default to `~/.plur` and `~/Data` when env vars are absent.

## Why this matters (per evaluation: "there's no CI for datacore, should there be?")

CI exists here for legitimate reasons:
- **Public OSS framework** (MIT, "Open-source framework for building AI-automated businesses") — hardcoded `/home/gregor` paths visible to every onlooker
- **Multi-contributor** including autonomous agents (last 7d: Miles 9 commits, plur9 4) — agents commit via nightshift without local hooks
- **Explicit design intent** (workflow comment): "cannot be bypassed with --no-verify or missing hook installation"

Disabling the workflow removes a hygiene gate that's still load-bearing. Fixing the underlying state stops the noise without removing the gate.

## Test plan

- [x] All three workflow checks expected to pass on this PR (root allowlist + PII email + personal path)
- [x] JSON, Python, and shell files parse cleanly after sanitization
- [x] Long-standing `archive_sync.py` syntax-error conflict resolved
- [ ] CI runs green