### PR TITLE
projector: recompute day names in body text too

### DIFF
--- a/.datacore/lib/ledger/projector.py
+++ b/.datacore/lib/ledger/projector.py
@@ -292,6 +292,9 @@ def render_item(item, *, level: int | None = None) -> list[str]:
     lines.extend("  " + line for line in _drawer(props))
 
     body = (org.get("body") or "").rstrip()
+    # Body text is copied verbatim, so a typed weekday inside it (a DEADLINE
+    # line captured as body, 4-forge 2026-09-04) came back on every projection.
+    body = _STAMP_DAY.sub(_fix_day, body)
     if body:
         lines.extend(body.split("\n"))
     return lines

--- a/.datacore/lib/tests/test_projector_tags.py
+++ b/.datacore/lib/tests/test_projector_tags.py
@@ -37,3 +37,11 @@ def test_typed_weekday_in_a_stamp_is_recomputed():
     assert _org_stamp("[2026-07-30 Wed 09:00]") == "[2026-07-30 Thu 09:00]"
     assert _org_stamp("<2026-07-30 Thu +1w>") == "<2026-07-30 Thu +1w>", "a correct stamp is untouched"
     assert _org_stamp("2026-07-30").startswith("<2026-07-30 Thu"), "bare dates still get bracketed with the right day"
+
+
+def test_typed_weekday_inside_body_text_is_recomputed():
+    """4-forge: a DEADLINE line captured as body text carried <2026-07-30 Wed>."""
+    item = _item("Generate SEO blog post")
+    item.payload["org"] = {"body": "DEADLINE: <2026-07-30 Wed>\nGenerate the post."}
+    text = "\n".join(render_item(item))
+    assert "<2026-07-30 Thu>" in text and "Wed" not in text


### PR DESCRIPTION
Follow-up to #80: a DEADLINE line captured as body text carried a typed weekday, and the body is copied verbatim. Day names inside body stamps are recomputed as well.

Test: test_projector_tags.py::test_typed_weekday_inside_body_text_is_recomputed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ASw7Pf89xqmcLPtX2Xa42