### PR TITLE
fix(install): move org templates to tracked path, fix Step 2 cp commands

### DIFF
--- a/.datacore/templates/org/habits.org.example
+++ b/.datacore/templates/org/habits.org.example
@@ -1,0 +1,23 @@
+#+TITLE: Habits
+#+FILETAGS: :habits:
+
+* Daily Habits
+** TODO Morning routine
+SCHEDULED: <2025-01-01 Wed .+1d>
+:PROPERTIES:
+:STYLE: habit
+:END:
+
+** TODO Evening review
+SCHEDULED: <2025-01-01 Wed .+1d>
+:PROPERTIES:
+:STYLE: habit
+:END:
+
+* Weekly Habits
+** TODO Weekly review
+SCHEDULED: <2025-01-05 Sun .+1w>
+:PROPERTIES:
+:STYLE: habit
+:END:
+

--- a/.datacore/templates/org/inbox.org.example
+++ b/.datacore/templates/org/inbox.org.example
@@ -1,0 +1,6 @@
+#+TITLE: Inbox
+#+FILETAGS: :inbox:
+
+* TODO Do more. With less.
+* Inbox
+

--- a/.datacore/templates/org/next_actions.org.example
+++ b/.datacore/templates/org/next_actions.org.example
@@ -1,0 +1,26 @@
+#+TITLE: Next Actions
+#+FILETAGS: :next:
+
+* Work
+** TODO Example task                                              :example:
+:PROPERTIES:
+:CREATED: [2025-01-01 Wed]
+:END:
+
+* Personal
+
+* AI Delegation
+Tasks tagged with :AI: are processed by autonomous agents.
+
+** TODO Example AI research task                              :AI:research:
+:PROPERTIES:
+:CREATED: [2025-01-01 Wed]
+:END:
+Research example topic
+
+** TODO Example AI content task                                :AI:content:
+:PROPERTIES:
+:CREATED: [2025-01-01 Wed]
+:END:
+Draft blog post about example topic
+

--- a/.datacore/templates/org/someday.org.example
+++ b/.datacore/templates/org/someday.org.example
@@ -1,0 +1,15 @@
+#+TITLE: Someday/Maybe
+#+FILETAGS: :someday:
+
+* Projects
+Ideas for future projects.
+
+* Learning
+Skills to develop someday.
+
+* Travel
+Places to visit.
+
+* Ideas
+Random ideas to revisit.
+

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -73,10 +73,10 @@ Copy template files to create your local configuration:
 cp install.yaml.example install.yaml
 
 # GTD org files
-cp 0-personal/org/inbox.org.example 0-personal/org/inbox.org
-cp 0-personal/org/next_actions.org.example 0-personal/org/next_actions.org
-cp 0-personal/org/someday.org.example 0-personal/org/someday.org
-cp 0-personal/org/habits.org.example 0-personal/org/habits.org
+cp .datacore/templates/org/inbox.org.example 0-personal/org/inbox.org
+cp .datacore/templates/org/next_actions.org.example 0-personal/org/next_actions.org
+cp .datacore/templates/org/someday.org.example 0-personal/org/someday.org
+cp .datacore/templates/org/habits.org.example 0-personal/org/habits.org
 
 # Build CLAUDE.md from layers (see Layered Context Pattern below)
 python .datacore/lib/context_merge.py rebuild --path .


### PR DESCRIPTION
## Summary

Fixes #71 — INSTALL.md Step 2 fails on a fresh clone because the org template files were only in `0-personal/org/_archive/templates/`, a path excluded by the root `.gitignore` (`/0-*/`).

- Added `.datacore/templates/org/` with four tracked template files: `inbox.org.example`, `next_actions.org.example`, `someday.org.example`, `habits.org.example`
- Updated INSTALL.md Step 2 `cp` commands to copy from the new tracked path

## Verification

```bash
# After cloning a fresh fork, Step 2 now works:
cp .datacore/templates/org/inbox.org.example 0-personal/org/inbox.org
cp .datacore/templates/org/next_actions.org.example 0-personal/org/next_actions.org
cp .datacore/templates/org/someday.org.example 0-personal/org/someday.org
cp .datacore/templates/org/habits.org.example 0-personal/org/habits.org
```

```bash
# Confirm templates are tracked:
git ls-files .datacore/templates/org/
# .datacore/templates/org/habits.org.example
# .datacore/templates/org/inbox.org.example
# .datacore/templates/org/next_actions.org.example
# .datacore/templates/org/someday.org.example
```

## Sibling check

Searched all tracked `.md` and `.yaml` files for references to the old `0-personal/org/*.org.example` cp pattern. Found one additional occurrence in `.datacore/dips/DIP-0005-installation-upgrade.md` — that file lives in the `datacore-dips` submodule and will be fixed in a separate PR to that repo.