### PR TITLE
fix(hooks): bound the plur session guard to a single nudge (extracted from #24)

### DIFF
--- a/.datacore/lib/hooks/plur_session_guard.py
+++ b/.datacore/lib/hooks/plur_session_guard.py
@@ -42,19 +42,40 @@ def main():
     ):
         return
 
-    sentinel = f"{tempfile.gettempdir()}/plur-session-{session_id}"
+    tmp = tempfile.gettempdir()
+    sentinel = f"{tmp}/plur-session-{session_id}"
     if os.path.exists(sentinel):
         return
 
-    # Block the tool call
+    # Fail-open after a single nudge. We deny at most ONE tool call per session
+    # to steer the first action toward session_start; after that we allow
+    # everything through even if the call never landed. This is deliberate and
+    # model-agnostic: a hard deny-everything guard collapses the model's action
+    # space to one allowed call, so any hiccup on that call (e.g. the deferred
+    # tool's "task required" race) can spiral into repeated identical calls or an
+    # indefinite block. Bounding the guard to one nudge makes that impossible —
+    # engram injection is best-effort, never worth trapping the session.
+    nudged = f"{tmp}/plur-session-nudged-{session_id}"
+    if os.path.exists(nudged):
+        return  # already nudged once this session -> allow work to proceed
+
+    try:
+        open(nudged, "w").close()
+    except OSError:
+        return  # can't record the nudge -> fail open rather than risk re-denying
+
     print(json.dumps({
         "hookSpecificOutput": {
             "hookEventName": "PreToolUse",
             "permissionDecision": "deny",
             "permissionDecisionReason": (
-                "BLOCKED: plur_session_start has not been called yet. "
-                "You MUST call mcp__plur__plur_session_start before using any other tool. "
-                "Use ToolSearch to load it first if needed."
+                "Reminder: call mcp__plur__plur_session_start once before other "
+                "tools so this session has memory. It is a deferred tool — first "
+                "run ToolSearch 'select:mcp__plur__plur_session_start' as its own "
+                "step, then call it a single time with a short task description. "
+                "Don't batch the ToolSearch with the call, and don't repeat it. "
+                "This reminder fires only once; your next tool call proceeds "
+                "normally whether or not session_start succeeded."
             ),
         }
     }))


### PR DESCRIPTION
Extracted from **#24** by @crtahlin, onto current `main`. Credit is his; this PR exists only because #24 cannot merge in its current form.

## Why extract rather than rebase #24

#24 was cut from a fork on 2026-05-31 and now carries **100 files / +39,350 / -1,438** — three months of unrelated divergence, including full rewrites of `today.md`, `diagnostic.md` and `ingest.md`. The change that matters is **21 lines in one file**. Rebasing would not separate them.

## The bug is live, and it fired twice today

The guard on `main` denies every tool call until a sentinel exists at `/tmp/plur-session-{id}`. That sentinel is written by `plur_session_mark.py` as a **PostToolUse** hook on `plur_session_start`.

So if `plur_session_start` *errors*, PostToolUse never fires, the sentinel is never written, and the guard denies **forever** while the model retries the same failing call. There is no attempt counter anywhere in the current file. That is the runaway loop #23 describes (~150 identical calls in one turn).

Both of today's occurrences had the same trigger — `plur_session_start` returned a ~102KB engram payload that exceeded the tool-result cap and came back as an error:

- this session: the call errored, the next two tool calls returned `BLOCKED`, and it only recovered because the operator stopped retrying
- a separate session the same day logged the payload overflow as `ENG-PPL-2026-08-26-016`

Two defects compound: the oversized injection makes `session_start` fail, and the unbounded guard converts that failure into a retry loop. **This PR fixes the second.** The first belongs to PLUR and is not addressed here.

## What it does

Adds a second sentinel, `/tmp/plur-session-nudged-{id}`. The guard denies **at most one** tool call per session to steer the first action toward `session_start`, then fails open — whether or not the call ever landed. It also fails open if the nudge file cannot be written, so a read-only `/tmp` degrades to no guard rather than to a permanent block.

The reason string now explains the deferred-tool flow (ToolSearch as its own step, call once, don't batch) and states that the reminder fires only once.

The trade is deliberate and stated in the code comment: engram injection is best-effort and is never worth trapping a session over. A hard deny-everything guard collapses the model's action space to a single allowed call, so any hiccup on that one call spirals.

## Verification

```
21 lines added, 1 file, no other change
```

Diffed against `main`'s copy: identical except the extracted `tmp` variable, the nudge block, and the reason string.

Closes #23. Supersedes #24 — closing that one with a pointer here.