### PR TITLE
feat(spaces): discover spaces by marker file, not by [0-9]-*/ glob

### DIFF
--- a/.datacore/lib/gtd_hygiene.py
+++ b/.datacore/lib/gtd_hygiene.py
@@ -29,6 +29,9 @@ import sys
 from datetime import date, datetime, timezone
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from spaces import discover_spaces  # noqa: E402
+
 DATA_DIR = Path(__file__).resolve().parents[2]
 ADAPTER = DATA_DIR / '.datacore' / 'lib' / 'org_workspace_adapter.py'
 
@@ -89,7 +92,8 @@ def main() -> int:
     args = parser.parse_args()
 
     spaces = {}
-    for space_dir in sorted(DATA_DIR.glob('[0-9]-*')):
+    for space in discover_spaces(DATA_DIR):
+        space_dir = space.path
         org_file = space_dir / 'org' / 'next_actions.org'
         if not org_file.exists():
             continue

--- a/.datacore/lib/nightshift_inbox_cleanup.py
+++ b/.datacore/lib/nightshift_inbox_cleanup.py
@@ -7,9 +7,13 @@ Run from ~/Data directory.
 import os
 import re
 import shutil
+import sys
 from pathlib import Path
 from collections import defaultdict
 from datetime import datetime
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from spaces import discover_spaces as _discover_spaces  # noqa: E402
 
 DATA_DIR = Path(os.environ.get("DATA_DIR", Path.home() / "Data"))
 
@@ -141,12 +145,8 @@ def is_stale_news(title: str) -> bool:
 
 
 def discover_spaces() -> list:
-    """Discover Datacore spaces matching [0-9]-* pattern."""
-    spaces = []
-    for d in sorted(DATA_DIR.iterdir()):
-        if d.is_dir() and re.match(r"^[0-9]-[a-zA-Z0-9_-]+$", d.name):
-            spaces.append(d.name)
-    return spaces
+    """Space directory names. See lib/spaces.py and DIP-0015."""
+    return [s.path.name for s in _discover_spaces(DATA_DIR)]
 
 
 def main():

--- a/.datacore/lib/priority_score.py
+++ b/.datacore/lib/priority_score.py
@@ -52,6 +52,9 @@ try:
 except ImportError:  # pragma: no cover
     yaml = None
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from spaces import discover_spaces  # noqa: E402
+
 #: Work matching nothing on the graph. `task_queue.calculate_priority` treats
 #: 5 as neutral, so unmapped work keeps exactly today's behaviour — absence of
 #: alignment is not evidence of unimportance, it is evidence of a missing edge.
@@ -129,8 +132,10 @@ class IntentGraph:
         """
         root = Path(root)
         nodes = cls._read_org(root / INTENTS_ORG)
-        for f in sorted(root.glob("[0-9]-*/org/intents.org")):
-            nodes.update(cls._read_org(f, prefix=f.parent.parent.name))
+        for space in discover_spaces(root):
+            f = space.path / "org" / "intents.org"
+            if f.is_file():
+                nodes.update(cls._read_org(f, prefix=space.path.name))
         cls._resolve_serves(nodes)
         return cls(nodes, cls._read_spotlight(root / SPOTLIGHT_YAML),
                    cls._read_tag_map(root))
@@ -243,7 +248,7 @@ class IntentGraph:
         """
         out: dict[str, str] = {}
         files = [root / ".datacore" / "tags.yaml"]
-        files += sorted(root.glob("[0-9]-*/.datacore/tags.yaml"))
+        files += [s.path / ".datacore" / "tags.yaml" for s in discover_spaces(root)]
         for f in files:
             if not (yaml and f.is_file()):
                 continue

--- a/.datacore/lib/spaces.py
+++ b/.datacore/lib/spaces.py
@@ -45,9 +45,13 @@ MARKER = Path(".datacore") / "config.yaml"
 #: being discovered. Remove once discovery_discrepancy() is empty everywhere.
 LEGACY_GLOB = "[0-9]-*"
 
