### PR TITLE
fix: move org templates to tracked location and update INSTALL.md paths

### DIFF
--- a/.datacore/templates/org/habits.org.example
+++ b/.datacore/templates/org/habits.org.example
@@ -1,0 +1,5 @@
+#+TITLE: Habits
+#+STARTUP: overview
+
+* Daily Habits
+# Track recurring habits and routines here

--- a/.datacore/templates/org/inbox.org.example
+++ b/.datacore/templates/org/inbox.org.example
@@ -1,0 +1,5 @@
+#+TITLE: Inbox
+#+STARTUP: overview
+
+* Inbox
+# Capture new tasks here — process to zero regularly

--- a/.datacore/templates/org/next_actions.org.example
+++ b/.datacore/templates/org/next_actions.org.example
@@ -1,0 +1,23 @@
+#+TITLE: Next Actions
+#+STARTUP: overview
+
+* Operations
+** Coordination
+
+* Product
+
+* Engineering
+** Development
+** Infrastructure
+
+* Research
+
+* Communications
+** Content
+** Documentation
+
+* Waiting For
+# Tasks waiting on external input or approval
+
+* AI Queue
+# Tasks tagged :AI: for autonomous processing

--- a/.datacore/templates/org/someday.org.example
+++ b/.datacore/templates/org/someday.org.example
@@ -1,0 +1,5 @@
+#+TITLE: Someday / Maybe
+#+STARTUP: overview
+
+* Someday / Maybe
+# Ideas and possibilities to revisit later

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -73,10 +73,10 @@ Copy template files to create your local configuration:
 cp install.yaml.example install.yaml
 
 # GTD org files
-cp 0-personal/org/inbox.org.example 0-personal/org/inbox.org
-cp 0-personal/org/next_actions.org.example 0-personal/org/next_actions.org
-cp 0-personal/org/someday.org.example 0-personal/org/someday.org
-cp 0-personal/org/habits.org.example 0-personal/org/habits.org
+cp .datacore/templates/org/inbox.org.example 0-personal/org/inbox.org
+cp .datacore/templates/org/next_actions.org.example 0-personal/org/next_actions.org
+cp .datacore/templates/org/someday.org.example 0-personal/org/someday.org
+cp .datacore/templates/org/habits.org.example 0-personal/org/habits.org
 
 # Build CLAUDE.md from layers (see Layered Context Pattern below)
 python .datacore/lib/context_merge.py rebuild --path .


### PR DESCRIPTION
## Problem

INSTALL.md Step 2 instructs users to copy org template files from `0-personal/org/*.example`, but those files don't exist on a fresh clone. The root `.gitignore` contains `/0-*/` which excludes the entire `0-personal/` directory, so any `.example` files placed there are never committed to the upstream repo.

## Fix

1. **Create 4 template files** under `.datacore/templates/org/` where they are tracked by git (the existing `.gitignore` exception `!**/org/*.example` already covers this path pattern).
2. **Update INSTALL.md** Step 2 to `cp` from `.datacore/templates/org/*.example` instead of the non-existent `0-personal/org/` path.

## Verification

- All 4 new files confirmed tracked: `git ls-files .datacore/templates/org/` shows them.
- Context merge validation passes: `python .datacore/lib/context_merge.py validate --path .` → OK.
- Tag validation passes: `python .datacore/lib/tag_validator.py --data-dir .` → OK.
- Root boundary CI (validate-boundaries.yml) will pass since files are under `.datacore/`.
- The old path (`0-personal/org/inbox.org.example`) is confirmed ignored by `.gitignore` line 9.

## Files Changed

- **New**: `.datacore/templates/org/inbox.org.example`, `.datacore/templates/org/next_actions.org.example`, `.datacore/templates/org/someday.org.example`, `.datacore/templates/org/habits.org.example`
- **Modified**: `INSTALL.md` (lines 76-79)

Closes #71
