### PR TITLE
salvage #53: validate-module ignores code blocks; research hooks declare boundaries

### DIFF
--- a/.datacore/lib/validate_module.py
+++ b/.datacore/lib/validate_module.py
@@ -217,6 +217,15 @@ class ModuleValidator:
 
         print()
 
+
+    def _strip_code_blocks(self, text: str) -> str:
+        """Strip fenced and inline code blocks before placeholder scanning."""
+        # Remove fenced blocks (``` ... ```)
+        text = re.sub(r'```[\s\S]*?```', '', text)
+        # Remove inline code (`...`) but not bare backticks
+        text = re.sub(r'`[^`\n]+`', '', text)
+        return text
+
     def check_placeholders(self):
         """Detect placeholder text in module files."""
         print("Placeholder Detection:")
@@ -244,7 +253,8 @@ class ModuleValidator:
                 continue
 
             try:
-                content = file.read_text()
+                raw = file.read_text()
+                content = self._strip_code_blocks(raw)
                 for match in pattern.finditer(content):
                     line_num = content[:match.start()].count('\n') + 1
                     rel_path = file.relative_to(self.module_path)

--- a/.datacore/modules/research/commands/nightshift-hook.md
+++ b/.datacore/modules/research/commands/nightshift-hook.md
@@ -149,6 +149,26 @@ Research processing complete:
 - Failures: X (details in journal)
 ```
 
+
+## Your Boundaries
+
+**YOU CAN:**
+- Read research_learning.org and count the processing queue
+- Invoke research-orchestrator agent in nightshift (non-interactive) mode
+- Write literature notes, zettels, and journal entries as directed by the orchestrator
+- Mark processed TODO items as DONE with :OUTPUT: and :ZETTELS: properties
+
+**YOU CANNOT:**
+- Exceed max_sources_per_night items in a single run
+- Require user confirmation — this hook is non-interactive
+- Delete research entries (only mark DONE)
+- Modify settings.local.yaml
+
+**YOU MUST:**
+- Exit cleanly (exit 0) when the queue is empty
+- Log failures without aborting the entire batch
+- Report final processing summary for the nightshift journal
+
 ## Error Handling
 
 ### No Items to Process

--- a/.datacore/modules/research/commands/today-hook.md
+++ b/.datacore/modules/research/commands/today-hook.md
@@ -152,6 +152,25 @@ When queue is clear:
 Research queue is clear.
 ```
 
+
+## Your Boundaries
+
+**YOU CAN:**
+- Read research_learning.org to count pending TODO items
+- Check Readwise API for archived item count (read-only)
+- List the podcast directory to find the most recent podcast
+- Output a concise research status block for the /today briefing
+
+**YOU CANNOT:**
+- Import or modify Readwise items (use /research-status for that)
+- Process research queue items (use /research-daily for that)
+- Write to research_learning.org or any org file
+
+**YOU MUST:**
+- Show "Queue: not set up" if research_learning.org doesn't exist
+- Degrade gracefully on any API or IO error (show status string, do not throw)
+- Keep output concise — this is a briefing section, not a full report
+
 ## Error Handling
 
 - If research_learning.org doesn't exist: Show "Queue: not set up"


### PR DESCRIPTION
The three September commits from #53 (Miles), cherry-picked onto current main with authorship kept. The rest of #53 is older than main and would regress it.

- validate_module: strip fenced and inline code before the placeholder scan (a documented placeholder inside a code block is not an unfilled placeholder)
- research today-hook and nightshift-hook: the Your Boundaries sections the module validator expects

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ASw7Pf89xqmcLPtX2Xa42