### PR TITLE
ledger: Phase 1 tooling (repair, generate, flip, cycle)

### DIFF
--- a/.datacore/lib/ledger_phase1_cycle.sh
+++ b/.datacore/lib/ledger_phase1_cycle.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Phase 1 cycle (DIP-0046): ingest -> converge -> project, hourly on every host.
+#   ingest    what writers put into org files since the last cycle -> ledger
+#   converge  this host's ledger logs with everyone else's (git transport)
+#   project   for spaces in Phase 1 only: org/next_actions.org <- ledger
+# Order is the whole point: projecting before ingesting loses a hand edit.
+set -u
+export DATACORE_ROOT="${DATACORE_ROOT:-$HOME/Data}"
+LIB="$DATACORE_ROOT/.datacore/lib"
+STATE="$HOME/.datacore/state"; mkdir -p "$STATE"
+PY=""
+for c in "${DATACORE_PYTHON:-}" python3.13 python3.12 python3.11 python3.10 /opt/homebrew/bin/python3 /usr/local/bin/python3 python3; do
+  [ -n "$c" ] || continue; command -v "$c" >/dev/null 2>&1 || continue
+  "$c" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3,10) else 1)' 2>/dev/null && { PY="$c"; break; }
+done
+[ -n "$PY" ] || { echo "FATAL: no python >= 3.10"; exit 127; }
+cd "$DATACORE_ROOT" || exit 2
+echo "=== $(date -u '+%F %H:%MZ') phase-1 cycle ==="
+PHASE1=$(for d in "$DATACORE_ROOT"/[0-9]-*; do [ "$(cat "$d/.datacore/ledger-phase" 2>/dev/null | tr -d '[:space:]')" = "1" ] && basename "$d"; done)
+if [ -z "$PHASE1" ]; then echo "no space in Phase 1; nothing to do"; exit 0; fi
+"$PY" "$LIB/ledger_ingest_org.py" --root "$DATACORE_ROOT" > "$STATE/phase1-ingest.log" 2>&1; echo "ingest  rc=$? $(tail -1 "$STATE/phase1-ingest.log" | cut -c1-100)"
+rc=0
+for s in $PHASE1; do
+  "$PY" "$LIB/ledger_transport.py" converge --space "$s" > "$STATE/phase1-converge-$s.log" 2>&1 || { echo "converge $s: $(grep -o '"reason": "[^"]*"' "$STATE/phase1-converge-$s.log" | head -1)"; rc=1; }
+done
+"$PY" "$LIB/ledger_project_org.py" --all 2>&1 | grep -v "authored" ; echo "project rc=$?"
+exit $rc

--- a/.datacore/lib/ledger_phase1_cycle.sh
+++ b/.datacore/lib/ledger_phase1_cycle.sh
@@ -6,7 +6,10 @@
 # Order is the whole point: projecting before ingesting loses a hand edit.
 set -u
 export DATACORE_ROOT="${DATACORE_ROOT:-$HOME/Data}"
-LIB="$DATACORE_ROOT/.datacore/lib"
+# The scripts come from THIS checkout (a runner worktree on main is fine); only
+# the data root is DATACORE_ROOT. A host whose ~/Data sits on someone's feature
+# branch still runs current tooling against its own data.
+LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 STATE="$HOME/.datacore/state"; mkdir -p "$STATE"
 PY=""
 for c in "${DATACORE_PYTHON:-}" python3.13 python3.12 python3.11 python3.10 /opt/homebrew/bin/python3 /usr/local/bin/python3 python3; do

--- a/.datacore/lib/ledger_phase1_flip.py
+++ b/.datacore/lib/ledger_phase1_flip.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Flip one space to Phase 1, or reverse it -- the drill's steps, on a real space.
+
+FLIP     write `.datacore/ledger-phase` = 1, ignore org/next_actions.org,
+         drop it from the index, generate it from the ledger, commit.
+REVERSE  remove the marker and the ignore line, commit the current generated
+         file as the authored file again.
+
+Preconditions for FLIP, checked, not assumed: the ledger folds; the space's
+last ingest left nothing unimported; org and projection agree on every live
+item (the shadow diff is clean for this space). Refuses otherwise.
+
+    ledger_phase1_flip.py --space NAME (--flip | --reverse) [--root DIR] [--apply]
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+LIB = Path(__file__).resolve().parent
+sys.path.insert(0, str(LIB))
+from ledger_project_org import MARKER, ORG, phase, project_space  # noqa: E402
+
+IGNORE_LINE = "org/next_actions.org"
+
+
+def git(space: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", "-C", str(space), *args], capture_output=True, text=True)
+
+
+def shadow_clean(space: Path) -> tuple[bool, str]:
+    from ledger_checkpoint import _fingerprint  # noqa: E402
+    from ledger.fold import fold
+    from ledger.log import read_events
+    from ledger.genesis import scan
+    live = _fingerprint(fold(read_events(space)))
+    before = scan(space)
+    unimported = len(before.importable)
+    ids_in_org = set()
+    for f in (space / "org").glob("*.org"):
+        for line in f.read_text(errors="replace").splitlines():
+            if line.strip().startswith(":ID:"):
+                ids_in_org.add(line.split(":ID:", 1)[1].strip())
+    extra = sorted(set(live) - ids_in_org)
+    if unimported:
+        return False, f"{unimported} org task(s) not yet in the ledger — ingest first"
+    if extra:
+        return False, f"{len(extra)} live ledger item(s) with no org task — run ledger_phase1_prepare first"
+    return True, f"{len(live)} live items agree"
+
+
+def flip(space: Path, apply: bool) -> int:
+    ok, why = shadow_clean(space)
+    print(f"  precondition: {why}")
+    if not ok:
+        return 1
+    if phase(space) == 1:
+        print("  already Phase 1"); return 0
+    if not apply:
+        print("  dry run — would write marker, ignore + untrack org/next_actions.org, generate, commit"); return 0
+    (space / MARKER).parent.mkdir(parents=True, exist_ok=True)
+    (space / MARKER).write_text("1\n")
+    gi = space / ".gitignore"
+    lines = gi.read_text().splitlines() if gi.exists() else []
+    if IGNORE_LINE not in lines:
+        gi.write_text("\n".join(lines + ["# Phase 1 (DIP-0046): generated from the ledger, never authored", IGNORE_LINE]) + "\n")
+    git(space, "rm", "-q", "--cached", str(ORG))
+    print("  " + project_space(space))
+    git(space, "add", ".gitignore", str(MARKER))
+    r = git(space, "commit", "-q", "-m", "phase 1: org/next_actions.org is generated from the ledger (DIP-0046)")
+    if r.returncode:
+        print("  commit refused:\n" + (r.stderr or r.stdout)[-400:]); return 1
+    print(f"  flipped: {git(space, 'log', '--oneline', '-1').stdout.strip()[:70]}")
+    return 0
+
+
+def reverse(space: Path, apply: bool) -> int:
+    if phase(space) != 1:
+        print("  not in Phase 1"); return 0
+    if not apply:
+        print("  dry run — would remove marker + ignore line and commit the generated file as authored"); return 0
+    print("  " + project_space(space))
+    (space / MARKER).unlink(missing_ok=True)
+    gi = space / ".gitignore"
+    keep = [l for l in gi.read_text().splitlines() if l != IGNORE_LINE and "Phase 1 (DIP-0046)" not in l]
+    gi.write_text("\n".join(keep) + ("\n" if keep else ""))
+    git(space, "add", ".gitignore", str(ORG))
+    git(space, "rm", "-q", "--cached", "--ignore-unmatch", str(MARKER))
+    r = git(space, "commit", "-q", "-m", "phase 0: org/next_actions.org is authored again (projection committed as the file)")
+    if r.returncode:
+        print("  commit refused:\n" + (r.stderr or r.stdout)[-400:]); return 1
+    print(f"  reversed: {git(space, 'log', '--oneline', '-1').stdout.strip()[:70]}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--root", type=Path, default=Path(os.environ.get("DATACORE_ROOT", Path.home() / "Data")))
+    ap.add_argument("--space", required=True)
+    g = ap.add_mutually_exclusive_group(required=True)
+    g.add_argument("--flip", action="store_true"); g.add_argument("--reverse", action="store_true")
+    ap.add_argument("--apply", action="store_true")
+    a = ap.parse_args(argv)
+    space = a.root / a.space
+    return flip(space, a.apply) if a.flip else reverse(space, a.apply)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.datacore/lib/ledger_phase1_prepare.py
+++ b/.datacore/lib/ledger_phase1_prepare.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Make a space's ledger and its org file agree, in the ledger, before Phase 1.
+
+Two things keep a space's shadow diff dirty for months and neither is fixed by
+editing org:
+
+  TWINS    After the 2026-08-11 id regeneration, every task in org carried a new
+           id and the next ingest created a NEW ledger item for each. The old
+           items stayed live with no org task. 2-datacore: 271 of 272 orphans
+           have a same-title task alive under another id. Retire the old one
+           as housekeeping (never as abandoned work), naming the twin.
+  DRIFT    Ingest fills holes; it never removes a tag or rewrites a title the
+           ledger already holds. A task whose tags or title moved in org stays
+           "changed" forever. Emit the org values as an update.
+
+Ledger only: this never touches an org file. Dry-run by default.
+
+    ledger_phase1_prepare.py --space 2-datacore [--root DIR] [--actor mac] [--apply]
+"""
+from __future__ import annotations
+
+import argparse
+import collections
+import inspect
+import os
+import re
+import sys
+from pathlib import Path
+
+LIB = Path(__file__).resolve().parent
+sys.path.insert(0, str(LIB))
+from ledger.fold import fold  # noqa: E402
+from ledger.log import EventLog, read_events  # noqa: E402
+
+LIVE = ("created", "claimed", "granted")
+STATE_RE = re.compile(r"^\*+\s+(?:(?:TODO|NEXT|DONE|WAITING|REVIEW|CANCELLED|DEFERRED|QUEUED)\s+)?(?:\[#[A-C]\]\s+)?(.*?)(?:\s+:[^\s]+:)?\s*$")
+ID_RE = re.compile(r"^\s*:ID:\s*(\S+)\s*$")
+TAGS_RE = re.compile(r"\s+:([^\s:]+(?::[^\s:]+)*):\s*$")
+
+
+def norm(title: str) -> str:
+    return re.sub(r"\s+", " ", title or "").strip().lower()
+
+
+def org_index(space: Path) -> tuple[dict[str, dict], dict[str, list[str]]]:
+    """id -> {title, tags (effective, minus filetags)}; normalised title -> [ids].
+
+    Effective tags, not heading tags: the ledger's fingerprint is inherited
+    tags included (ledger_checkpoint._fingerprint), so comparing against the
+    heading alone would "fix" every child task by stripping what it inherits.
+    """
+    from org_workspace import OrgWorkspace
+    by_id: dict[str, dict] = {}
+    by_title: dict[str, list[str]] = collections.defaultdict(list)
+    for f in sorted((space / "org").glob("*.org")):
+        ws = OrgWorkspace()
+        try:
+            ws.load(f)
+        except Exception as exc:  # noqa: BLE001
+            print(f"  skip {f.name}: {exc}", file=sys.stderr); continue
+        filetags = set()
+        for line in f.read_text(errors="replace").splitlines()[:40]:
+            m = re.match(r"#\+FILETAGS:\s*:?(.*?):?\s*$", line, re.I)
+            if m:
+                filetags = {t for t in m.group(1).split(":") if t}
+        for node in ws.all_nodes():
+            props = node.properties or {}
+            tid = props.get("ID")
+            if not tid:
+                continue
+            eff = sorted(set(node.tags or []) - filetags)
+            own = sorted(set(node.shallow_tags or []) - filetags)
+            by_id[tid] = {"title": (node.heading or "").strip(), "tags": eff, "own": own}
+            by_title[norm(node.heading or "")].append(tid)
+    return by_id, by_title
+
+
+def _open_log(space: Path, actor: str) -> EventLog:
+    params = list(inspect.signature(EventLog.__init__).parameters)
+    kwargs = {}
+    for name in params[1:]:
+        if name in ("space", "space_dir", "root"):
+            kwargs[name] = space
+        elif name in ("events_dir", "log_dir", "path"):
+            kwargs[name] = space / ".datacore" / "events"
+        elif name == "actor":
+            kwargs[name] = actor
+    return EventLog(**kwargs)
+
+
+def plan(space: Path) -> dict:
+    state = fold(read_events(space))
+    by_id, by_title = org_index(space)
+    live = [i for i in state.items.values() if i.status in LIVE and not (i.payload or {}).get("section")]
+    dismiss, update = [], []
+    for item in live:
+        if item.id in by_id:
+            org = by_id[item.id]
+            p = item.payload or {}
+            eff = sorted(set(p.get("effective_tags") or p.get("tags") or []) - set(p.get("filetags") or []))
+            if norm(item.title) != norm(org["title"]) or eff != org["tags"]:
+                update.append((item.id, org["title"], org["tags"], org["own"]))
+            continue
+        twins = [t for t in by_title.get(norm(item.title), []) if t != item.id]
+        if twins:
+            dismiss.append((item.id, f"duplicate: superseded by {twins[0]} after the 2026-08-11 id regeneration"))
+        else:
+            dismiss.append((item.id, "no org task in this space at Phase 1 preparation"))
+    return {"live": len(live), "dismiss": dismiss, "update": update}
+
+
+def apply(space: Path, actor: str, p: dict) -> int:
+    log = _open_log(space, actor)
+    n = 0
+    for iid, reason in p["dismiss"]:
+        log.append("item.dismiss", {"id": iid, "reason": reason, "kind": "housekeeping"}); n += 1
+    for iid, title, tags, own in p["update"]:
+        # both fields: the fingerprint falls back to `tags` when `effective_tags` is empty
+        log.append("item.update", {"id": iid, "title": title, "tags": own, "effective_tags": tags}); n += 1
+    return n
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--root", type=Path, default=Path(os.environ.get("DATACORE_ROOT", Path.home() / "Data")))
+    ap.add_argument("--space", required=True)
+    ap.add_argument("--actor", default=os.environ.get("DATACORE_ACTOR") or os.uname().nodename.split(".")[0])
+    ap.add_argument("--apply", action="store_true")
+    a = ap.parse_args(argv)
+    space = a.root / a.space
+    p = plan(space)
+    twins = sum(1 for _, r in p["dismiss"] if r.startswith("duplicate"))
+    print(f"  {a.space}: live={p['live']} dismiss={len(p['dismiss'])} (twins {twins}, no-twin {len(p['dismiss']) - twins}) update={len(p['update'])}")
+    for iid, title, tags, own in p["update"]:
+        print(f"    update {iid}: title={title[:50]!r} tags={tags}")
+    if not a.apply:
+        print("  dry run — re-run with --apply"); return 0
+    n = apply(space, a.actor, p)
+    print(f"  appended {n} event(s) as {a.actor}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.datacore/lib/ledger_project_org.py
+++ b/.datacore/lib/ledger_project_org.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Write org/next_actions.org FROM the ledger, for spaces in Phase 1 only.
+
+Phase 1 (DIP-0046): the org file is generated and gitignored; the ledger is
+the record. A space is in Phase 1 when `.datacore/ledger-phase` in that space
+reads `1`. Any other space is left untouched -- this tool never generates
+over an authored file.
+
+Run it AFTER an ingest: ingest captures what writers put in the org file since
+the last cycle, then the projection re-emits everything the ledger holds.
+Projecting without ingesting first is how a hand edit gets lost.
+
+    ledger_project_org.py --space NAME | --all [--root DIR]
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+LIB = Path(__file__).resolve().parent
+sys.path.insert(0, str(LIB))
+from ledger.fold import fold  # noqa: E402
+from ledger.log import read_events  # noqa: E402
+from ledger.projector import project  # noqa: E402
+
+MARKER = Path(".datacore") / "ledger-phase"
+ORG = Path("org") / "next_actions.org"
+
+
+HEADER_COPY = Path(".datacore") / "ledger-org-header"
+
+
+def _with_org_header(space: Path, target: Path, text: str) -> str:
+    """Keep the authored file's `#+TITLE/#+CATEGORY/#+STARTUP/#+TAGS/...` lines.
+
+    The projector opens with a GENERATED banner and no in-buffer settings; an
+    org-mode user's tag completion and startup folding live in those lines.
+    They are read from the current file when it has them, else from the copy
+    saved at flip time, and the banner is replaced by one honest line.
+    """
+    header: list[str] = []
+    src = target if target.exists() else None
+    if src is not None:
+        for line in src.read_text(errors="replace").splitlines():
+            if line.startswith("#+"):
+                header.append(line)
+            elif line.strip() and not line.startswith("#"):
+                break
+    if header:
+        (space / HEADER_COPY).write_text("\n".join(header) + "\n")
+    elif (space / HEADER_COPY).exists():
+        header = (space / HEADER_COPY).read_text().splitlines()
+    body = [l for l in text.splitlines() if not l.startswith("# ")]
+    note = "# Generated from the ledger (Phase 1, DIP-0046). Edits here are ingested hourly; the ledger is the record."
+    return "\n".join(header + [note] + body) + "\n"
+
+
+def phase(space: Path) -> int:
+    try:
+        return int((space / MARKER).read_text().strip() or "0")
+    except (FileNotFoundError, ValueError):
+        return 0
+
+
+def project_space(space: Path) -> str:
+    if phase(space) != 1:
+        return "phase 0, authored — not generated"
+    text = project(fold(read_events(space)), space=space.name).text
+    target = space / ORG
+    text = _with_org_header(space, target, text)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tmp = target.with_suffix(".org.tmp")
+    tmp.write_text(text, encoding="utf-8")
+    os.replace(tmp, target)
+    return f"generated {ORG} ({text.count(chr(10))} lines)"
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--root", type=Path, default=Path(os.environ.get("DATACORE_ROOT", Path.home() / "Data")))
+    g = ap.add_mutually_exclusive_group(required=True)
+    g.add_argument("--space")
+    g.add_argument("--all", action="store_true")
+    a = ap.parse_args(argv)
+    spaces = [a.root / a.space] if a.space else sorted(p for p in a.root.glob("[0-9]-*") if (p / ".datacore" / "events").is_dir())
+    for s in spaces:
+        print(f"  {s.name:14} {project_space(s)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.datacore/lib/tests/test_ledger_phase1_tools.py
+++ b/.datacore/lib/tests/test_ledger_phase1_tools.py
@@ -1,0 +1,87 @@
+"""Phase 1 tooling: repair the ledger, generate org from it only when flipped, flip and reverse."""
+import importlib.util, json, pathlib, subprocess, sys
+
+LIB = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(LIB))
+
+
+def _load(name):
+    spec = importlib.util.spec_from_file_location(name, LIB / f"{name}.py")
+    m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m); return m
+
+
+def _git(cwd, *a):
+    return subprocess.run(["git", *a], cwd=cwd, capture_output=True, text=True, check=True)
+
+
+ORG = """#+TITLE: Drill
+#+STARTUP: overview
+#+TAGS: AI(a) research(r)
+
+* TODO Alpha task  :research:
+:PROPERTIES:
+:ID: new-alpha
+:END:
+* TODO Beta task
+:PROPERTIES:
+:ID: beta
+:END:
+"""
+
+
+def _space(tmp_path):
+    from ledger.log import EventLog
+    space = tmp_path / "9-drill"; (space / "org").mkdir(parents=True); (space / ".datacore" / "events").mkdir(parents=True)
+    (space / "org" / "next_actions.org").write_text(ORG)
+    log = EventLog(space, "mac")
+    log.append("item.create", {"id": "old-alpha", "title": "Alpha task", "tags": ["research"], "effective_tags": ["research"], "space": "9-drill", "level": 1})
+    log.append("item.create", {"id": "new-alpha", "title": "Alpha task", "tags": ["research"], "effective_tags": ["research"], "space": "9-drill", "level": 1})
+    log.append("item.create", {"id": "beta", "title": "Beta task (old title)", "tags": ["AI"], "effective_tags": ["AI"], "space": "9-drill", "level": 1})
+    log.append("item.create", {"id": "ghost", "title": "Nobody has this in org", "tags": [], "effective_tags": [], "space": "9-drill", "level": 1})
+    return space
+
+
+def test_prepare_retires_twins_as_housekeeping_and_updates_drift(tmp_path):
+    P = _load("ledger_phase1_prepare"); space = _space(tmp_path)
+    plan = P.plan(space)
+    dismissed = dict(plan["dismiss"])
+    assert "old-alpha" in dismissed and "superseded by new-alpha" in dismissed["old-alpha"]
+    assert "ghost" in dismissed and "no org task" in dismissed["ghost"]
+    assert [u[0] for u in plan["update"]] == ["beta"], "only the task whose title/tags moved in org"
+    P.apply(space, "mac", plan)
+    from ledger.fold import fold, closure_kind
+    from ledger.log import read_events
+    st = fold(read_events(space))
+    assert st.items["old-alpha"].status == "dismissed" and closure_kind(st.items["old-alpha"]) == "housekeeping"
+    assert st.items["new-alpha"].status == "created"
+    assert st.items["beta"].title == "Beta task" and st.items["beta"].payload["effective_tags"] == []
+    assert P.plan(space)["dismiss"] == [] and P.plan(space)["update"] == [], "idempotent"
+
+
+def test_project_org_only_generates_in_phase_1_and_keeps_the_header(tmp_path):
+    G = _load("ledger_project_org"); space = _space(tmp_path)
+    before = (space / "org" / "next_actions.org").read_text()
+    assert "not generated" in G.project_space(space) and (space / "org" / "next_actions.org").read_text() == before
+    (space / ".datacore" / "ledger-phase").write_text("1\n")
+    assert G.project_space(space).startswith("generated")
+    text = (space / "org" / "next_actions.org").read_text()
+    assert text.startswith("#+TITLE: Drill\n#+STARTUP: overview\n#+TAGS: AI(a) research(r)\n"), "org header kept"
+    assert "Generated from the ledger" in text and "DO NOT EDIT" not in text
+    assert "Alpha task" in text and "Nobody has this in org" in text, "the ledger drives the file now"
+
+
+def test_flip_refuses_until_ledger_and_org_agree_then_flips_and_reverses(tmp_path):
+    F = _load("ledger_phase1_flip"); P = _load("ledger_phase1_prepare"); space = _space(tmp_path)
+    _git(space, "init", "-q", "-b", "main"); _git(space, "config", "user.email", "t@t"); _git(space, "config", "user.name", "t")
+    _git(space, "add", "-A"); _git(space, "commit", "-q", "-m", "base")
+    assert F.flip(space, apply=True) == 1, "orphans in the ledger: refused"
+    P.apply(space, "mac", P.plan(space))
+    _git(space, "add", "-A"); _git(space, "commit", "-q", "-m", "prepared")
+    assert F.flip(space, apply=True) == 0
+    assert (space / ".datacore" / "ledger-phase").read_text().strip() == "1"
+    assert subprocess.run(["git", "ls-files", "--error-unmatch", "org/next_actions.org"], cwd=space, capture_output=True).returncode != 0, "untracked while generated"
+    assert "org/next_actions.org" in (space / ".gitignore").read_text()
+    assert F.reverse(space, apply=True) == 0
+    assert subprocess.run(["git", "ls-files", "--error-unmatch", "org/next_actions.org"], cwd=space, capture_output=True).returncode == 0, "tracked again"
+    assert not (space / ".datacore" / "ledger-phase").exists()
+    assert "Alpha task" in (space / "org" / "next_actions.org").read_text()


### PR DESCRIPTION
Everything needed to take one space ledger-first, per DIP-0046 Phase 1, with the reversal the drill proved:

- ledger_phase1_prepare: retires the 271 post-id-churn twins in 2-datacore as housekeeping (each names its twin) and emits org title/tags where ingest never would; ledger only, dry-run by default
- ledger_project_org: org/next_actions.org from the ledger, only where .datacore/ledger-phase reads 1; keeps the org header lines
- ledger_phase1_flip: flip and reverse on a real space; flip refuses until org and ledger agree
- ledger_phase1_cycle.sh: ingest, converge, project, hourly on every host

Tests: test_ledger_phase1_tools.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N565gr1tEwgK6DDVm8Mpfy