### PR TITLE
ops(wave-trader): fix crash-loop PYTHONPATH, track unit template

### DIFF
--- a/.datacore/lib/wave-trader.service
+++ b/.datacore/lib/wave-trader.service
@@ -1,0 +1,37 @@
+# WaveTrader systemd unit — TEMPLATE.
+#
+# Install: substitute <HOME> with the real home (e.g. /home/gregor) and copy to
+#   /etc/systemd/system/wave-trader.service, then `systemctl daemon-reload`.
+#
+# PYTHONPATH note: the executor imports `datacore.ledger` (DIP-0047 order
+# attestation), whose package lives at <HOME>/Data/.datacore/lib. That path MUST
+# be on PYTHONPATH or the service crash-loops on `No module named 'datacore'`.
+[Unit]
+Description=WaveTrader — multi-asset regime-gated wave bot (Hyperliquid)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=gregor
+WorkingDirectory=<HOME>/Data/.datacore/modules/trading/lib/gateio
+Environment=PYTHONPATH=<HOME>/Data/.datacore/modules/trading/lib/gateio:<HOME>/Data/.datacore/lib
+# --shadow flag for paper-trading. Remove flag to go live.
+# Default assets exclude SOL (managed by ladder-trader).
+ExecStart=<HOME>/venvs/trading/bin/python3 -u wave_trader.py --watch --interval 60 --shadow --assets SOL ETH SUI DOGE BTC
+Restart=on-failure
+RestartSec=30
+StartLimitBurst=5
+StartLimitIntervalSec=300
+MemoryMax=512M
+StandardOutput=journal
+StandardError=journal
+# Security hardening
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=<HOME>/Data/.datacore/state/trading <HOME>/.datacore
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target

--- a/.datacore/lib/wave-trader.service
+++ b/.datacore/lib/wave-trader.service
@@ -1,6 +1,6 @@
 # WaveTrader systemd unit — TEMPLATE.
 #
-# Install: substitute <HOME> with the real home (e.g. /home/gregor) and copy to
+# Install: substitute <HOME> with the real home (e.g. /home/<account>) and copy to
 #   /etc/systemd/system/wave-trader.service, then `systemctl daemon-reload`.
 #
 # PYTHONPATH note: the executor imports `datacore.ledger` (DIP-0047 order


### PR DESCRIPTION
## What

wave-trader.service was crash-looping — 2927 restarts, every 30s — on:

```
from datacore.ledger import attests
ModuleNotFoundError: No module named 'datacore'
```

The unit's `Environment=PYTHONPATH` only contained the gateio dir. The
`datacore` package (used for DIP-0047 order attestation) lives at
`.datacore/lib`, which was missing from the path.

## Fix

Append `.datacore/lib` to `PYTHONPATH`. Verified the import resolves.
Applied live in `/etc/systemd/system/` (NRestarts back to 0, service
running clean in shadow mode) and added here as a `<HOME>` template
alongside the sibling units so a re-provision won't reintroduce the loop.

## Context

Found while investigating a separate Telegram alert-spam report. The spam
itself was stale price thresholds in the (gitignored) alerts_config.yaml —
fixed live, not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)