### PR TITLE
recurrence: forget counters for jobs the manifest no longer names

### DIFF
--- a/.datacore/lib/job_verify.py
+++ b/.datacore/lib/job_verify.py
@@ -117,6 +117,38 @@ def _send_telegram(message: str) -> bool:
 _NO_EMIT = False
 
 
+def _recurrence():
+    """The recurrence module, by package import or by path (same fallback the
+    two call sites below used to carry separately)."""
+    try:
+        from jobs import recurrence as _rec
+    except ImportError:  # pragma: no cover
+        import importlib.util as _ilu
+        _spec = _ilu.spec_from_file_location(
+            "recurrence", Path(__file__).parent / "jobs" / "recurrence.py")
+        _rec = _ilu.module_from_spec(_spec)
+        _spec.loader.exec_module(_rec)
+    return _rec
+
+
+def _prune_recurrence(jobs) -> None:
+    """Forget counters for jobs the manifest no longer names (any machine).
+
+    Runs on every real verification so a renamed or deleted job cannot stay
+    "recurring" forever -- a record with no job can never receive the pass
+    that would reset it.
+    """
+    if _NO_EMIT:
+        return
+    try:
+        gone = _recurrence().prune({j.name for j in jobs})
+    except Exception as exc:  # noqa: BLE001 -- bookkeeping must not stop verification
+        print(f"recurrence prune skipped: {exc}", file=sys.stderr)
+        return
+    for name in gone:
+        print(f"recurrence: forgot {name} (no longer in the manifest)", file=sys.stderr)
+
+
 def _note_pass(job_name: str) -> None:
     """Reset a job's consecutive-failure count.
 
@@ -317,6 +349,7 @@ def main(argv: list[str] | None = None) -> None:
         print(f"error: cannot read manifest {manifest_path}: {exc}", file=sys.stderr)
         sys.exit(1)
 
+    _prune_recurrence(jobs)
     machine_jobs = [job for job in jobs if job.machine == args.machine]
 
     if not machine_jobs:

--- a/.datacore/lib/jobs/recurrence.py
+++ b/.datacore/lib/jobs/recurrence.py
@@ -145,6 +145,24 @@ def _record_unlocked(job_name: str, failed: bool, today: str) -> dict:
     return rec
 
 
+def prune(known: set[str]) -> list[str]:
+    """Drop records for jobs the manifest no longer names. Returns what went.
+
+    A record for a job that no longer exists can never receive a pass, so it
+    stays "recurring" forever and the summary keeps naming it: on 2026-09-03
+    winston reported box-registry-gc 3x recurring for a job that had been
+    renamed to mac-registry-gc that morning. Class 4, applied to the counter.
+    """
+    with _locked():
+        state = _load()
+        gone = sorted(k for k in state if k not in known)
+        if gone:
+            for k in gone:
+                del state[k]
+            _save(state)
+        return gone
+
+
 def describe(job_name: str, rec: dict, n_failures: int) -> str:
     """The alert line. Below the threshold it is unchanged from before.
 

--- a/.datacore/lib/tests/test_job_verify.py
+++ b/.datacore/lib/tests/test_job_verify.py
@@ -681,3 +681,28 @@ def test_running_the_verifier_never_touches_production_recurrence_state(tmp_path
     assert before == after, "a test wrote to the PRODUCTION recurrence state"
     if after:
         assert "isolation-probe-job" not in json.loads(after)
+
+
+def test_a_real_run_forgets_recurrence_records_for_jobs_no_longer_in_the_manifest(tmp_path, monkeypatch, capsys):
+    """box-registry-gc was renamed to mac-registry-gc; winston kept reporting
+    the old name as 3x recurring because no pass could ever reach it."""
+    import json, os
+    state_dir = Path(os.environ["DATACORE_STATE"]); state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / "job-verify-recurrence.json").write_text(json.dumps({
+        "ghost-job": {"consecutive": 3, "first_failed": "2026-09-01", "recurring": True}}))
+    artifact = tmp_path / "backup.log"; artifact.write_text("done")
+    manifest = _write_manifest(tmp_path, [_job("backup-notes", "mac", str(artifact))])
+    space = _space(tmp_path)
+    monkeypatch.setenv("DATACORE_ACTOR", "test-actor")
+
+    # a dry run must not touch the counters
+    assert _run_main(["--machine", "mac", "--manifest", str(manifest), "--space", str(space), "--no-emit"]) == 0
+    assert "ghost-job" in json.loads((state_dir / "job-verify-recurrence.json").read_text())
+    capsys.readouterr()
+
+    assert _run_main(["--machine", "mac", "--manifest", str(manifest), "--space", str(space)]) == 0
+    err = capsys.readouterr().err
+    state = json.loads((state_dir / "job-verify-recurrence.json").read_text())
+    assert "ghost-job" not in state, "a record for a job the manifest no longer names must be forgotten"
+    assert "backup-notes" in state, "the live job's pass must still be recorded"
+    assert "forgot ghost-job" in err

--- a/.datacore/lib/tests/test_jobs_recurrence.py
+++ b/.datacore/lib/tests/test_jobs_recurrence.py
@@ -109,3 +109,18 @@ def test_concurrent_records_do_not_lose_updates(rec):
     for t in ts: t.join()
     assert not errors
     assert rec._load()["j"]["consecutive"] == 40
+
+
+
+def test_prune_forgets_jobs_the_manifest_no_longer_names(rec):
+    """A record for a deleted or renamed job can never receive a pass, so it
+    would stay recurring forever: box-registry-gc, 2026-09-03."""
+    for _ in range(3):
+        rec.record("box-registry-gc", failed=True)
+    rec.record("mac-registry-gc", failed=True)
+    assert [r["job"] for r in rec.summary()] == ["box-registry-gc"]
+    gone = rec.prune({"mac-registry-gc", "other"})
+    assert gone == ["box-registry-gc"]
+    assert rec.summary() == []
+    assert "mac-registry-gc" in rec._load(), "a known job's record must survive the prune"
+    assert rec.prune({"mac-registry-gc"}) == [], "idempotent"


### PR DESCRIPTION
Follow-up to #67: a recurrence record for a renamed or deleted job could never receive a pass, so it stayed "recurring" forever (winston: box-registry-gc 3x, hours after it became mac-registry-gc). job_verify now prunes counters against the full manifest on every real run; dry runs never touch them. Unit + integration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ASw7Pf89xqmcLPtX2Xa42
