### PR TITLE
docs: lead GETTING_STARTED.md with datacore init CLI, demote manual to advanced

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -1,26 +1,44 @@
 # Getting Started
 
-Get Datacore running in 5 minutes.
+Get Datacore running in 2 minutes.
 
-## Prerequisites
+## Recommended: CLI Setup
 
-- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) installed
-- [Git](https://git-scm.com/) and [GitHub CLI](https://cli.github.com/)
-- Python 3.8+
-
-## Setup
+The CLI handles everything automatically — forking, cloning, org file creation, Python
+dependencies, git hooks, and MCP configuration:
 
 ```bash
-# 1. Fork and clone
-mkdir ~/Data && cd ~/Data
-gh repo fork datacore-one/datacore --clone=false
-git clone https://github.com/YOUR-USERNAME/datacore.git .
-git remote add upstream https://github.com/datacore-one/datacore.git
-
-# 2. Initialize
-cp install.yaml.example install.yaml
-python .datacore/lib/context_merge.py rebuild --path .
+npx @datacore-one/cli init
 ```
+
+That's it. Open Claude Code in `~/Data` and jump to [First Commands](#first-commands).
+
+**Prefer a global install?**
+
+```bash
+npm install -g @datacore-one/cli
+datacore init
+```
+
+## Alternative: MCP Server Only
+
+If you want Claude Code integration without the full GTD system (no `~/Data` directory,
+no org files):
+
+```bash
+npx @datacore-one/mcp init
+```
+
+Then add to `.claude/mcp.json` (or `.cursor/mcp.json`):
+
+```json
+"datacore": {
+  "command": "npx",
+  "args": ["-y", "@datacore-one/mcp"]
+}
+```
+
+---
 
 ## First Commands
 
@@ -34,7 +52,8 @@ Open Claude Code in `~/Data` and try:
 
 ## Capture Tasks
 
-Say "add task: Review quarterly report" and it goes to your inbox. Process with "process inbox".
+Say "add task: Review quarterly report" and it goes to your inbox. Process with
+"process inbox".
 
 ## AI Delegation
 
@@ -48,6 +67,42 @@ Run `/tomorrow` before bed to queue AI tasks.
 
 ## Next Steps
 
-- [Full Installation Guide](INSTALL.md) -- modules, MCP servers, team spaces
-- [Module Catalog](.datacore/CATALOG.md) -- available extensions
-- [Contributing](CONTRIBUTING.md) -- how to contribute
+- [Full Installation Guide](INSTALL.md) — modules, MCP servers, team spaces
+- [Module Catalog](.datacore/CATALOG.md) — available extensions
+- [Contributing](CONTRIBUTING.md) — how to contribute
+
+---
+
+## Advanced: Manual Setup
+
+For contributors, forks that need custom CI, or cases where the CLI cannot run.
+The CLI above is faster and less error-prone — only use this path if you have a
+specific reason to.
+
+### Prerequisites
+
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) installed
+- [Git](https://git-scm.com/) and [GitHub CLI](https://cli.github.com/)
+- Python 3.8+
+
+### Setup
+
+```bash
+# 1. Fork and clone into ~/Data (note the dot — clones into current directory)
+mkdir ~/Data && cd ~/Data
+gh repo fork datacore-one/datacore --clone=false
+git clone https://github.com/YOUR-USERNAME/datacore.git .
+git remote add upstream https://github.com/datacore-one/datacore.git
+
+# 2. Install Python dependencies
+pip install -r .datacore/lib/requirements.txt
+
+# 3. Activate configuration template
+cp install.yaml.example install.yaml
+
+# 4. Build CLAUDE.md from layers
+python .datacore/lib/context_merge.py rebuild --path .
+```
+
+See [INSTALL.md](INSTALL.md) for the complete manual walkthrough — org file templates,
+MCP server configuration, team spaces, and module installation.


### PR DESCRIPTION
## Summary

- Closes #72, #74
- Restructures GETTING_STARTED.md so `npx @datacore-one/cli init` is the primary recommended path (2-minute setup)
- Adds MCP-server-only path as a second option for users who don't need the full GTD system
- Demotes the manual fork-and-clone setup to an "Advanced" section at the end, pointing to INSTALL.md for the complete walkthrough
- Removes the broken org file template `cp` commands from GETTING_STARTED.md (those paths don't exist; fix tracked in #71)

## Test plan

- [ ] Read the new GETTING_STARTED.md top-to-bottom as a first-time user — CLI path should be the first thing a new user sees
- [ ] Verify the "Advanced: Manual Setup" section links correctly to INSTALL.md
- [ ] Verify no broken paths are referenced in the manual section
- [ ] Confirm the MCP-only snippet matches what README.md shows