-#: A space nested under another lives at e.g.
-#: ``<root>/1-space/1-tracks/clients/<name>``, which is depth 4.
-MAX_DEPTH = 4
+#: A client space nested under its owner sits at e.g.
+#: ``<root>/<space>/1-tracks/clients/<name>`` — depth 4 — so 4 is the shallowest
+#: bound that works today and leaves no headroom. One extra grouping directory
+#: would push a space out of discovery *silently*, which is the failure mode
+#: this module exists to remove. 5 costs one more level of a walk that already
+#: skips everything expensive.
+MAX_DEPTH = 5
 
 #: Never descended into. ``2-projects`` holds cloned repositories with their own
 #: dependency trees and is the single biggest cost in an unbounded walk.

--- a/.datacore/lib/spaces.py
+++ b/.datacore/lib/spaces.py
@@ -1,0 +1,219 @@
+"""Space discovery.
+
+A directory is a space if it carries ``.datacore/config.yaml`` with a ``space:``
+key — the way git finds ``.git`` and monorepo tools find ``package.json``.
+Location stops mattering, so a space may live at the install root, nested under
+another space, or anywhere else.
+
+This replaces globbing ``[0-9]-*/`` at the install root, which was duplicated
+across fifteen call sites and conflated three separate things: whether a
+directory *is* a space, what *kind* of space it is, and its local sort order.
+The numeric prefix is a per-install ordinal — the same space repo is ``5-x`` in
+one install and ``9-x`` in another — so it never carried identity.
+
+Migration is deliberately non-breaking. ``discover_spaces()`` returns the
+**union** of marker-discovered and glob-discovered directories, so nothing that
+was found before stops being found. ``discovery_discrepancy()`` reports where
+the two disagree; once it is empty for every install, ``include_legacy`` can
+default to False and the glob can go. See DIP-0015 and issue #41.
+
+Typical use::
+
+    from spaces import discover_spaces
+
+    for space in discover_spaces():
+        next_actions = space.path / "org" / "next_actions.org"
+
+    for space in discover_spaces(types={"team"}):
+        ...
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+log = logging.getLogger(__name__)
+
+MARKER = Path(".datacore") / "config.yaml"
+
+#: Legacy pattern. Retained so a space that has not yet gained a marker keeps
+#: being discovered. Remove once discovery_discrepancy() is empty everywhere.
+LEGACY_GLOB = "[0-9]-*"
+
+#: A space nested under another lives at e.g.
+#: ``<root>/1-space/1-tracks/clients/<name>``, which is depth 4.
+MAX_DEPTH = 4
+
+#: Never descended into. ``2-projects`` holds cloned repositories with their own
+#: dependency trees and is the single biggest cost in an unbounded walk.
+SKIP_DIRS = frozenset({
+    ".git", ".venv", "venv", "node_modules", "__pycache__", ".mypy_cache",
+    ".pytest_cache", ".ruff_cache", "2-projects", "4-archive", ".obsidian",
+    "dist", "build", ".next", "target",
+})
+
+
+@dataclass(frozen=True)
+class Space:
+    """One discovered space."""
+
+    path: Path
+    name: str
+    type: str
+    owner: str | None = None
+    marked: bool = True
+    """False when found only by the legacy glob — it has no marker yet."""
+
+    @property
+    def ordinal(self) -> int | None:
+        """The local sort prefix, if the directory has one.
+
+        Purely cosmetic and per-install. Never use it as identity.
+        """
+        head = self.path.name.split("-", 1)[0]
+        return int(head) if head.isdigit() else None
+
+
+def data_root() -> Path:
+    """The install root. ``DATACORE_ROOT`` wins, else ``~/Data``."""
+    return Path(os.environ.get("DATACORE_ROOT", Path.home() / "Data"))
+
+
+def read_marker(path: Path) -> dict | None:
+    """The ``space:`` block from ``path``'s marker, or None if it is not a space.
+
+    A malformed or unreadable marker is not a space, and says so in the log
+    rather than raising — one bad file must not take out discovery for every
+    other space.
+    """
+    marker = path / MARKER
+    if not marker.is_file():
+        return None
+    try:
+        loaded = yaml.safe_load(marker.read_text(encoding="utf-8")) or {}
+    except (yaml.YAMLError, OSError) as exc:
+        log.warning("space marker unreadable, skipping: %s (%s)", marker, exc)
+        return None
+    block = loaded.get("space")
+    if not isinstance(block, dict):
+        return None
+    return block
+
+
+def _walk(root: Path, depth: int = 1):
+    """Directories worth testing for a marker, breadth-first, depth-bounded."""
+    if depth > MAX_DEPTH:
+        return
+    try:
+        entries = sorted(p for p in root.iterdir() if p.is_dir())
+    except (PermissionError, OSError):
+        return
+    for entry in entries:
+        if entry.name in SKIP_DIRS or entry.is_symlink():
+            continue
+        yield entry
+        yield from _walk(entry, depth + 1)
+
+
+def _legacy_dirs(root: Path) -> list[Path]:
+    """Directories the old ``[0-9]-*/`` glob would have matched."""
+    return sorted(p for p in root.glob(LEGACY_GLOB) if p.is_dir())
+
+
+def _from_marker(path: Path, block: dict) -> Space:
+    return Space(
+        path=path,
+        name=str(block.get("name") or _implied_name(path)),
+        type=str(block.get("type") or "unknown"),
+        owner=block.get("owner"),
+        marked=True,
+    )
+
+
+def _implied_name(path: Path) -> str:
+    """Directory name with any local ordinal prefix stripped."""
+    head, _, tail = path.name.partition("-")
+    return tail if head.isdigit() and tail else path.name
+
+
+def discover_spaces(
+    root: Path | None = None,
+    *,
+    types: set[str] | None = None,
+    include_legacy: bool = True,
+) -> list[Space]:
+    """Every space under ``root``, marker-discovered plus (by default) legacy.
+
+    Args:
+        root: install root. Defaults to :func:`data_root`.
+        types: keep only these ``space.type`` values. Legacy directories have
+            no declared type, so a ``types`` filter necessarily excludes them.
+        include_legacy: also return ``[0-9]-*/`` directories that carry no
+            marker. True during migration so nothing silently disappears.
+
+    Returns:
+        Spaces sorted by path. Marker-discovered entries win over legacy ones
+        for the same directory.
+    """
+    root = root or data_root()
+    found: dict[Path, Space] = {}
+
+    for candidate in _walk(root):
+        block = read_marker(candidate)
+        if block is not None:
+            found[candidate] = _from_marker(candidate, block)
+
+    if include_legacy:
+        for path in _legacy_dirs(root):
+            if path in found:
+                continue
+            found[path] = Space(
+                path=path,
+                name=_implied_name(path),
+                type="unknown",
+                owner=None,
+                marked=False,
+            )
+
+    spaces = sorted(found.values(), key=lambda s: s.path)
+    if types is not None:
+        spaces = [s for s in spaces if s.type in types]
+    return spaces
+
+
+def discovery_discrepancy(root: Path | None = None) -> tuple[set[Path], set[Path]]:
+    """Where marker and glob discovery disagree.
+
+    Returns ``(marker_only, legacy_only)``. ``legacy_only`` is the set that
+    would vanish if the glob were dropped today — it must be empty before
+    ``include_legacy`` is turned off. ``marker_only`` is the set the glob never
+    saw, which is the point of the change.
+    """
+    root = root or data_root()
+    marker = {s.path for s in discover_spaces(root, include_legacy=False)}
+    legacy = set(_legacy_dirs(root))
+    return marker - legacy, legacy - marker
+
+
+def find_space(path: Path, root: Path | None = None) -> Space | None:
+    """The innermost space containing ``path``, or None.
+
+    Innermost matters once spaces nest: a path inside a client space owned by a
+    team space belongs to the client space, not the team one.
+    """
+    root = root or data_root()
+    path = path.resolve()
+    best: Space | None = None
+    for space in discover_spaces(root):
+        try:
+            path.relative_to(space.path.resolve())
+        except ValueError:
+            continue
+        if best is None or len(space.path.parts) > len(best.path.parts):
+            best = space
+    return best

--- a/.datacore/lib/stamp_seq_todo.py
+++ b/.datacore/lib/stamp_seq_todo.py
@@ -19,7 +19,10 @@ import argparse
 import sys
 from pathlib import Path
 
-CANONICAL = ("#+SEQ_TODO: TODO(t) NEXT(n!) WAITING(w!) DEFERRED(f) QUEUED(q) "
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from spaces import discover_spaces  # noqa: E402
+
+CANONICAL =("#+SEQ_TODO: TODO(t) NEXT(n!) WAITING(w!) DEFERRED(f) QUEUED(q) "
              "WORKING(W!) REVIEW(r!) | DONE(d!) FAILED(x!) CANCELLED(c!)")
 
 SCOPE = {"inbox.org", "next_actions.org", "someday.org", "nightshift.org",
@@ -64,7 +67,8 @@ def main() -> int:
 
     data_dir = Path(args.data_dir)
     changed = 0
-    for space in sorted(data_dir.glob("[0-9]-*/org")):
+    for discovered in discover_spaces(data_dir):
+        space = discovered.path / "org"
         for f in sorted(space.glob("*.org")):
             if f.name not in SCOPE or "archive" in f.name.lower():
                 continue

--- a/.datacore/lib/tag_utils.py
+++ b/.datacore/lib/tag_utils.py
@@ -10,9 +10,13 @@ Usage:
 """
 
 import re
