### PR TITLE
fix(morning_journal): retire stale Daily Briefing check (refs #54)

### DIFF
--- a/.datacore/lib/morning_journal.py
+++ b/.datacore/lib/morning_journal.py
@@ -41,16 +41,17 @@ def main() -> int:
         print(sync.stderr.strip(), file=sys.stderr)
 
     journal = JOURNALS / f"{today}.md"
-    missing = (
-        "journal not published" if not journal.exists()
-        else "briefing section missing" if "## Daily Briefing" not in journal.read_text()
-        else None
-    )
+    # "## Daily Briefing" check retired 2026-07-29: miles_delivery paste was
+    # retired; briefing now ships as audio + Telegram + app card — nothing
+    # writes that heading into the journal anymore. Keep only the file-exists
+    # check; if the journal is absent the overnight batch failed entirely.
+    # See datacore#54.
+    missing = "journal not published" if not journal.exists() else None
     if missing:
         # Single daily shot (08:30) — a miss must be LOUD, not a log line.
         # Silent non-delivery is exactly what the 2026-07-29 post-mortem
         # was about.
-        msg = f"Morning briefing NOT delivered ({missing}) — check nightshift-today on the server"
+        msg = f"Morning briefing NOT delivered ({missing}) — check nightshift on the server"
         print(f"{today}: {msg}")
         subprocess.run(
             ["osascript", "-e",


### PR DESCRIPTION
## What

Removes the stale `"## Daily Briefing" not in journal.read_text()` check from `morning_journal.py` (Mac-side morning opener), which has been generating a false "briefing section missing" macOS notification on every journal open since 2026-07-29.

## Why

The `miles_delivery` paste was retired 2026-07-29. Briefing now ships as **audio + Telegram opener + app card** — nothing writes `## Daily Briefing` into the journal file anymore, so the check was guaranteed to false-positive forever.

## Change

- Keep the file-exists guard: if today's journal is absent, the overnight batch failed entirely → still alert
- Remove the `## Daily Briefing` content check: once the file exists, open it
- Update error message: `nightshift-today` → `nightshift` (old component name retired)

## Scope

This fixes the **Mac-side** half of issue #54. The **primary fix** (removing `journal_briefing` from `CHECKS` in `cos_verify_morning.py`) lives in `datacore-one/datacore-chief-of-staff` — that's the server-side verifier producing the daily RED in v2-verify + morning alerts since 2026-08-16.

## Related

- Closes #54 (Mac-side half)
- See also: #55 (token-refresh timer self-heal), #56 (config drift detection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)