### PR TITLE
projector: recompute the day name in every org stamp

### DIFF
--- a/.datacore/lib/ledger/projector.py
+++ b/.datacore/lib/ledger/projector.py
@@ -127,6 +127,18 @@ class Projection:
 _BARE_DATE = re.compile(r"^(\d{4})-(\d{2})-(\d{2})$")
 
 
+_STAMP_DAY = re.compile(r"([<\[])(\d{4})-(\d{2})-(\d{2}) [A-Za-z]{2,3}(?=[ >\]])")
+
+
+def _fix_day(m: "re.Match") -> str:
+    import datetime as _dt
+    try:
+        day = _dt.date(int(m.group(2)), int(m.group(3)), int(m.group(4))).strftime("%a")
+    except ValueError:
+        return m.group(0)
+    return f"{m.group(1)}{m.group(2)}-{m.group(3)}-{m.group(4)} {day}"
+
+
 def _org_stamp(value):
     """Render a date as a VALID org timestamp: `<YYYY-MM-DD Day>`.
 
@@ -148,6 +160,11 @@ def _org_stamp(value):
     if not value:
         return value
     text = str(value).strip()
+    # A bracketed stamp is passed through -- except its DAY NAME, which is
+    # recomputed from the date. Typed weekdays reach the ledger from org files
+    # (`<2026-07-30 Wed>`; it was a Thursday) and a projection that repeats
+    # them fails the date hook on every autosave (4-forge, 2026-09-04).
+    text = _STAMP_DAY.sub(_fix_day, text)
     m = _BARE_DATE.match(text)
     if not m:
         return text

--- a/.datacore/lib/tests/test_projector_tags.py
+++ b/.datacore/lib/tests/test_projector_tags.py
@@ -6,7 +6,7 @@ import pathlib, sys
 LIB = pathlib.Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(LIB))
 from ledger.fold import ItemState          # noqa: E402
-from ledger.projector import render_item, _clean_title_and_tags  # noqa: E402
+from ledger.projector import render_item, _clean_title_and_tags, _org_stamp  # noqa: E402
 
 
 def _item(title, tags=None, status="created", state="TODO"):
@@ -28,3 +28,12 @@ def test_ordinary_titles_and_tags_are_untouched():
     assert render_item(_item("Ship it", tags=["AI", "plur"]))[0] == "* TODO Ship it  :AI:plur:"
     assert render_item(_item("No tags here"))[0] == "* TODO No tags here"
     assert _clean_title_and_tags("ratio 1:2 in title", []) == ("ratio 1:2 in title", [])
+
+
+
+def test_typed_weekday_in_a_stamp_is_recomputed():
+    """4-forge's checkpoint carried <2026-07-30 Wed>; 2026-07-30 was a Thursday."""
+    assert _org_stamp("<2026-07-30 Wed>") == "<2026-07-30 Thu>"
+    assert _org_stamp("[2026-07-30 Wed 09:00]") == "[2026-07-30 Thu 09:00]"
+    assert _org_stamp("<2026-07-30 Thu +1w>") == "<2026-07-30 Thu +1w>", "a correct stamp is untouched"
+    assert _org_stamp("2026-07-30").startswith("<2026-07-30 Thu"), "bare dates still get bracketed with the right day"


### PR DESCRIPTION
Typed weekdays reach the ledger from org files; the checkpoint projection repeated <2026-07-30 Wed> (a Thursday) and the date hook refused 4-forge autosave on winston every 15 minutes. The projector now recomputes the day name in every stamp it writes, keeping time-of-day and repeaters.

Test: test_projector_tags.py::test_typed_weekday_in_a_stamp_is_recomputed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ASw7Pf89xqmcLPtX2Xa42