### PR TITLE
fix(install): use ${HOME}/Data in mcp example path, add pip install step

### DIFF
--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -3,7 +3,7 @@
     "gamma": {
       "command": "node",
       "args": [
-        "/path/to/Data/.datacore/modules/slides/mcp-server/dist/index.js"
+        "${HOME}/Data/.datacore/modules/slides/mcp-server/dist/index.js"
       ],
       "env": {
         "GAMMA_API_KEY": "your-gamma-api-key-here"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -64,6 +64,12 @@ git remote -v
 # upstream  https://github.com/datacore-one/datacore.git (fetch)
 ```
 
+### Step 1b: Install Python Dependencies
+
+```bash
+pip install -r .datacore/lib/requirements.txt
+```
+
 ### Step 2: Activate Templates
 
 Copy template files to create your local configuration:


### PR DESCRIPTION
## Summary

- Fixes #73: Replace `/path/to/Data/` placeholder in `.mcp.json.example` gamma server path with `${HOME}/Data` so it works out of the box for the standard install location.
- Fixes #75: Add **Step 1b** to `INSTALL.md` — `pip install -r .datacore/lib/requirements.txt` — immediately after clone/fork so Python deps are present before template activation and database init steps that depend on them.

## Changes

- `.mcp.json.example` line 6: `/path/to/Data/` → `${HOME}/Data/`
- `INSTALL.md`: new Step 1b section inserted between Step 1 (clone) and Step 2 (activate templates)

## Test plan

- [ ] Copy `.mcp.json.example` → `.mcp.json` on a fresh clone; confirm Claude Code picks up the gamma server at the correct resolved path
- [ ] Follow INSTALL.md steps 1 → 1b → 2 on a clean Python venv; confirm no `ModuleNotFoundError` on subsequent steps