### PR TITLE
validate-module: TODO and FIXME are placeholders only as markers

### DIFF
--- a/.datacore/lib/tests/test_validate_module_placeholders.py
+++ b/.datacore/lib/tests/test_validate_module_placeholders.py
@@ -1,0 +1,31 @@
+"""The placeholder scan flags markers, not the org keyword in prose."""
+import importlib.util, pathlib, tempfile
+
+ROOT = pathlib.Path(__file__).resolve().parents[3]
+spec = importlib.util.spec_from_file_location("vm", ROOT / ".datacore" / "lib" / "validate_module.py")
+V = importlib.util.module_from_spec(spec); spec.loader.exec_module(V)
+
+
+def _issues(tmp_path, text):
+    mod = pathlib.Path(tempfile.mkdtemp(dir=tmp_path)); (mod / "commands").mkdir()
+    (mod / "commands" / "x.md").write_text(text)
+    v = V.ModuleValidator(mod); v.check_placeholders()
+    return [i for i in v.issues if "Placeholder" in i]
+
+
+def test_org_keyword_in_prose_is_not_a_placeholder(tmp_path):
+    assert _issues(tmp_path, "- Counts pending TODO items\n- Scans for TODO/DONE counts per section\n") == []
+
+
+def test_markers_are_placeholders(tmp_path):
+    assert len(_issues(tmp_path, "TODO: fill this in\n")) == 1
+    assert len(_issues(tmp_path, "See [TODO] and <FIXME> below\n")) == 2
+    assert len(_issues(tmp_path, "FIXME: broken\n")) == 1
+
+
+def test_markers_inside_code_blocks_are_ignored(tmp_path):
+    assert _issues(tmp_path, "```\nTODO: example inside code\n```\nand `TODO: inline`\n") == []
+
+
+def test_other_template_placeholders_still_count(tmp_path):
+    assert len(_issues(tmp_path, "Author: <author>\n")) == 1

--- a/.datacore/lib/validate_module.py
+++ b/.datacore/lib/validate_module.py
@@ -230,9 +230,14 @@ class ModuleValidator:
         """Detect placeholder text in module files."""
         print("Placeholder Detection:")
 
+        # TODO and FIXME count only as MARKERS. Bare `TODO` matched the org
+        # state keyword every module doc uses in prose ("counts pending TODO
+        # items", "TODO/DONE counts") and the research module carried 16
+        # such false positives after code blocks were already excluded
+        # (2026-09-04). A marker is `TODO:` / `FIXME:` or a bracketed form.
         placeholder_patterns = [
-            r'TODO',
-            r'FIXME',
+            r'(?<![\w/])(?:TODO|FIXME)\s*:',
+            r'[\[<{](?:TODO|FIXME)[\]>}]',
             r'\[Replace\s+this\]',
             r'\[Add\s+\w+\s+here\]',
             r'\[Fill.*?\]',


### PR DESCRIPTION
Bare TODO matched the org state keyword in prose and left the research module with 16 false positives after #83 excluded code blocks. A placeholder is now TODO:/FIXME: or a bracketed form; the other template placeholders are unchanged. The research module validates 32/32 with this.

Tests: test_validate_module_placeholders.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ASw7Pf89xqmcLPtX2Xa42