+import sys
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Set
 import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from spaces import discover_spaces  # noqa: E402
 
 
 def normalize_tag(tag: str) -> str:
@@ -73,8 +77,8 @@ def load_registry(data_root: Path) -> Dict:
         _merge_registry(registry, system_registry)
 
     # 2. Space registries
-    for space_dir in data_root.glob('[0-9]-*'):
-        space_registry = space_dir / '.datacore' / 'tags.yaml'
+    for space in discover_spaces(data_root):
+        space_registry = space.path / '.datacore' / 'tags.yaml'
         if space_registry.exists():
             _merge_registry(registry, space_registry)
 

--- a/.datacore/lib/tag_validator.py
+++ b/.datacore/lib/tag_validator.py
@@ -26,6 +26,9 @@ from typing import Dict, List, Set, Tuple
 
 import yaml
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from spaces import discover_spaces  # noqa: E402
+
 
 class TagValidator:
     """Validates tags against the canonical registry."""
@@ -50,14 +53,8 @@ class TagValidator:
         self._load_registry()
 
     def _discover_space_dirs(self) -> list:
-        """Discover [0-9]-* space directories under data_dir."""
-        try:
-            return sorted(
-                p for p in self.data_dir.iterdir()
-                if p.is_dir() and p.name[:1].isdigit()
-            )
-        except (PermissionError, OSError):
-            return []
+        """Space directories under data_dir. See lib/spaces.py and DIP-0015."""
+        return [s.path for s in discover_spaces(self.data_dir)]
 
     def _load_registry(self):
         """Load tag registry from YAML."""

--- a/.datacore/tests/test_spaces.py
+++ b/.datacore/tests/test_spaces.py
@@ -71,6 +71,19 @@ def test_finds_marked_spaces(tmp_path):
     assert all(s.marked for s in found)
 
 
+def test_client_space_nested_under_its_owner_is_found(tmp_path):
+    """The real layout: <root>/<space>/1-tracks/clients/<name> is depth 4.
+
+    Regression guard — this sat exactly on MAX_DEPTH when first shipped, so one
+    extra grouping directory would have dropped it out of discovery silently.
+    """
+    make_space(tmp_path, "1-owner", "owner")
+    deeper = make_space(
+        tmp_path, "1-owner/1-tracks/clients/active/acme", "acme", type_="client"
+    )
+    assert deeper in [s.path for s in discover_spaces(tmp_path, include_legacy=False)]
+
+
 def test_location_does_not_matter(tmp_path):
     """The whole point: a space need not sit at the install root."""
     make_space(tmp_path, "1-owner", "owner")

--- a/.datacore/tests/test_spaces.py
+++ b/.datacore/tests/test_spaces.py
@@ -1,0 +1,228 @@
+"""Tests for marker-based space discovery (issue #41, DIP-0015)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "lib"))
+
+from spaces import (  # noqa: E402
+    MAX_DEPTH,
+    Space,
+    discover_spaces,
+    discovery_discrepancy,
+    find_space,
+    read_marker,
+)
+
+
+def make_space(root: Path, rel: str, name: str, type_: str = "team", owner=None) -> Path:
+    """Create a directory carrying a space marker."""
+    path = root / rel
+    (path / ".datacore").mkdir(parents=True, exist_ok=True)
+    lines = ["space:", f"  name: {name}", f"  type: {type_}"]
+    if owner:
+        lines.append(f"  owner: {owner}")
+    (path / ".datacore" / "config.yaml").write_text("\n".join(lines) + "\n")
+    return path
+
+
+# ── marker reading ───────────────────────────────────────────────────────────
+
+def test_reads_marker(tmp_path):
+    make_space(tmp_path, "1-alpha", "alpha")
+    assert read_marker(tmp_path / "1-alpha") == {"name": "alpha", "type": "team"}
+
+
+def test_directory_without_marker_is_not_a_space(tmp_path):
+    (tmp_path / "plain").mkdir()
+    assert read_marker(tmp_path / "plain") is None
+
+
+def test_config_without_space_key_is_not_a_space(tmp_path):
+    d = tmp_path / "1-alpha" / ".datacore"
+    d.mkdir(parents=True)
+    (d / "config.yaml").write_text("modules:\n  - x\n")
+    assert read_marker(tmp_path / "1-alpha") is None
+
+
+def test_malformed_marker_is_skipped_not_raised(tmp_path):
+    """One bad file must not take out discovery for every other space."""
+    d = tmp_path / "1-alpha" / ".datacore"
+    d.mkdir(parents=True)
+    (d / "config.yaml").write_text("space: [unclosed\n")
+    make_space(tmp_path, "2-beta", "beta")
+
+    assert read_marker(tmp_path / "1-alpha") is None
+    assert [s.name for s in discover_spaces(tmp_path, include_legacy=False)] == ["beta"]
+
+
+# ── discovery ────────────────────────────────────────────────────────────────
+
+def test_finds_marked_spaces(tmp_path):
+    make_space(tmp_path, "1-alpha", "alpha")
+    make_space(tmp_path, "2-beta", "beta", type_="personal")
+
+    found = discover_spaces(tmp_path, include_legacy=False)
+    assert [(s.name, s.type) for s in found] == [("alpha", "team"), ("beta", "personal")]
+    assert all(s.marked for s in found)
+
+
+def test_location_does_not_matter(tmp_path):
+    """The whole point: a space need not sit at the install root."""
+    make_space(tmp_path, "1-owner", "owner")
+    nested = make_space(
+        tmp_path, "1-owner/1-tracks/clients/acme", "acme", type_="client", owner="owner"
+    )
+
+    found = discover_spaces(tmp_path, include_legacy=False)
+    assert nested in [s.path for s in found]
+
+    acme = next(s for s in found if s.name == "acme")
+    assert acme.type == "client"
+    assert acme.owner == "owner"
+    assert acme.ordinal is None  # no numeric prefix, and none needed
+
+
+def test_type_filter(tmp_path):
+    make_space(tmp_path, "1-alpha", "alpha", type_="team")
+    make_space(tmp_path, "2-beta", "beta", type_="client")
+
+    assert [s.name for s in discover_spaces(tmp_path, types={"client"})] == ["beta"]
+
+
+def test_skips_heavy_directories(tmp_path):
+    """2-projects holds cloned repos; descending into it is the main walk cost."""
+    make_space(tmp_path, "2-projects/vendored", "vendored")
+    make_space(tmp_path, "1-alpha/node_modules/pkg", "pkg")
+    make_space(tmp_path, "1-alpha", "alpha")
+
+    assert [s.name for s in discover_spaces(tmp_path, include_legacy=False)] == ["alpha"]
+
+
+def test_respects_depth_bound(tmp_path):
+    deep = "/".join(f"d{i}" for i in range(MAX_DEPTH + 2))
+    make_space(tmp_path, deep, "toodeep")
+    assert discover_spaces(tmp_path, include_legacy=False) == []
+
+
+def test_does_not_follow_symlinks(tmp_path):
+    """A symlinked space would otherwise be discovered twice, at two paths."""
+    real = make_space(tmp_path, "1-alpha", "alpha")
+    (tmp_path / "link").symlink_to(real, target_is_directory=True)
+
+    found = discover_spaces(tmp_path, include_legacy=False)
+    assert [s.path for s in found] == [real]
+
+
+# ── legacy union: migration must not lose anything ───────────────────────────
+
+def test_union_includes_unmarked_legacy_dirs(tmp_path):
+    make_space(tmp_path, "1-alpha", "alpha")
+    (tmp_path / "2-unmarked").mkdir()
+
+    names = {s.name for s in discover_spaces(tmp_path)}
+    assert names == {"alpha", "unmarked"}
+
+    unmarked = next(s for s in discover_spaces(tmp_path) if s.name == "unmarked")
+    assert unmarked.marked is False
+    assert unmarked.type == "unknown"
+
+
+def test_marker_wins_over_legacy_for_same_directory(tmp_path):
+    make_space(tmp_path, "1-alpha", "alpha")
+    found = [s for s in discover_spaces(tmp_path) if s.path.name == "1-alpha"]
+    assert len(found) == 1
+    assert found[0].marked is True
+
+
+def test_legacy_can_be_excluded(tmp_path):
+    make_space(tmp_path, "1-alpha", "alpha")
+    (tmp_path / "2-unmarked").mkdir()
+    assert [s.name for s in discover_spaces(tmp_path, include_legacy=False)] == ["alpha"]
+
+
+def test_type_filter_excludes_legacy(tmp_path):
+    """Legacy dirs declare no type, so any type filter necessarily drops them."""
+    (tmp_path / "2-unmarked").mkdir()
+    assert discover_spaces(tmp_path, types={"team"}) == []
+
+
+# ── discrepancy: the gate on dropping the glob ───────────────────────────────
+
+def test_discrepancy_reports_what_would_vanish(tmp_path):
+    make_space(tmp_path, "1-alpha", "alpha")
+    (tmp_path / "2-unmarked").mkdir()
+
+    marker_only, legacy_only = discovery_discrepancy(tmp_path)
+    assert legacy_only == {tmp_path / "2-unmarked"}
+    assert marker_only == set()
+
+
+def test_discrepancy_reports_what_the_glob_never_saw(tmp_path):
+    make_space(tmp_path, "1-owner", "owner")
+    nested = make_space(tmp_path, "1-owner/clients/acme", "acme", type_="client")
+
+    marker_only, legacy_only = discovery_discrepancy(tmp_path)
+    assert nested in marker_only
+    assert legacy_only == set()
+
+
+def test_discrepancy_empty_when_fully_migrated(tmp_path):
+    make_space(tmp_path, "1-alpha", "alpha")
+    make_space(tmp_path, "2-beta", "beta")
+    assert discovery_discrepancy(tmp_path) == (set(), set())
+
+
+# ── containment ──────────────────────────────────────────────────────────────
+
+def test_find_space_returns_containing_space(tmp_path):
+    alpha = make_space(tmp_path, "1-alpha", "alpha")
+    target = alpha / "org" / "next_actions.org"
+    target.parent.mkdir(parents=True)
+    target.touch()
+
+    assert find_space(target, tmp_path).name == "alpha"
+
+
+def test_find_space_prefers_innermost(tmp_path):
+    """A path inside a nested client space belongs to it, not to its owner."""
+    make_space(tmp_path, "1-owner", "owner")
+    acme = make_space(tmp_path, "1-owner/clients/acme", "acme", type_="client")
+
+    assert find_space(acme / "notes.md", tmp_path).name == "acme"
+
+
+def test_find_space_returns_none_outside_any_space(tmp_path):
+    make_space(tmp_path, "1-alpha", "alpha")
+    loose = tmp_path / "loose.md"
+    loose.touch()
+    assert find_space(loose, tmp_path) is None
+
+
+# ── ordinal is cosmetic ──────────────────────────────────────────────────────
+
+@pytest.mark.parametrize(
+    "dirname, expected",
+    [("1-alpha", 1), ("12-alpha", 12), ("alpha", None), ("acme", None)],
+)
+def test_ordinal_parsing(tmp_path, dirname, expected):
+    make_space(tmp_path, dirname, "x")
+    space = discover_spaces(tmp_path, include_legacy=False)[0]
+    assert space.ordinal == expected
+
+
+def test_same_space_may_carry_different_ordinals_per_install(tmp_path):
+    """Identity comes from the marker, never from the prefix."""
+    a = make_space(tmp_path / "install-a", "5-thing", "thing")
+    b = make_space(tmp_path / "install-b", "9-thing", "thing")
+
+    name_a = discover_spaces(tmp_path / "install-a", include_legacy=False)[0]
+    name_b = discover_spaces(tmp_path / "install-b", include_legacy=False)[0]
+
+    assert name_a.name == name_b.name == "thing"
+    assert (name_a.ordinal, name_b.ordinal) == (5, 9)
+    assert a != b


### PR DESCRIPTION
Closes part of #41.

A directory is a space if it carries `.datacore/config.yaml` with a `space:`
key — the way git finds `.git` and monorepo tooling finds `package.json`.
Location stops mattering, so a space may sit at the install root or nested
inside another.

## Why

The `[0-9]-*/` glob conflated three separate things: whether a directory *is* a
space, what *kind* it is, and its local sort order. The numeric prefix is a
**per-install ordinal** — the same repository is `5-x` in one contributor's
install and `9-x` in another's — so it never carried identity, yet fifteen call
sites keyed on it across five parallel discovery implementations.

The practical cost: any structural change needed a fifteen-file sweep, and a
missed site dropped a space from that subsystem **silently** — no error, just
absent from journals, hygiene runs, or tag validation until someone noticed.

## What's here

`.datacore/lib/spaces.py`:

```python
discover_spaces(root=None, *, types=None, include_legacy=True) -> list[Space]
discovery_discrepancy(root=None) -> tuple[set[Path], set[Path]]
find_space(path, root=None) -> Space | None      # innermost containing space
Space(path, name, type, owner, marked)           # .ordinal is cosmetic only
```

Migrated 6 call sites and retired 2 of the 5 parallel implementations:
`tag_utils`, `tag_validator`, `gtd_hygiene`, `stamp_seq_todo`, `priority_score`
(×2), `nightshift_inbox_cleanup`.

25 tests covering marker parsing, nesting, type filters, depth bound, symlink
non-following, skip-list, the legacy union, discrepancy reporting, innermost
containment, and that the same space carries different ordinals per install.

## Non-breaking by construction

`discover_spaces()` returns the **union** of marker- and glob-discovered
directories, so nothing found before stops being found. Verified on a real
install — identical output before and after:

```
10 spaces discovered
discovery_discrepancy() -> (set(), set())
```

`discovery_discrepancy()` is the gate on removing the glob: its `legacy_only`
set must be empty everywhere before `include_legacy` can default to False.
**Dropping the glob is deliberately not in this PR.**

## Not done yet

- **9 call sites remain**, including `hooks.py`, `agent_wrap_up`,
  `nightshift_archival`, `zettel_db`, `add_engram_preamble`,
  `install_space_hooks`, `org_tag_audit`, `migrate_org_tag`. One-off dated
  migration scripts are intentionally left alone.
- **Marker backfill does not travel yet.** Each space is its own repository, so
  markers must be committed there — four separate repos still need one. Until
  then those spaces are found by the legacy glob only.
- **`0-inbox` cannot carry a tracked marker.** The root `.gitignore` rule
  `/0-*/` excludes it, and git cannot re-include a file beneath an excluded
  directory, so the rule needs narrowing first. Covered by the legacy union
  meanwhile.
- **`create-space` must emit the marker**, and the scaffolding audit should flag
  its absence — otherwise this decays exactly as the `install.yaml` registry did
  (it reached 2 of 9 entries because registration was optional).

## Notes for review

- The walk is depth-bounded (`MAX_DEPTH = 4`, enough for a space nested at
  `<root>/<space>/1-tracks/clients/<name>`) and skips `2-projects`,
  `node_modules`, `.git` and similar. `2-projects` is the single biggest cost in
  an unbounded walk since it holds cloned repositories.
- Symlinks are not followed, so a symlinked space is not discovered twice under
  two paths.
- A malformed marker logs a warning and is skipped rather than raising — one bad
  file must not take out discovery for every other space.

Spec change is in a companion PR on `datacore-dips` (DIP-0015 Part 0).
