### PR TITLE
roadmap agent-ready: sprint_sync, ai_task_gate, agent_readiness, task-lifecycle spec

### DIFF
--- a/.datacore/hooks/space-pre-commit
+++ b/.datacore/hooks/space-pre-commit
@@ -194,6 +194,31 @@ if git diff --cached --name-only | grep -q '^roadmap\.yaml$'; then
   fi
 fi
 
+# A staged org file must not queue work an agent cannot execute.
+#
+# `:AI:` is nightshift's queue, not a label — find_ai_tasks selects exactly the
+# headings carrying it in TODO/NEXT. On 2026-09-04 that queue held 92 tasks of
+# which 4 named a surface and a definition of done, because the tag had been
+# added by hand, by agents and by cadences for months with nothing checking it.
+# Normally sprint_sync writes the tag from sprint.yaml and this never fires; it
+# exists for the hand-added exception, which is the path that caused the drift.
+#
+# Same repo-relative rule as the roadmap check above: staged paths are
+# `org/next_actions.org`, never `5-plur/org/next_actions.org`.
+_staged_org=$(git diff --cached --name-only | grep '^org/.*\.org$' || true)
+if [ -n "$_staged_org" ]; then
+  _gate=""
+  for _c in "$HOME/Data/.datacore/lib/ai_task_gate.py" \
+            "$(git rev-parse --show-toplevel)/../.datacore/lib/ai_task_gate.py"; do
+    [ -f "$_c" ] && { _gate="$_c"; break; }
+  done
+  if [ -n "$_gate" ]; then
+    if ! python3 "$_gate" $_staged_org; then
+      fail=1
+    fi
+  fi
+fi
+
 [ "$fail" = "1" ] && { printf "\nTo bypass (emergency): git commit --no-verify\n"; exit 1; }
 
 exit 0

--- a/.datacore/lib/agent_readiness.py
+++ b/.datacore/lib/agent_readiness.py
@@ -26,13 +26,41 @@ import yaml
 REPO = Path(__file__).resolve().parents[2]
 ROADMAP = REPO / "5-plur" / "roadmap.yaml"
 ADAPTER = REPO / ".datacore/lib/org_workspace_adapter.py"
-ORG = ["5-plur/org/next_actions.org", "5-plur/org/someday.org",
-       "5-plur/org/inbox.org"]
+# EVERY space, not just 5-plur. nightshift's find_ai_tasks walks the whole data
+# directory — it does not know what a roadmap is — so a queue measured in one
+# space is not the queue that runs. Scoped to 5-plur this check reported ONE
+# finding on 2026-09-04 while the executor was about to select 265 tasks across
+# six spaces, 262 of them with no surface and no definition of done. Third time
+# the same mistake: measure the set the executor actually selects.
+def _org_files() -> list[str]:
+    out = []
+    for space in sorted(REPO.glob("[0-9]-*")):
+        d = space / "org"
+        if d.is_dir():
+            out += [str(p.relative_to(REPO)) for p in sorted(d.glob("*.org"))]
+    return out
+
+
+ORG = _org_files()
 VERIFIABLE = {"test", "metric", "url", "artifact", "merged-pr"}
 JUDGEMENT = {"decision", "signed", "screenshot"}
 
 
 OPEN_STATES = {"NEXT", "TODO", "WAITING", "REVIEW"}
+
+# Only a space that HAS a roadmap can require its tasks to link to one. 5-plur
+# has roadmap.yaml; 0-personal, 6-meridian and the rest do not, and demanding a
+# ROADMAP property there reported 357 findings for a file that does not exist.
+# SURFACE and DONE_WHEN are required everywhere — an agent always needs to know
+# where the work lands and how it will know it finished, roadmap or no roadmap.
+HAS_ROADMAP = {p.parent.name for p in REPO.glob("[0-9]-*/roadmap.yaml")}
+
+
+def _space_of(node) -> str:
+    try:
+        return Path(str(node.file_path)).relative_to(REPO).parts[0]
+    except Exception:
+        return "?"
 
 
 def tasks():
@@ -46,13 +74,22 @@ def tasks():
     gives the real NodeView, body included. It is also faster: one parse
     instead of three subprocesses.
     """
+    import contextlib, io
+
     from org_workspace import OrgWorkspace
 
     ws = OrgWorkspace()
-    for f in ORG:
-        p = REPO / f
-        if p.exists():
-            ws.load(p)
+    # load() prints a line per duplicate ID it regenerates. Across all spaces
+    # that is dozens of lines of unrelated noise on top of this report. The
+    # regeneration is IN MEMORY ONLY — this function never calls save_all() —
+    # so swallowing the log changes nothing on disk. Verified 2026-09-04: org
+    # files are byte-identical after a run.
+    with contextlib.redirect_stdout(io.StringIO()), \
+            contextlib.redirect_stderr(io.StringIO()):
+        for f in ORG:
+            p = REPO / f
+            if p.exists():
+                ws.load(p)
     out = []
     for n in ws.all_nodes():
         if n.todo not in OPEN_STATES:
@@ -60,6 +97,7 @@ def tasks():
         out.append({
             "heading": n.heading or "",
             "state": n.todo,
+            "_space": _space_of(n),
             # SHALLOW, not inherited. org-mode inherits tags from ancestors and
             # org_workspace's `.tags` honours that — but nightshift does not:
             # nightshift_parser matches `(\s+:[\w:]+:)?$` on the heading LINE
@@ -101,8 +139,9 @@ def main():
         p = t.get("properties") or {}
         rid = p.get("ROADMAP")
         if not rid:
-            findings["select"].append(
-                f"AI task with no epic: {t['heading'][:60]}")
+            if t.get("_space") in HAS_ROADMAP:
+                findings["select"].append(
+                    f"AI task with no epic: {t['heading'][:60]}")
             continue
         epic = items.get(rid)
         if epic and epic.get("blocked_on") == "human":
@@ -136,14 +175,17 @@ def main():
     # NB: do not name this walrus `r` — a comprehension's walrus binds in the
     # ENCLOSING scope, and `r` is the parsed roadmap. Doing so replaced the
     # roadmap with a string and killed the VERIFY check thirty lines later.
-    unassigned = [(t, why) for t in ai if (why := _bad_surface(t))]
-    for t, reason in unassigned[:6]:
-        findings["locate"].append(
-            f"AI task — agent cannot tell which repo ({reason}): "
-            f"{t['heading'][:52]}")
-    if len(unassigned) > 6:
-        findings["locate"].append(
-            f"...and {len(unassigned) - 6} more AI tasks with an unusable SURFACE")
+    # ONE finding per task, and let the printer do the truncating. This block
+    # used to append six rows plus a literal "...and N more" row, so the
+    # section reported 7 while 357 tasks were affected — every other check
+    # counts tasks, so the sections were not comparable and the total meant
+    # nothing. Never fold a count into the finding list.
+    for t in ai:
+        reason = _bad_surface(t)
+        if reason:
+            findings["locate"].append(
+                f"AI task — agent cannot tell which repo ({reason}): "
+                f"{t['heading'][:52]}")
 
     # 3 FINISH ---------------------------------------------------------------
     #
@@ -165,7 +207,16 @@ def main():
             continue                       # has its own — fine
         epic = items.get(rid) if rid else None
         if not epic:
-            continue                       # already caught by SELECT
+            # "already caught by SELECT" was true only while SELECT demanded a
+            # ROADMAP on every task. Now that it only demands one where a
+            # roadmap exists, a task outside 5-plur with neither a DONE_WHEN
+            # nor an epic falls through both checks — unfinishable and
+            # unreported. It is the most common shape in the pool, so silently
+            # skipping it made the fleet look clean.
+            findings["finish"].append(
+                f"no DONE_WHEN and no epic to inherit one from — nothing "
+                f"defines success: {t['heading'][:48]}")
+            continue
         if by_epic[rid] > 1:
             findings["finish"].append(
                 f"no task-level DONE_WHEN, and epic {rid}'s condition is shared "

--- a/.datacore/lib/agent_readiness.py
+++ b/.datacore/lib/agent_readiness.py
@@ -32,17 +32,45 @@ VERIFIABLE = {"test", "metric", "url", "artifact", "merged-pr"}
 JUDGEMENT = {"decision", "signed", "screenshot"}
 
 
+OPEN_STATES = {"NEXT", "TODO", "WAITING", "REVIEW"}
+
+
 def tasks():
-    out = []
+    """Read the org files directly rather than through the adapter's `list`.
+
+    `org_workspace_adapter.py list` emits heading/state/tags/properties and NO
+    BODY key. The 3b BRIEF check below asks whether there is prose an agent can
+    act on — and against the adapter it was reading `t.get("body")` on a dict
+    that never has one, so the body half of that test was dead from the day it
+    was written and only the property half ever fired. Loading the workspace
+    gives the real NodeView, body included. It is also faster: one parse
+    instead of three subprocesses.
+    """
+    from org_workspace import OrgWorkspace
+
+    ws = OrgWorkspace()
     for f in ORG:
-        r = subprocess.run(["python3", str(ADAPTER), "list", "--file", f,
-                            "--states", "NEXT,TODO,WAITING,REVIEW"],
-                           capture_output=True, text=True, cwd=REPO)
-        if r.returncode:
+        p = REPO / f
+        if p.exists():
+            ws.load(p)
+    out = []
+    for n in ws.all_nodes():
+        if n.todo not in OPEN_STATES:
             continue
-        for t in json.loads(r.stdout)["tasks"]:
-            t["_f"] = f
-            out.append(t)
+        out.append({
+            "heading": n.heading or "",
+            "state": n.todo,
+            # SHALLOW, not inherited. org-mode inherits tags from ancestors and
+            # org_workspace's `.tags` honours that — but nightshift does not:
+            # nightshift_parser matches `(\s+:[\w:]+:)?$` on the heading LINE
+            # and never walks parents. So a live child under a DONE parent
+            # tagged :AI: looks queued to org_workspace and is invisible to the
+            # executor. Four tasks sat in exactly that state on 2026-09-04.
+            # Mirror the executor or this check measures a queue nobody runs.
+            "tags": list(n.shallow_tags or []),
+            "properties": dict(n.properties or {}),
+            "body": (n.body or ""),
+        })
     return out
 
 
@@ -54,7 +82,18 @@ def main():
     r = yaml.safe_load(ROADMAP.read_text())
     items = {i["id"]: i for i in r["items"]}
     ts = tasks()
-    ai = [t for t in ts if "AI" in (t.get("tags") or [])]
+
+    # THE QUEUE IS NOT EVERY :AI: TASK. nightshift_parser.find_ai_tasks selects
+    # `states = ['TODO', 'NEXT']` and nothing else, so a REVIEW-state task
+    # tagged :AI: is work an agent has already DONE and a human has not yet
+    # looked at — the tag is provenance there, not a request. Scoring those for
+    # "can an agent start this" measures a set the executor will never select,
+    # which inflated this report by 52 findings on 2026-09-04 and is the same
+    # wrong-question mistake the FINISH check made (see below). Mirror the
+    # executor: if find_ai_tasks' state list changes, change this with it.
+    QUEUED = ("TODO", "NEXT")
+    tagged = [t for t in ts if "AI" in (t.get("tags") or [])]
+    ai = [t for t in tagged if t.get("state") in QUEUED]
     findings = defaultdict(list)
 
     # 1 SELECT ---------------------------------------------------------------
@@ -72,15 +111,39 @@ def main():
                 f"{t['heading'][:52]}")
 
     # 2 LOCATE ---------------------------------------------------------------
-    unassigned = [t for t in ai
-                  if (t.get("properties") or {}).get("SURFACE") in (None, "unassigned")]
-    for t in unassigned[:6]:
+    # SURFACE has to be one of the DECLARED surfaces, not merely non-empty.
+    # In the wild it carries two incompatible meanings: task_surface.py's
+    # vocabulary ("which repo do I work in" — core, enterprise, hub, ops...)
+    # and, on GEO tasks, a publication URL like "plur.ai/blog (canonical) +
+    # dev.to mirror". The second is useful to a writer and useless to an agent
+    # asking which checkout to open, and an emptiness test passes it. Validate
+    # against the vocabulary so a URL fails LOCATE the way a blank would.
+    sys.path.insert(0, str(REPO / ".datacore/lib"))
+    try:
+        from task_surface import SURFACES as _S, DEFAULT as _D
+        KNOWN = {n for n, _ in _S} | {_D}
+    except Exception:                       # never let the check die on import
+        KNOWN = set()
+
+    def _bad_surface(t):
+        s = (t.get("properties") or {}).get("SURFACE")
+        if s in (None, "", "unassigned"):
+            return "no surface"
+        if KNOWN and s not in KNOWN:
+            return f"surface {s[:28]!r} is not one of {sorted(KNOWN - {'unassigned'})[:4]}..."
+        return None
+
+    # NB: do not name this walrus `r` — a comprehension's walrus binds in the
+    # ENCLOSING scope, and `r` is the parsed roadmap. Doing so replaced the
+    # roadmap with a string and killed the VERIFY check thirty lines later.
+    unassigned = [(t, why) for t in ai if (why := _bad_surface(t))]
+    for t, reason in unassigned[:6]:
         findings["locate"].append(
-            f"AI task with no surface — agent cannot tell which repo: "
-            f"{t['heading'][:56]}")
+            f"AI task — agent cannot tell which repo ({reason}): "
+            f"{t['heading'][:52]}")
     if len(unassigned) > 6:
         findings["locate"].append(
-            f"...and {len(unassigned) - 6} more AI tasks with SURFACE unassigned")
+            f"...and {len(unassigned) - 6} more AI tasks with an unusable SURFACE")
 
     # 3 FINISH ---------------------------------------------------------------
     #
@@ -177,8 +240,9 @@ def main():
              "avoid":  "5 AVOID  — is undoable work clearly marked"}
 
     total = sum(len(v) for v in findings.values())
-    print(f"{len(r['items'])} epics · {len(ts)} open tasks · {len(ai)} tagged :AI:")
-    print(f"{total} readiness finding(s)\n")
+    print(f"{len(r['items'])} epics · {len(ts)} open tasks · "
+          f"{len(tagged)} tagged :AI: · {len(ai)} of them QUEUED (TODO/NEXT)")
+    print(f"{total} readiness finding(s) — against the queue, not the pool\n")
     for k in ("select", "locate", "finish", "brief", "verify", "avoid"):
         rows = findings.get(k) or []
         print(f"── {LABEL[k]} — {len(rows)}")

--- a/.datacore/lib/ai_task_gate.py
+++ b/.datacore/lib/ai_task_gate.py
@@ -59,6 +59,14 @@ def main(argv: list[str]) -> int:
         if node.todo not in QUEUED or "AI" not in (node.shallow_tags or []):
             continue
         props = node.properties or {}
+        # A queue REFERENCE deliberately carries no spec — SOURCE_ID points at
+        # the task that holds it, so that one record cannot drift from the copy
+        # that runs (task_queue.resolve_queued_task merges them at selection
+        # time, and REFUSES when the pointer dangles). Demanding the spec on
+        # both ends would force the duplication the reference design exists to
+        # prevent. The source task is gated on its own terms.
+        if str(props.get("SOURCE_ID") or "").strip():
+            continue
         missing = [k for k in REQUIRED if not str(props.get(k) or "").strip()
                    or str(props.get(k)).strip() == "unassigned"]
         if missing:

--- a/.datacore/lib/ai_task_gate.py
+++ b/.datacore/lib/ai_task_gate.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Refuse an :AI: task an agent could not actually execute.
+
+`:AI:` is not a label meaning "an agent could do this one day". It is a QUEUE:
+nightshift_parser.find_ai_tasks selects exactly the org headings tagged :AI: in
+state TODO or NEXT, and hands them to an agent overnight. So the tag is a
+promise that the task is executable as written.
+
+On 2026-09-04 that promise was false for 88 of the 92 tasks holding the tag —
+they named no surface, so the agent could not tell which repo, and no
+definition of done, so it could not tell whether it had succeeded. The pool had
+drifted there gradually: every hand-added `:AI:`, every agent filing follow-up
+work, every cadence, each individually reasonable.
+
+The fix that lasts is not a backfill, it is a gate. Three properties, checked
+where the tag is written:
+
+    ROADMAP    which outcome this serves        (SELECT)
+    SURFACE    which repo the work lands in     (LOCATE)
+    DONE_WHEN  how the agent knows it finished  (FINISH)
+
+Normally nothing hits this gate, because sprint_sync.py writes the tag from
+sprint.yaml and fills all three from fields the sprint already carries. It
+fires on the hand-added exception — which is exactly the path that produced the
+drift.
+
+    python3 .datacore/lib/ai_task_gate.py <file.org> [...]      # exit 1 on fail
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REQUIRED = {
+    "ROADMAP": "no ROADMAP — the agent cannot tell which outcome this serves",
+    "SURFACE": "no SURFACE — the agent cannot tell which repo to work in",
+    "DONE_WHEN": "no DONE_WHEN — the agent cannot tell when it has finished",
+}
+QUEUED = ("TODO", "NEXT")
+
+
+def main(argv: list[str]) -> int:
+    files = [Path(a) for a in argv if a.endswith(".org")]
+    if not files:
+        return 0
+
+    from org_workspace import OrgWorkspace
+
+    ws = OrgWorkspace()
+    for f in files:
+        if f.exists():
+            ws.load(f)
+
+    bad = []
+    for node in ws.all_nodes():
+        # shallow_tags, not tags: nightshift reads the heading line and does
+        # not inherit tags from ancestors, so an inherited :AI: is not queued
+        # and must not be gated as though it were. See agent_readiness.tasks().
+        if node.todo not in QUEUED or "AI" not in (node.shallow_tags or []):
+            continue
+        props = node.properties or {}
+        missing = [k for k in REQUIRED if not str(props.get(k) or "").strip()
+                   or str(props.get(k)).strip() == "unassigned"]
+        if missing:
+            bad.append((node.heading, missing, props.get("ID")))
+
+    if not bad:
+        return 0
+
+    print(f"\n\033[1;31m{len(bad)} :AI: TASK(S) AN AGENT CANNOT EXECUTE\033[0m")
+    print("The :AI: tag is nightshift's queue, not a classification.\n")
+    for heading, missing, tid in bad[:15]:
+        print(f"  {heading[:72]}")
+        print(f"    {tid or '(no id)'}")
+        for k in missing:
+            print(f"    - {REQUIRED[k]}")
+    if len(bad) > 15:
+        print(f"  ...and {len(bad) - 15} more")
+    print("\nEither give the task all three properties, or drop the :AI: tag —")
+    print("the task stays in the pool either way, it just is not queued.")
+    print("Sprint work should come from sprint.yaml:")
+    print("  python3 .datacore/lib/sprint_sync.py --active --apply")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.datacore/lib/ai_task_gate.py
+++ b/.datacore/lib/ai_task_gate.py
@@ -12,12 +12,17 @@ definition of done, so it could not tell whether it had succeeded. The pool had
 drifted there gradually: every hand-added `:AI:`, every agent filing follow-up
 work, every cadence, each individually reasonable.
 
-The fix that lasts is not a backfill, it is a gate. Three properties, checked
-where the tag is written:
+The fix that lasts is not a backfill, it is a gate, checked where the tag is
+written:
 
-    ROADMAP    which outcome this serves        (SELECT)
-    SURFACE    which repo the work lands in     (LOCATE)
-    DONE_WHEN  how the agent knows it finished  (FINISH)
+    SURFACE                            which repo the work lands in   (LOCATE)
+    DONE_WHEN or ACCEPTANCE_CRITERIA   how it knows it finished       (FINISH)
+    ROADMAP                            which outcome it serves        (SELECT)
+                                       — only in a space that HAS a roadmap
+
+It mirrors nightshift_parser._is_executable rather than exceeding it. A gate
+stricter than the executor rejects work the executor would run happily, which
+teaches people to reach for --no-verify, after which it guards nothing.
 
 Normally nothing hits this gate, because sprint_sync.py writes the tag from
 sprint.yaml and fills all three from fields the sprint already carries. It
@@ -31,12 +36,40 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-REQUIRED = {
-    "ROADMAP": "no ROADMAP — the agent cannot tell which outcome this serves",
-    "SURFACE": "no SURFACE — the agent cannot tell which repo to work in",
-    "DONE_WHEN": "no DONE_WHEN — the agent cannot tell when it has finished",
-}
 QUEUED = ("TODO", "NEXT")
+
+# Mirror nightshift_parser._is_executable exactly. A gate STRICTER than the
+# executor rejects work the executor would happily run, which teaches people to
+# pass --no-verify and then guards nothing at all.
+#
+# ACCEPTANCE_CRITERIA is DONE_WHEN's older spelling and several well-specified
+# tasks predate the rename; both are accepted.
+DONE_KEYS = ("DONE_WHEN", "ACCEPTANCE_CRITERIA")
+
+# ROADMAP is required only in a space that HAS a roadmap. 0-personal and
+# 6-meridian have none, and demanding an epic link there is a complaint about a
+# file that does not exist — the same scoping error agent_readiness made.
+REPO = Path(__file__).resolve().parents[2]
+HAS_ROADMAP = {p.parent.name for p in REPO.glob("[0-9]-*/roadmap.yaml")}
+
+
+def _space_of(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(REPO).parts[0]
+    except Exception:
+        return "?"
+
+
+def _missing(props: dict, space: str) -> list[str]:
+    out = []
+    surface = str(props.get("SURFACE") or "").strip()
+    if not surface or surface == "unassigned":
+        out.append("no SURFACE — the agent cannot tell which repo to work in")
+    if not any(str(props.get(k) or "").strip() for k in DONE_KEYS):
+        out.append("no DONE_WHEN — the agent cannot tell when it has finished")
+    if space in HAS_ROADMAP and not str(props.get("ROADMAP") or "").strip():
+        out.append("no ROADMAP — the agent cannot tell which outcome this serves")
+    return out
 
 
 def main(argv: list[str]) -> int:
@@ -67,8 +100,7 @@ def main(argv: list[str]) -> int:
         # prevent. The source task is gated on its own terms.
         if str(props.get("SOURCE_ID") or "").strip():
             continue
-        missing = [k for k in REQUIRED if not str(props.get(k) or "").strip()
-                   or str(props.get(k)).strip() == "unassigned"]
+        missing = _missing(props, _space_of(Path(str(node.path))))
         if missing:
             bad.append((node.heading, missing, props.get("ID")))
 
@@ -80,8 +112,8 @@ def main(argv: list[str]) -> int:
     for heading, missing, tid in bad[:15]:
         print(f"  {heading[:72]}")
         print(f"    {tid or '(no id)'}")
-        for k in missing:
-            print(f"    - {REQUIRED[k]}")
+        for reason in missing:
+            print(f"    - {reason}")
     if len(bad) > 15:
         print(f"  ...and {len(bad) - 15} more")
     print("\nEither give the task all three properties, or drop the :AI: tag —")

--- a/.datacore/lib/sprint_sync.py
+++ b/.datacore/lib/sprint_sync.py
@@ -150,8 +150,14 @@ def sync_queue(ws, space: str, wanted: list[dict], apply: bool) -> tuple[list, l
     for n in ws.all_nodes():
         if "nightshift.org" not in str(n.path):  # NodeView exposes .path, not .file_path
             continue
-        nid = (n.properties or {}).get("ID") or ""
-        if nid.startswith("org-sprint-") and nid.endswith("-q"):
+        # Identify our own entries by their PROPERTIES, not by an id prefix.
+        # The prefix test only held while every projected task was created by
+        # this script; an ADOPTED task keeps its author's id, so
+        # `org-20260904-trust-surface-q` failed the prefix check and the entry
+        # would have been recreated on every single run.
+        pr = n.properties or {}
+        nid = pr.get("ID") or ""
+        if pr.get("SOURCE_ID") and pr.get("SPRINT") and nid.endswith("-q"):
             have[nid] = n
 
     added, removed = [], []
@@ -213,6 +219,13 @@ def discover(space: str) -> list[Path]:
     sprint id, and prefer the non-worktree path.
     """
     found = sorted((REPO / space).glob("2-projects/*/sprints/*/sprint.yaml"))
+    # Track-level sprints too. Work that is not in one code repo — ops, hub
+    # submissions, bizdev, statutory — has no 2-projects/ home, and filing it
+    # under a code repo's sprints/ would be a lie about where it lives.
+    # It goes under `1-tracks/<track>/sprints/` rather than a bare `sprints/`
+    # at the space root: DIP-0015 fixes the allowed root directories and the
+    # structure hook refuses a new one, correctly.
+    found += sorted((REPO / space).glob("1-tracks/*/sprints/*/sprint.yaml"))
     best: dict[str, Path] = {}
     for p in found:
         key = p.parent.name
@@ -277,7 +290,11 @@ def agent_items(sprint: dict, include_stretch: bool) -> tuple[list[dict], list[s
         claimer = str(it.get("default_claimer") or it.get("owner") or "")
         if not AGENT_CLAIMER.search(claimer):
             continue
-        missing = [f for f in REQUIRED if not it.get(f)]
+        # An adopting item need only name the task; the task already carries
+        # roadmap, surface and its definition of done, and repeating them in the
+        # sprint file creates two copies that drift.
+        required = ("title", "org") if it.get("org") else REQUIRED
+        missing = [f for f in required if not it.get(f)]
         if missing:
             problems.append(
                 f"{it.get('id', '?')} ({claimer}) is claimed by an agent but has no "
@@ -328,15 +345,23 @@ def main() -> int:
         problems += [f"{sid}: {p}" for p in probs]
 
         for it in mine:
-            tid = f"org-sprint-{slug(sid)}-{slug(it['id'])}"
+            # ADOPT vs CREATE. `org: <task-id>` means the task ALREADY EXISTS —
+            # someone wrote it, with its own ROADMAP/SURFACE/DONE_WHEN — and the
+            # sprint is claiming it, not re-describing it. Without this the only
+            # way to sprint an existing task was to create a second one beside
+            # it, which then competes with the original and strips the
+            # original's tag on the same pass. A parallel session hit exactly
+            # that on 2026-09-04 with thirteen roadmap-unblocking tasks.
+            adopted = str(it.get("org") or "").strip()
+            tid = adopted or f"org-sprint-{slug(sid)}-{slug(it['id'])}"
             keep_ids.add(tid)
             tags = ["AI"] + [tag_slug(t) for t in (it.get("labels") or [])]
             props = {
                 "ID": tid,
-                "ROADMAP": str(it["roadmap"]),
-                "MILESTONE": str(it["milestone"]),
-                "SURFACE": str(it["surface"]),
-                "DONE_WHEN": one_line(it["acceptance"]),
+                "ROADMAP": str(it.get("roadmap") or ""),
+                "MILESTONE": str(it.get("milestone") or ""),
+                "SURFACE": str(it.get("surface") or ""),
+                "DONE_WHEN": one_line(it.get("acceptance") or ""),
                 "SPRINT": sid,
                 "SPRINT_ITEM": str(it["id"]),
                 "ASSIGNEE": str(it.get("default_claimer") or ""),
@@ -345,6 +370,34 @@ def main() -> int:
             }
             if it.get("effort_estimate"):
                 props["EFFORT"] = str(it["effort_estimate"])
+
+            if adopted:
+                existing = ws.find_by_id(adopted)
+                if existing is None:
+                    problems.append(
+                        f"{sid}: {it['id']} adopts org task {adopted!r}, which does "
+                        f"not exist — refusing rather than silently creating a "
+                        f"second task under that name")
+                    keep_ids.discard(tid)
+                    continue
+                # The author's own words win. The sprint supplies only what the
+                # task is missing, plus its own SPRINT bookkeeping — overwriting
+                # a DONE_WHEN somebody wrote with one paraphrased into a sprint
+                # file is how the definition of done quietly drifts.
+                have = existing.properties or {}
+                for k in ("ROADMAP", "MILESTONE", "SURFACE", "DONE_WHEN", "REF",
+                          "EFFORT", "ASSIGNEE"):
+                    if str(have.get(k) or "").strip():
+                        props[k] = have[k]
+                gaps = [k for k in ("ROADMAP", "SURFACE", "DONE_WHEN")
+                        if not str(props.get(k) or "").strip()]
+                if gaps:
+                    problems.append(
+                        f"{sid}: {it['id']} adopts {adopted} but neither the "
+                        f"sprint nor the task supplies {', '.join(gaps)} — an "
+                        f"agent still could not run it")
+                    keep_ids.discard(tid)
+                    continue
 
             node = ws.find_by_id(tid)
 
@@ -359,7 +412,7 @@ def main() -> int:
                     "tags": [tag_slug(t) for t in (it.get("labels") or [])],
                     "sprint": sid,
                     "assignee": str(it.get("default_claimer") or ""),
-                    "surface": str(it["surface"]),
+                    "surface": str(props.get("SURFACE") or ""),
                 })
 
             if node is None:

--- a/.datacore/lib/sprint_sync.py
+++ b/.datacore/lib/sprint_sync.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""Project a sprint into the agent queue, and keep the queue equal to the sprint.
+
+THE PROBLEM THIS SOLVES. Two things both claimed to say what agents work on and
+neither read the other. `sprint.yaml` was written, reviewed and never consumed —
+nothing in the tree read it, and the `miles_routing.sprint_tag_filter` field had
+zero readers. Meanwhile nightshift selects work by one rule: an org heading
+tagged `:AI:` in state TODO or NEXT (see nightshift_parser.find_ai_tasks). So the
+sprint was a document and the queue was a tag, and on 2026-09-04 the tag held 92
+tasks of which 4 named a surface and a definition of done. The other 88 would
+have been picked up by an agent that could not tell which repo they belonged to
+or how it would know it had finished.
+
+THE FIX IS A DIRECTION, NOT A SYNC. `sprint.yaml` is the source; the `:AI:` tag
+is a projection of it. This script is the ONLY writer of that tag:
+
+    in sprint + claimed by an agent   ->  org task exists, tagged :AI:
+    not in sprint                     ->  :AI: removed (the task itself stays)
+
+Removing the tag does not delete, defer or deprioritise anything. It says "not
+this sprint", which is what a sprint means. The task keeps its ROADMAP link and
+waits in the pool for a sprint to pull it.
+
+WHY IT REFUSES. A sprint item claimed by an agent must carry roadmap, milestone,
+surface and acceptance. Those are exactly the four things agent_readiness.py
+checks, and sprint.yaml already had fields for all of them. Refusing here is the
+point: an underspecified item is caught while a human is still looking at the
+sprint, instead of at 02:00 by an agent that cannot act on it.
+
+    python3 .datacore/lib/sprint_sync.py --active            # dry run
+    python3 .datacore/lib/sprint_sync.py --sprint 2026-W37-core-sprint1 --apply
+    python3 .datacore/lib/sprint_sync.py --active --apply
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO = Path(__file__).resolve().parents[2]
+
+# A claimer that is an agent. Everything else is a person, and a person's item
+# is NOT projected into the agent queue however well specified it is.
+AGENT_CLAIMER = re.compile(r"nightshift|miles|tris|agent|winston", re.I)
+
+PRIORITY = {"must": "A", "should": "B", "could": "C"}
+
+# Fields an agent-claimed item must carry. These mirror agent_readiness.py's
+# LOCATE / SELECT / FINISH gates one-for-one; keep them in step.
+REQUIRED = ("title", "roadmap", "milestone", "surface", "acceptance")
+
+# In-flight work is never un-queued mid-run: pulling the tag out from under a
+# running agent orphans the task and the agent's own completion write lands on
+# a heading that no longer claims to be its work.
+IN_FLIGHT = {"executing", "requeued", "claimed"}
+
+# ...but the hold has to expire, or it protects a corpse. The enterprise issue
+# sweep sat at NIGHTSHIFT_STATUS: executing for SEVEN DAYS with two requeues
+# and score 0.0, its COMPLETED stamp predating its STARTED stamp. Nothing was
+# running; the status was simply never cleared, and an unexpiring exemption
+# meant every sync politely stepped around it. A run that has not moved in this
+# many days is stuck, and stuck work is un-queued and named, not sheltered.
+STALE_AFTER_DAYS = 2
+STAMPS = ("NIGHTSHIFT_STARTED", "NIGHTSHIFT_ROUTED", "NIGHTSHIFT_COMPLETED")
+
+
+def slug(s: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", str(s).lower()).strip("-")
+
+
+def one_line(s: str) -> str:
+    """Acceptance prose -> a single-line DONE_WHEN an org property can hold.
+
+    Rejoin words the sprint's own line-wrapping split across a hyphen first:
+    YAML folds "thirty-\\neight" and a naive whitespace collapse turns that
+    into "thirty- eight". Only rejoin when the next character is lowercase, so
+    genuine compounds ("self-hosted", "no-benchmark-war") keep their hyphen.
+    """
+    s = re.sub(r"-\n(?=[a-z])", "", (s or ""))
+    return re.sub(r"\s+", " ", s.strip())
+
+
+def _age_days(props: dict) -> float | None:
+    """Days since this task last showed a sign of life. None if it never has."""
+    from datetime import datetime, timezone
+
+    newest = None
+    for k in STAMPS:
+        raw = str(props.get(k) or "").strip()
+        if not raw:
+            continue
+        try:
+            dt = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        except ValueError:
+            continue
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        if newest is None or dt > newest:
+            newest = dt
+    if newest is None:
+        return None
+    return (datetime.now(timezone.utc) - newest).total_seconds() / 86400
+
+
+def discover(space: str) -> list[Path]:
+    return sorted((REPO / space).glob("2-projects/*/sprints/*/sprint.yaml"))
+
+
+def pick(space: str, want: str | None, active: bool) -> list[Path]:
+    found = discover(space)
+    if want:
+        hit = [p for p in found if want in str(p)]
+        if not hit:
+            sys.exit(f"no sprint matching {want!r} under {space}/2-projects/*/sprints/")
+        return hit
+    if active:
+        out = []
+        for p in found:
+            d = yaml.safe_load(p.read_text()) or {}
+            if d.get("status") == "active":
+                out.append(p)
+        return out
+    return found
+
+
+def items_of(sprint: dict, include_stretch: bool) -> list[dict]:
+    rows = list(sprint.get("backlog") or [])
+    if include_stretch:
+        rows += list(sprint.get("stretch") or [])
+    return rows
+
+
+def agent_items(sprint: dict, include_stretch: bool) -> tuple[list[dict], list[str]]:
+    """Split the sprint's items into agent-claimed and everything else."""
+    mine, problems = [], []
+    for it in items_of(sprint, include_stretch):
+        claimer = str(it.get("default_claimer") or it.get("owner") or "")
+        if not AGENT_CLAIMER.search(claimer):
+            continue
+        missing = [f for f in REQUIRED if not it.get(f)]
+        if missing:
+            problems.append(
+                f"{it.get('id', '?')} ({claimer}) is claimed by an agent but has no "
+                f"{', '.join(missing)} — an agent cannot "
+                + ("find the repo" if "surface" in missing else "know it finished")
+            )
+            continue
+        mine.append(it)
+    return mine, problems
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--space", default="5-plur")
+    ap.add_argument("--sprint", help="sprint id or path fragment")
+    ap.add_argument("--active", action="store_true",
+                    help="every sprint whose status is 'active'")
+    ap.add_argument("--stretch", action="store_true",
+                    help="project stretch items too (default: backlog only)")
+    ap.add_argument("--apply", action="store_true", help="write; default is a dry run")
+    ap.add_argument("--strict", action="store_true",
+                    help="exit non-zero if any sprint item is underspecified")
+    args = ap.parse_args()
+
+    paths = pick(args.space, args.sprint, args.active)
+    if not paths:
+        print("no sprint selected — pass --sprint <id> or mark one status: active")
+        return 0
+
+    from org_workspace import OrgWorkspace
+
+    org_dir = REPO / args.space / "org"
+    org_files = [p for p in (org_dir / "next_actions.org", org_dir / "inbox.org",
+                             org_dir / "someday.org") if p.exists()]
+    ws = OrgWorkspace()
+    for f in org_files:
+        ws.load(f)
+
+    target = org_dir / "next_actions.org"
+    keep_ids: set[str] = set()
+    created, updated, problems = [], [], []
+
+    for sp in paths:
+        sprint = yaml.safe_load(sp.read_text()) or {}
+        sid = sprint.get("sprint_id") or sp.parent.name
+        mine, probs = agent_items(sprint, args.stretch)
+        problems += [f"{sid}: {p}" for p in probs]
+
+        for it in mine:
+            tid = f"org-sprint-{slug(sid)}-{slug(it['id'])}"
+            keep_ids.add(tid)
+            tags = ["AI"] + [slug(t) for t in (it.get("labels") or [])]
+            props = {
+                "ID": tid,
+                "ROADMAP": str(it["roadmap"]),
+                "MILESTONE": str(it["milestone"]),
+                "SURFACE": str(it["surface"]),
+                "DONE_WHEN": one_line(it["acceptance"]),
+                "SPRINT": sid,
+                "SPRINT_ITEM": str(it["id"]),
+                "ASSIGNEE": str(it.get("default_claimer") or ""),
+                "SOURCE": "sprint_sync",
+                "REF": str(it.get("ref") or ""),
+            }
+            if it.get("effort_estimate"):
+                props["EFFORT"] = str(it["effort_estimate"])
+
+            node = ws.find_by_id(tid)
+            if node is None:
+                if args.apply:
+                    ws.create_node(
+                        file=target,
+                        heading=str(it["title"]),
+                        state="TODO",
+                        tags=tags,
+                        body=one_line(it["acceptance"]),
+                        **props,
+                    )
+                created.append((tid, it["title"]))
+            else:
+                changed = []
+                for k, v in props.items():
+                    if k == "ID":
+                        continue
+                    if (node.properties or {}).get(k) != v:
+                        changed.append(k)
+                        if args.apply:
+                            ws.set_property(node, k, v)
+                cur = set(node.shallow_tags or [])
+                if "AI" not in cur:
+                    changed.append("tags")
+                    if args.apply:
+                        ws.set_tags(node, sorted(cur | {"AI"}))
+                if changed:
+                    updated.append((tid, it["title"], changed))
+
+    # ---- everything not in the sprint loses the tag ------------------------
+    cleared, held, stuck = [], [], []
+    for node in ws.all_nodes():
+        if node.todo not in ("TODO", "NEXT"):
+            continue
+        # shallow_tags: only a tag on this heading's own line is queued, and
+        # only that one can be removed here. An :AI: inherited from an ancestor
+        # is invisible to nightshift anyway (it parses the heading line, never
+        # the parents), so treating it as queued would have this script report
+        # un-queuing work it did not touch and could not have. It did exactly
+        # that for four tasks before this was corrected on 2026-09-04.
+        tags = list(node.shallow_tags or [])
+        if "AI" not in tags:
+            continue
+        nid = (node.properties or {}).get("ID")
+        if nid in keep_ids:
+            continue
+        props = node.properties or {}
+        status = str(props.get("NIGHTSHIFT_STATUS") or "").lower()
+        if status in IN_FLIGHT:
+            age = _age_days(props)
+            if age is None or age <= STALE_AFTER_DAYS:
+                held.append((nid, node.heading[:60], status))
+                continue
+            stuck.append((nid, node.heading[:60], status, age))
+            # falls through and is un-queued
+        if args.apply:
+            ws.set_tags(node, [t for t in tags if t != "AI"])
+        cleared.append((nid, node.heading[:60]))
+
+    if args.apply:
+        ws.save_all()
+
+    mode = "APPLIED" if args.apply else "DRY RUN — nothing written"
+    print(f"sprint_sync — {mode}")
+    print(f"sprints: {', '.join(p.parent.name for p in paths)}\n")
+    print(f"queued (created)   {len(created)}")
+    for tid, title in created[:12]:
+        print(f"   + {title[:70]}")
+    print(f"queued (updated)   {len(updated)}")
+    for tid, title, ch in updated[:12]:
+        print(f"   ~ {title[:52]} [{', '.join(ch[:4])}]")
+    print(f"un-queued (:AI: removed, task kept)  {len(cleared)}")
+    for nid, h in cleared[:12]:
+        print(f"   - {h}")
+    if len(cleared) > 12:
+        print(f"   ...and {len(cleared) - 12} more")
+    if held:
+        print(f"held in flight (not touched)  {len(held)}")
+        for nid, h, s in held[:6]:
+            print(f"   = {h} [{s}]")
+    if stuck:
+        print(f"\nSTUCK — claimed to be running, has not moved  {len(stuck)}")
+        for nid, h, s, age in stuck:
+            print(f"   ! {h}")
+            print(f"     {s} for {age:.0f} days — un-queued; nothing is running it")
+    if problems:
+        print(f"\nREFUSED — underspecified sprint items  {len(problems)}")
+        for p in problems:
+            print(f"   ! {p}")
+        print("   fix these in sprint.yaml; an agent cannot act on them as written")
+
+    return 1 if (args.strict and problems) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.datacore/lib/sprint_sync.py
+++ b/.datacore/lib/sprint_sync.py
@@ -1,21 +1,30 @@
 #!/usr/bin/env python3
 """Project a sprint into the agent queue, and keep the queue equal to the sprint.
 
-THE PROBLEM THIS SOLVES. Two things both claimed to say what agents work on and
-neither read the other. `sprint.yaml` was written, reviewed and never consumed —
-nothing in the tree read it, and the `miles_routing.sprint_tag_filter` field had
-zero readers. Meanwhile nightshift selects work by one rule: an org heading
-tagged `:AI:` in state TODO or NEXT (see nightshift_parser.find_ai_tasks). So the
-sprint was a document and the queue was a tag, and on 2026-09-04 the tag held 92
-tasks of which 4 named a surface and a definition of done. The other 88 would
-have been picked up by an agent that could not tell which repo they belonged to
-or how it would know it had finished.
+THE PROBLEM THIS SOLVES. `sprint.yaml` was written, reviewed and never consumed:
+nothing in the tree read it, and `miles_routing.sprint_tag_filter` had zero
+readers anywhere.
 
-THE FIX IS A DIRECTION, NOT A SYNC. `sprint.yaml` is the source; the `:AI:` tag
-is a projection of it. This script is the ONLY writer of that tag:
+THERE ARE THREE LEVELS, AND ONLY THE THIRD RUNS. Getting this wrong is the
+single most expensive mistake available here, so it is spelled out:
 
-    in sprint + claimed by an agent   ->  org task exists, tagged :AI:
-    not in sprint                     ->  :AI: removed (the task itself stays)
+  1. A task in next_actions.org            — exists
+  2. ...tagged :AI:                        — is a CANDIDATE
+  3. ...AND referenced from nightshift.org — RUNS
+
+`task_queue.build_queue` keeps only entries whose file is `nightshift.org` and
+drops everything else. On 2026-09-04 the fleet had 261 tasks at level 2 and the
+runner executed 2 — the system already said so on every run ("261 :AI: task(s)
+tagged but not queued — they will NOT run") and it read as noise. 5-plur had no
+nightshift.org at all, so a perfectly specified sprint task would have sat at
+level 2 forever. This script writes all three levels.
+
+THE FIX IS A DIRECTION, NOT A SYNC. `sprint.yaml` is the source; both the tag
+and the queue entry are projections of it:
+
+    in sprint + claimed by an agent   ->  task tagged :AI:, entry in the queue
+    not in sprint                     ->  :AI: removed, queue entry removed
+                                          (the task itself always stays)
 
 Removing the tag does not delete, defer or deprioritise anything. It says "not
 this sprint", which is what a sprint means. The task keeps its ROADMAP link and
@@ -66,9 +75,26 @@ IN_FLIGHT = {"executing", "requeued", "claimed"}
 STALE_AFTER_DAYS = 2
 STAMPS = ("NIGHTSHIFT_STARTED", "NIGHTSHIFT_ROUTED", "NIGHTSHIFT_COMPLETED")
 
+# DIP-0009 v2.0 closed states. A task in one of these is finished; the sprint
+# still lists the item, so the queue must check the TASK, not the sprint.
+CLOSED_STATES = {"DONE", "DEFERRED", "CANCELLED"}
+
 
 def slug(s: str) -> str:
     return re.sub(r"[^a-z0-9]+", "-", str(s).lower()).strip("-")
+
+
+def tag_slug(s: str) -> str:
+    """An org TAG, which may not contain a hyphen.
+
+    nightshift_parser matches tags as `(\\s+:[\\w:]+:)?$` and `\\w` excludes
+    `-`. A heading ending `:AI:release-blocker:pinned:` therefore matches NO
+    tag group at all: the whole string stays inside the title, the task parses
+    with zero tags, and it is silently never selected. A sprint label of
+    "release-blocker" put exactly one item in that state — queued, well
+    specified, and invisible to the runner. Underscores parse; hyphens do not.
+    """
+    return re.sub(r"[^a-z0-9]+", "_", str(s).lower()).strip("_")
 
 
 def one_line(s: str) -> str:
@@ -81,6 +107,78 @@ def one_line(s: str) -> str:
     """
     s = re.sub(r"-\n(?=[a-z])", "", (s or ""))
     return re.sub(r"\s+", " ", s.strip())
+
+
+QUEUE_HEADER = """#+TITLE: Nightshift Queue — {space}
+#+CATEGORY: Nightshift
+#+FILETAGS: :nightshift:AI:
+#+SEQ_TODO: TODO(t) NEXT(n!) WAITING(w!) REVIEW(r!) | DONE(d!) DEFERRED(f!) CANCELLED(c!)
+#+STARTUP: overview
+
+# GENERATED SECTION BELOW — written by .datacore/lib/sprint_sync.py.
+# The runner executes entries from THIS FILE ONLY (task_queue.build_queue
+# keeps `nightshift.org` entries and drops everything else), so a task tagged
+# :AI: in next_actions.org is a CANDIDATE and nothing more. That distinction
+# cost this sprint its whole premise once already: five perfectly specified
+# sprint tasks sat in next_actions.org where no runner would ever have seen
+# them. Entries here are REFERENCES — SOURCE_ID points at the real task, so
+# the spec cannot drift from the copy that runs.
+
+* Sprint queue
+  :PROPERTIES:
+  :ID: org-sprint-queue-{slug}
+  :END:
+"""
+
+
+def sync_queue(ws, space: str, wanted: list[dict], apply: bool) -> tuple[list, list]:
+    """Mirror the sprint's agent tasks as reference entries in nightshift.org.
+
+    Returns (added, removed). Idempotent: an entry already present is left
+    alone, and an entry whose task is no longer in the sprint is removed.
+    """
+    qfile = REPO / space / "org" / "nightshift.org"
+    if not qfile.exists():
+        if not apply:
+            return [(w["id"], w["title"], "would create " + str(qfile)) for w in wanted], []
+        qfile.parent.mkdir(parents=True, exist_ok=True)
+        qfile.write_text(QUEUE_HEADER.format(space=space, slug=slug(space)))
+    ws.load(qfile)
+
+    want_by_qid = {f"{w['id']}-q": w for w in wanted}
+    have = {}
+    for n in ws.all_nodes():
+        if "nightshift.org" not in str(n.path):  # NodeView exposes .path, not .file_path
+            continue
+        nid = (n.properties or {}).get("ID") or ""
+        if nid.startswith("org-sprint-") and nid.endswith("-q"):
+            have[nid] = n
+
+    added, removed = [], []
+    for qid, w in want_by_qid.items():
+        if qid in have:
+            continue
+        added.append((qid, w["title"], "queued"))
+        if apply:
+            ws.create_node(
+                file=qfile,
+                heading=w["title"],
+                state="NEXT",
+                tags=["AI"] + w["tags"],
+                body=f"Reference entry. The specification lives on {w['id']}.",
+                ID=qid,
+                SOURCE_ID=w["id"],
+                SPACE=space,
+                SPRINT=w["sprint"],
+                ASSIGNEE=w["assignee"],
+                SURFACE=w["surface"],
+            )
+    for qid, node in have.items():
+        if qid not in want_by_qid:
+            removed.append((qid, node.heading[:58]))
+            if apply:
+                ws.remove_node(node)
+    return added, removed
 
 
 def _age_days(props: dict) -> float | None:
@@ -221,6 +319,7 @@ def main() -> int:
     target = org_dir / "next_actions.org"
     keep_ids: set[str] = set()
     created, updated, problems = [], [], []
+    queue_want: list[dict] = []
 
     for sp in paths:
         sprint = yaml.safe_load(sp.read_text()) or {}
@@ -231,7 +330,7 @@ def main() -> int:
         for it in mine:
             tid = f"org-sprint-{slug(sid)}-{slug(it['id'])}"
             keep_ids.add(tid)
-            tags = ["AI"] + [slug(t) for t in (it.get("labels") or [])]
+            tags = ["AI"] + [tag_slug(t) for t in (it.get("labels") or [])]
             props = {
                 "ID": tid,
                 "ROADMAP": str(it["roadmap"]),
@@ -248,6 +347,21 @@ def main() -> int:
                 props["EFFORT"] = str(it["effort_estimate"])
 
             node = ws.find_by_id(tid)
+
+            # A finished item is not re-queued. Without this the sync would
+            # resurrect its own completed work every run: the queue entry is
+            # keyed off the sprint item, not the task's state, so S02-5 —
+            # already DONE — was about to be handed back to an agent.
+            if node is None or node.todo not in CLOSED_STATES:
+                queue_want.append({
+                    "id": tid,
+                    "title": str(it["title"]),
+                    "tags": [tag_slug(t) for t in (it.get("labels") or [])],
+                    "sprint": sid,
+                    "assignee": str(it.get("default_claimer") or ""),
+                    "surface": str(it["surface"]),
+                })
+
             if node is None:
                 if args.apply:
                     ws.create_node(
@@ -268,11 +382,20 @@ def main() -> int:
                         changed.append(k)
                         if args.apply:
                             ws.set_property(node, k, v)
+                # Normalise the WHOLE tag set, not just "is AI present". An
+                # earlier version only added the AI tag and left everything
+                # else alone, so a task that already carried a hyphenated
+                # label kept it — and a hyphen makes nightshift's tag regex
+                # miss the group entirely, giving the task zero tags and
+                # hiding it from selection. Adding AI to a set the parser
+                # cannot read achieves nothing.
                 cur = set(node.shallow_tags or [])
-                if "AI" not in cur:
+                want_tags = set(tags)
+                if not want_tags.issubset(cur) or any("-" in t for t in cur):
                     changed.append("tags")
                     if args.apply:
-                        ws.set_tags(node, sorted(cur | {"AI"}))
+                        keep = {t for t in cur if "-" not in t}
+                        ws.set_tags(node, sorted(keep | want_tags))
                 if changed:
                     updated.append((tid, it["title"], changed))
 
@@ -306,6 +429,9 @@ def main() -> int:
             ws.set_tags(node, [t for t in tags if t != "AI"])
         cleared.append((nid, node.heading[:60]))
 
+    # The queue is a different file from the pool, and only the queue runs.
+    q_added, q_removed = sync_queue(ws, args.space, queue_want, args.apply)
+
     if args.apply:
         ws.save_all()
 
@@ -318,6 +444,13 @@ def main() -> int:
     print(f"queued (updated)   {len(updated)}")
     for tid, title, ch in updated[:12]:
         print(f"   ~ {title[:52]} [{', '.join(ch[:4])}]")
+    print(f"nightshift.org queue entries added   {len(q_added)}")
+    for qid, title, note in q_added[:12]:
+        print(f"   > {title[:62]}  [{note}]")
+    if q_removed:
+        print(f"nightshift.org queue entries removed {len(q_removed)}")
+        for qid, h in q_removed[:8]:
+            print(f"   < {h}")
     print(f"un-queued (:AI: removed, task kept)  {len(cleared)}")
     for nid, h in cleared[:12]:
         print(f"   - {h}")

--- a/.datacore/lib/sprint_sync.py
+++ b/.datacore/lib/sprint_sync.py
@@ -106,7 +106,22 @@ def _age_days(props: dict) -> float | None:
 
 
 def discover(space: str) -> list[Path]:
-    return sorted((REPO / space).glob("2-projects/*/sprints/*/sprint.yaml"))
+    """Every sprint.yaml under the space, ONE per sprint_id.
+
+    Worktrees duplicate the whole tree, so `2-projects/*/sprints/*` finds the
+    same sprint once per checkout — `enterprise` and `enterprise-wt-ci-gate`
+    both matched, and every sprint appeared twice. Projecting a sprint twice is
+    harmless only by luck; deduplicate on the directory name, which is the
+    sprint id, and prefer the non-worktree path.
+    """
+    found = sorted((REPO / space).glob("2-projects/*/sprints/*/sprint.yaml"))
+    best: dict[str, Path] = {}
+    for p in found:
+        key = p.parent.name
+        prev = best.get(key)
+        if prev is None or ("-wt-" in str(prev) and "-wt-" not in str(p)):
+            best[key] = p
+    return sorted(best.values())
 
 
 def pick(space: str, want: str | None, active: bool) -> list[Path]:
@@ -117,11 +132,35 @@ def pick(space: str, want: str | None, active: bool) -> list[Path]:
             sys.exit(f"no sprint matching {want!r} under {space}/2-projects/*/sprints/")
         return hit
     if active:
-        out = []
+        # `status: active` alone is not enough. Ten sprints from W23 to W31
+        # still said active on 2026-09-04 — months of sprints nobody closed —
+        # and --active --apply would have projected every one of them into
+        # tonight's queue. A sprint whose end date has passed is over whatever
+        # its status field says; the field is a claim, the date is a fact.
+        from datetime import date
+
+        today = date.today()
+        out, expired = [], []
         for p in found:
             d = yaml.safe_load(p.read_text()) or {}
-            if d.get("status") == "active":
-                out.append(p)
+            if d.get("status") != "active":
+                continue
+            end = (d.get("dates") or {}).get("end")
+            if isinstance(end, str):
+                try:
+                    end = date.fromisoformat(end)
+                except ValueError:
+                    end = None
+            if end and end < today:
+                expired.append((p.parent.name, end))
+                continue
+            out.append(p)
+        if expired:
+            print(f"IGNORING {len(expired)} sprint(s) still marked active whose "
+                  f"end date has passed — close them:")
+            for name, end in sorted(expired, key=lambda x: str(x[1])):
+                print(f"   {name} ended {end} ({(today - end).days} days ago)")
+            print()
         return out
     return found
 

--- a/.datacore/skills/roadmap-build/SKILL.md
+++ b/.datacore/skills/roadmap-build/SKILL.md
@@ -1,0 +1,372 @@
+---
+name: roadmap-build
+version: 2.0.0
+description: |
+  Build or repair a roadmap that agents can actually execute, not just read.
+  Produces a single validated YAML source of truth, generated views, definitions
+  of done with evidence kinds, a task pool linked on two axes, an idea intake
+  queue, and three standing checks that keep it honest.
+  Use when asked to "build a roadmap", "fix the roadmap", "consolidate roadmaps",
+  "make the roadmap agent-ready", when several roadmap documents have drifted
+  apart, or when agents cannot tell what to work on next.
+triggers:
+  - build a roadmap
+  - fix the roadmap
+  - consolidate roadmaps
+  - roadmap is fragmented
+  - make the roadmap agent-ready
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Grep
+  - Glob
+---
+
+# Roadmap: build one agents can execute
+
+Derived from rebuilding the PLUR roadmap, 2026-09-01 to 2026-09-03: five drifted
+documents to one validated source of 93 epics, 750 tasks, and three checks that
+catch regressions nobody would notice by reading.
+
+## The one thing that matters
+
+**A roadmap is good when it is CHECKABLE, not when it is well written.**
+
+Every structural finding in that rebuild came from a script, never from reading
+the file: five areas built and invisible, eleven epics whose repo state
+contradicted them, fourteen agent-doable tasks parked behind a wrong flag. The
+prose was fine throughout. The prose is always fine.
+
+So: build the checks early and let them find the work. Do not write the whole
+roadmap and validate at the end.
+
+---
+
+## Phase 1 — Find what is already true
+
+Before writing anything, read the repos. Roadmaps decay by omission far more
+than by error, and the omissions are invisible from inside the document.
+
+```bash
+gh issue list --repo <org>/<repo> --state open --limit 200
+gh pr list --repo <org>/<repo> --state open
+git -C <repo> log --oneline -40
+ls <repo>/src/<subsystem>/          # whole subsystems with no roadmap presence
+```
+
+**Expect to find work that shipped and work that is invisible.** In the PLUR
+rebuild: a provenance subsystem shipped in a repo the roadmap represented with
+two gated lines; eleven modules and three shipping tools with zero items; a
+49-route admin surface with no coverage at all.
+
+Ask of every subsystem: *does the roadmap know this exists?* Where it does not,
+that is an epic, and its status is whatever the code says — not what the
+document assumed.
+
+## Phase 2 — One writable source
+
+Pick ONE file. Everything else becomes a generated view or a marked pointer.
+
+**Why fragmentation happens, and it is not carelessness:** every document is
+writable, so ideas land in whichever one is open, and none is wrong enough to
+fix. The fix is not discipline. It is removing the ability to write.
+
+Mark every other roadmap-shaped file with a canonical pointer naming what an
+item added there would be invisible to. Then add a check that flags a *new*
+unmarked one, because a sixth document is how the first five happened.
+
+### Item schema
+
+```yaml
+- id: R-001
+  track: core                 # which product line
+  lane: prod                  # kind of work: prod | rnd | ops | geo | community
+  milestone: M2               # the rung, or `continuous`
+  title: <outcome, not a task>
+  outcome: >-
+    <what becomes true — one sentence, in the reader's language>
+  done_when:
+    condition: >-             # falsifiable, singular
+      <what must be true>
+    evidence: test            # test|metric|artifact|screenshot|url|merged-pr|decision|signed
+    verify: >-                # the command or address that settles it
+      <exact check>
+  serves: [<intent-id>]       # must resolve against the intent graph
+  horizon: now                # now | next | later | gated
+  status: ready               # ready | in_progress | blocked | done
+  blocked_on: null            # null | human | agent | external | dependency
+  delegable: true             # can an agent finish this?
+  owner: null
+  gh: <org>/<repo>#123        # optional, enables drift detection
+```
+
+**`evidence` is the field that makes an epic actionable for an agent** — it says
+what artifact to go and produce. A condition without an evidence kind is a wish.
+
+### Milestones are rungs, not dates
+
+Each milestone should widen **who benefits** — one person, one team, the
+organisation, everyone building on you, everyone. That is the test for belonging
+on the ladder. Gate on conditions, never dates, so nothing slips by being late.
+
+`continuous` is a legitimate value with a rule attached: **an epic belongs there
+only if it would still be running after the last milestone ships.** Anything that
+ENDS belongs on a rung, even a distant one. Without that rule it becomes the
+bucket with no gate and absorbs everything.
+
+## Phase 3 — The task pool, on two axes
+
+Tasks link to epics by a `ROADMAP:` property. That is necessary and not
+sufficient.
+
+**`ROADMAP` says which outcome a task serves. It does not say where the work
+happens.** An agent needs both — different repos, different reviewers, different
+context. Add a second axis:
+
+- `SURFACE` — which repo or surface the work lands in
+- `MILESTONE`, `EPIC` — propagated from the epic, never hand-set
+
+Link conservatively. **A wrong parent is worse than none**, because it points an
+agent at the wrong outcome. Leave a task unlinked rather than guess, and report
+the unlinked count as a finding rather than hiding it.
+
+## Phase 4 — Definitions of done, at BOTH levels
+
+This is the step most likely to be got wrong, and the failure is subtle.
+
+**An epic's `done_when` is a milestone test. A task needs its own.**
+
+In the PLUR rebuild the readiness audit reported zero problems because it
+checked whether the *epic* had a condition. But 66 tasks shared one epic's
+*"fewer than five PRs are open"*. An agent that finishes one of them and checks
+that condition finds it **false** — because thirteen other people's work is not
+done. It cannot observe its own success.
+
+**Rule:** if more than one task points at an epic, every one of those tasks needs
+its own `DONE_WHEN`. Fixing the check turned 0 findings into 56.
+
+Task-level conditions are cheap and specific:
+
+> *"Rebase PR #919"* → **done when #919 shows no conflict and CI is green** —
+> not when the merge queue is under five PRs.
+
+## Phase 5 — Three checks
+
+Build all three. Each catches a class the others cannot.
+
+**1. Validate** — schema and internal contradictions. Runs on every commit that
+touches the roadmap. Must refuse:
+- a `now`/`next` epic with no `done_when` (nobody can finish what nothing defines)
+- `blocked_on: human` together with `delegable: true` (tells an agent to start
+  work it cannot finish — the most expensive contradiction on a board)
+- an unknown milestone, evidence kind, or `serves` that resolves to nothing
+
+**2. Drift** — the roadmap against reality. Manual or on a cadence, never on
+commit: it reaches the network.
+- an epic whose linked issue is **closed as COMPLETED** — may be done
+- an epic whose issue is **closed as NOT_PLANNED** — points at a *rejected*
+  issue. **These mean opposite things and checking only `closed` conflates
+  them**, reading a retirement as progress
+- a `now` epic no task points at — indistinguishable from finished
+- a note asserting a state older than ~45 days, but **only when the date sits
+  next to a state word.** Matching the whole note fires on citations, and a
+  check that cries wolf teaches people to ignore it
+- a roadmap-shaped file with no canonical pointer
+
+**3. Agent readiness** — the five preconditions for unsupervised work:
+
+| | asks |
+|---|---|
+| SELECT | can an agent find genuinely available work? |
+| LOCATE | does the work say where it happens? |
+| FINISH | does the **task** say what finishing means? |
+| BRIEF | is there enough written to act on? |
+| VERIFY | can the agent check the result itself? |
+| AVOID | is undoable work clearly marked? |
+
+For BRIEF: a heading naming a **resolvable reference** (issue, file, URL) *is* a
+brief — the agent can fetch it. Only flag headings naming something unlocatable.
+"Rebase plur#919" needs no prose.
+
+For VERIFY: an epic marked `delegable` whose evidence is `signed`, `decision` or
+`screenshot` is a contradiction. **No agent produces a signature.**
+
+## Phase 6 — The intake queue
+
+Create `feature-ideas.md`. Every candidate enters there; nothing goes straight
+into the roadmap.
+
+**Four verdicts, exactly one each, and nothing leaves a review without one:**
+
+- **ADOPT** → a roadmap item with a `done_when`
+- **TRIAL** → an experiment with a hypothesis and a date
+- **WATCH** → a re-check date
+- **DROP** → one line of reason
+
+**DROP is a success.** The expensive outcome is not saying no; it is re-deriving
+the same no three times because nobody wrote it down. An idea that stays
+"interesting" for three reviews is a DROP nobody has been willing to write.
+
+**Why a queue at all:** the roadmap refuses items with no definition of done, and
+most ideas cannot state one yet. Forcing one produces fiction. The queue is
+where an idea waits, costing nothing, until it can answer that question.
+
+**Review bi-weekly, not weekly.** Most weeks produce nothing worth a decision,
+and a review that usually has no input stops being attended.
+
+---
+
+## Phase 7 — The execution path, or the roadmap is decoration
+
+A roadmap agents cannot REACH is not a roadmap, it is a document. This phase is
+the half most likely to be skipped, because everything above it looks finished.
+
+### Find the executor's real selection rule. Do not infer it.
+
+Open the runner and read what it selects. In the PLUR system it turned out to be
+three levels, and only the third runs anything:
+
+| | |
+|---|---|
+| task exists in the pool file | exists |
+| ...carries the agent tag | is a **CANDIDATE** |
+| ...**referenced from the queue file** | **RUNS** |
+
+The fleet had 261 tasks at level 2 and executed 2. The runner had been printing
+`261 tagged but not queued — they will NOT run` on every single run, and it read
+as noise. The space holding the roadmap had no queue file at all, so five
+perfectly specified sprint items would have sat at level 2 forever.
+
+**Ask "what does the runner select?" and answer it by calling the runner's own
+selection function.** Not by reading it. Not by reasoning about the tag.
+
+### The sprint must have a consumer
+
+A sprint file nothing reads is a wish. Grep for a reader before trusting it —
+`sprint_tag_filter` had **zero readers anywhere in the tree** while being the
+field the sprint used to claim it routed work.
+
+Write the projection instead: sprint file → task properties → queue entry. One
+direction only, and it is the **sole writer** of the agent tag. In the sprint →
+queued; not in the sprint → tag removed, entry removed, task untouched. Removing
+the tag is not deprioritising; it means "not this sprint".
+
+Then run it from inside the runner's own preflight, before it builds the queue.
+Anything that depends on a human remembering to run it will drift the first busy
+week.
+
+Guards it needs, each bought with a real defect:
+
+- **Refuse an underspecified item** — the same fields readiness checks. Caught
+  while a human is still looking at the sprint, not at 02:00 by an agent.
+- **Expire the in-flight exemption.** "Currently executing" sheltered two tasks
+  stuck for 5 and 7 days, one with its COMPLETED stamp *before* its STARTED
+  stamp. An unexpiring exemption protects a corpse.
+- **Ignore an `active` sprint whose end date has passed.** Five sprints, oldest
+  89 days, would all have projected at once. The status field is a claim; the
+  date is a fact.
+- **Deduplicate discovery** — worktrees make one sprint appear many times.
+- **Never re-queue a closed task.** The queue keys off the sprint item, not the
+  task's state, so a completed item gets handed back otherwise.
+
+### Acceptance must stop at the agent's own control boundary
+
+This is the highest-value rule in this phase.
+
+Agents were "leaving work open" and looked unreliable. The cause was in the
+acceptance criteria we wrote: they ended at **merged**, which needs an approving
+review and a code owner. An agent cannot reach that state, so it never reports
+done, so the task sits open — and the criterion, not the agent, was the defect.
+
+Write agent acceptance as: **written, pushed, CI green, review requested.**
+Merging is a human item and belongs in a human-gated list with a name against
+it. If an item's acceptance needs another party, it is not agent work.
+
+### Deploy it, then verify on the machine that runs it
+
+Code on your laptop executes nothing. Check the runner host for the branch it is
+actually on and whether your files exist there. The PLUR fleet ran the Data repo
+on one unrelated feature branch and the runner module on another, with neither
+new script present — so a night's work would have used none of it.
+
+
+---
+
+## Failure modes — every one of these actually happened
+
+| symptom | cause | fix |
+|---|---|---|
+| Audit passes, agents still stall | checked the epic's `done_when`, not the task's | require task-level when an epic is shared |
+| Agent starts work it cannot finish | `blocked_on: human` on an epic where only *some* steps need a person | `blocked_on` describes the WHOLE epic; put it on the steps |
+| A check silently never fires | path matched the wrong form — the hook runs *inside* the repo, so the staged path is relative to it | stage something invalid and confirm rejection |
+| Hook edits do nothing | `core.hooksPath` overrides `.git/hooks/`; the symlink is dead | find the live path before editing |
+| A retired issue reads as progress | only checked `closed`, not `state_reason` | distinguish COMPLETED from NOT_PLANNED |
+| Classifier looks right, output is wrong | verified aggregate counts, never sampled rows | print actual rows and read them |
+| Stale-note check ignored | matched a state word anywhere in the note | require proximity to the date |
+| Layout breaks after a "fix" | bumped font sizes inside a fixed-coordinate SVG | scale the whole SVG, never its fonts |
+| Items appended to the wrong list | YAML appended at EOF joins the last top-level key | insert inside the target block explicitly |
+| Fields lose their block scalar | replacement dropped the leading indent | preserve indentation on every line |
+| Agent leaves everything open | acceptance ended at "merged", which needs a reviewer | stop acceptance at the agent's control boundary |
+| A queued, well-specified task never runs | tag had a **hyphen** — org tag regex is `:[\w:]+:` and `\w` excludes `-`, so the whole group fails to match and the task parses with ZERO tags | use underscores; assert the parsed tags, never eyeball the heading |
+| Check counts a set the executor ignores | scored every tagged task, but the runner selects only certain states | mirror the executor's filter exactly |
+| Tasks look queued and are invisible | org inherits tags from ancestors; the runner reads only the heading line | use shallow tags wherever you mirror the runner |
+| A test half of a check never fires | read a field the data source does not emit (`body` from a list API) | load the real object, not the summary |
+| Section counts are not comparable | one check appended a row per task, another six rows plus "…and N more" | one finding per item; let the printer truncate |
+| A later check dies mid-run | walrus in a comprehension binds in the ENCLOSING scope and clobbered the parsed roadmap | never reuse a live name for a comprehension walrus |
+| Gate gets bypassed with --no-verify | the gate was STRICTER than the executor and rejected runnable work | mirror the executor's definition, never exceed it |
+| Nothing runs after a "fix" | filtered at DISCOVERY, hiding work from the reports built to surface it | filter where work is CHOSEN, not where it is found |
+
+## Verification discipline
+
+**Verify the rendered output, not the source you just wrote.** Several defects
+in the PLUR rebuild shipped because the source looked right:
+
+```bash
+# after generating a view, read what it actually produced
+python3 -c "import re,html as H; h=open('out.html').read();
+print(H.unescape(re.sub(r'<[^>]+>',' ',re.search(r'<div class=\"x\">(.*?)</div>',h,re.S).group(1))))"
+
+# prove a check discriminates — revert the fix, confirm failure, restore
+```
+
+A test that passes before and after the fix is not a test.
+
+**Call the real function rather than reasoning about it.** Every serious error in
+the PLUR rebuild survived reading and died on execution: the queue that was three
+levels deep, the tag regex that rejected hyphens, the executability filter that
+broke nine tests the moment it ran. Reading tells you what the code appears to
+do; calling it tells you what it does.
+
+**When a suite fails after your change, the suite is usually right.** Nine tests
+failed on a filter that looked obviously correct, and one of them
+(`test_queue_visibility`) existed precisely because three earlier defects all had
+the shape "the system knew something and said nothing". The change was the bug.
+
+## Sequence
+
+1. Read the repos. Find what is built and invisible.
+2. Create the single source; mark every other file as a view.
+3. Write the validator **before** the content, so bad items cannot land.
+4. Fill items from repos + existing documents. Status from code, not prose.
+5. Link tasks on both axes. Leave doubtful ones unlinked.
+6. Write `done_when` at epic level, then at task level wherever shared.
+7. Build drift and readiness. Fix what they find. Re-run.
+8. Wire the validator into the commit hook. **Test it rejects.**
+9. Create the intake queue. Seed it with live inputs so it is not aspirational.
+10. **Find the executor's real selection rule by calling it.** Wire the sprint
+    into it, and check the runner host has the code.
+11. Execute one queued task end to end yourself. A loop you have not run once is
+    a loop you are guessing about.
+12. Report the residue honestly — what is unlinked, unproven, undecided.
+
+## What to tell the user at the end
+
+Give the number, and give what it does not cover. In the PLUR rebuild the last
+finding was *"36 epics marked delegable with no agent work yet in review —
+delegability is asserted, not demonstrated."* That is a fact, not a defect, and
+editing it away would have been the only dishonest move available.
+
+**Structural readiness is not demonstrated readiness.** One agent completing one
+task end to end is worth more than any audit — say so.

--- a/.datacore/specs/roadmap-agent-ready-handoff.md
+++ b/.datacore/specs/roadmap-agent-ready-handoff.md
@@ -1,0 +1,186 @@
+# Finish making the roadmap agent-ready — handoff prompt
+
+Written 2026-09-04. Everything below was verified by running it, not by reading
+docs. Numbers are from that evening; re-measure before trusting them.
+
+Paste the section under **PROMPT** into the parallel session.
+
+---
+
+## PROMPT
+
+You are finishing a piece of work that is ~80% done. The PLUR roadmap is now
+agent-executable in principle — `5-plur/roadmap.yaml` is the single source, a
+pre-commit hook validates it, `sprint_sync.py` projects an active sprint into
+the agent queue, and one queued task was executed end-to-end and closed. What
+remains is the part that makes it true on the machines that actually run.
+
+Read these two first. They are short and they contain the model you need:
+- `.datacore/specs/task-lifecycle-and-ledger-coverage.md`
+- `~/.claude/skills/roadmap-build/SKILL.md` (Phase 7 especially)
+
+**The one thing to internalise:** there are three levels and only the third
+runs. A task in `next_actions.org` *exists*; tagged `:AI:` it is a *candidate*;
+referenced from `<space>/org/nightshift.org` it *runs*. `:AI:` is a **projection
+of an active sprint**, never a hand-applied label — `sprint_sync --apply` strips
+any tag it did not put there. If you want a task to run, put it in a sprint.
+
+Work the items below in order; 1 blocks 2, and 2 blocks everything being real.
+
+### 1. Land the tooling on main — nothing works until this happens
+
+`.datacore/lib/sprint_sync.py` and `.datacore/lib/ai_task_gate.py` **do not
+exist on `origin/main`**. They are only on `fix/creds-multivar-resolution`,
+which is 12 commits ahead of main with no open PR. The nightshift host pulls
+main, so today it can never run the projection.
+
+Open a PR from that branch, or merge it. Verify with:
+
+```bash
+git cat-file -e origin/main:.datacore/lib/sprint_sync.py && echo on-main
+```
+
+Do not cherry-pick just those two files — the branch also carries the
+`agent_readiness.py` corrections and the pre-commit gate wiring, and half of
+that landing is worse than none.
+
+### 2. Deploy to the nightshift host, and verify ON the host
+
+The fleet is running code from before all of this:
+
+| repo | server branch | needs |
+|---|---|---|
+| `~/Data` | `nightshift/<date>` during a run, else `main` | main to carry item 1 |
+| `~/Data/.datacore/modules/nightshift` | `feat/tier1-haiku-batch` | switch to `main` |
+
+The module checkout is 9 ahead / 15 behind `main` and its server-side work is
+**already committed** as `7033050` ("park: server-side work before branch
+realignment"). The push was rejected as behind — reconcile and push that branch
+first so nothing is lost, *then* move to main.
+
+**Never do this while a run is active.** `run.py` is being executed; checking
+out another branch rewrites it under a live process. Check first:
+
+```bash
+ssh nightshift 'systemctl show nightshift-overnight.service -p ActiveState --value'
+```
+
+Only `inactive`/`failed` is safe. Then, on the host:
+
+```bash
+cd ~/Data/.datacore/modules/nightshift
+git push origin feat/tier1-haiku-batch   # after reconciling
+git checkout main && git pull
+cd ~/Data && git checkout main && git pull
+sudo systemctl restart nightshift-overnight.timer
+```
+
+Verify afterwards that `lib/run.py` contains `Syncing queue to active sprint`
+and that `.datacore/lib/sprint_sync.py` exists **on the host**. Code on a laptop
+executes nothing.
+
+### 3. Merge the three sprint branches
+
+The sprints were cut onto their own branches rather than onto whatever feature
+branch each checkout happened to be sitting on:
+
+- `plur-ai/plur` → `sprints/2026-W37-core-sprint1` (11 agent items)
+- `plur-ai/enterprise` → `sprints/2026-W37-enterprise-sprint10` (8 agent items)
+- the continuous sprint is already on `plur-space` main — nothing to do
+
+### 4. Activate Monday's sprints
+
+Both W37 sprints are `status: planning`. On Monday:
+
+```bash
+# set `status: active` in each sprint.yaml, then
+python3 .datacore/lib/sprint_sync.py --active --apply
+```
+
+`2026-W37-continuous-sprint1` is already active and its 11 tasks are queued.
+Expect the sync to be idempotent (0/0/0/0) if nothing changed.
+
+### 5. Drain the unexecutable `:AI:` pool
+
+`agent_readiness.py` reports **683 findings** fleet-wide. They do not run — the
+overflow path filters on executability — but they are noise on every report and
+they *would* run if that filter were ever turned off.
+
+Measured 2026-09-04, `:AI:` in TODO/NEXT:
+
+| space | executable | unexecutable |
+|---|---|---|
+| 0-personal | 4 | **186** |
+| 6-meridian | 1 | 27 |
+| 3-fds | 0 | 2 |
+| 9-practice | 0 | 1 |
+| 2-datacore | 51 | 0 |
+
+For each: either give it `SURFACE` + `DONE_WHEN` (`ROADMAP` only where a
+`roadmap.yaml` exists) or drop the `:AI:` tag. **Dropping the tag is not
+demotion** — the task stays in the pool with its links intact; it is simply not
+queued. Most of the 186 should lose the tag.
+
+Watch for `SURFACE` holding a publication URL (`plur.ai/blog`) rather than a
+repo. It passes an emptiness test, names no checkout, and several GEO tasks have
+it. The vocabulary is in `.datacore/lib/task_surface.py`.
+
+### 6. Close the ledger's blind span
+
+For org-routed work the ledger sees `item.create`, `item.update`, `item.dismiss`
+and nothing else — not claim, not execution, not completion. So "who did this,
+when, at what cost" cannot be answered from the attested record.
+
+The vocabulary already exists in `EVENT_TYPES` and is simply never written:
+
+- `claim.py` emits **`item.claim`** where it already writes
+  `NIGHTSHIFT_EXECUTOR`. This is the keystone: it makes `item.complete` legal
+  later, because the fold's `status == claimed` precondition becomes true
+  honestly instead of by fabrication.
+- `run.py` emits **`item.complete`** / **`item.release`** at the existing
+  `_emit_lifecycle('completed' | 'failed')` call site — same place, second sink.
+- **`item.clock.start` / `item.clock.stop`** around execution.
+
+Do **not** fabricate a claim to satisfy the state machine; that is exactly what
+`ledger_ingest_org.py` refuses to do, and its reasoning is worth reading before
+you touch this.
+
+### Constraints that are not negotiable
+
+- **Cap table and equity work is human-only** (ENG-2026-0709-013). Never `:AI:`,
+  never nightshift, never in a sprint.
+- **R-094's bizdev agent QUALIFIES and never CONTACTS** — no outreach in any
+  channel at any autonomy level. Enable the `crm` module and reuse the
+  `research-prospect` skill; do not write a new agent.
+- **R-063: an agent drafts the DPA, it does not publish it.** Ask first. The
+  trust page does not wait on that, and must not describe `plur.datafund.io` —
+  internal infrastructure, not a service.
+- **R-093 has two halves** — the reconciler going forward *and* a one-time sweep
+  of the 167 finished `Review:` tasks. Half of it leaves the backlog wrong.
+- **Commit org edits immediately.** Org files are rewritten wholesale from an
+  in-memory model, so an uncommitted edit is destroyed silently and
+  `git status` looks clean afterwards (ENG-GPL-2026-09-04-022). Verify with
+  grep, not with a clean status.
+
+### How to know you are done
+
+```bash
+python3 .datacore/lib/agent_readiness.py          # findings, fleet-wide
+python3 .datacore/lib/ai_task_gate.py <org files> # exit 0
+python3 .datacore/lib/sprint_sync.py --active     # idempotent: 0/0/0/0
+cd .datacore/modules/nightshift && python3 -m pytest tests/ -q   # 180 pass
+```
+
+And the only test that actually matters: **let one overnight run execute a
+sprint task and close it unattended**, then compare against the baseline of 66
+tasks at `NIGHTSHIFT_STATUS: needs_review` against 14 done. If that ratio does
+not move, the acceptance-criteria theory is wrong and the retro should say so
+plainly rather than explaining it away.
+
+### The habit that found every real bug here
+
+Call the function; do not reason about it. Every serious error in this rebuild
+survived careful reading and died the moment something ran: the queue that was
+three levels deep, the tag regex that silently rejects hyphens, the check that
+scored a set the executor never selects, the filter that broke nine tests. And
+when a suite fails after your change, assume the suite is right.

--- a/.datacore/specs/task-lifecycle-and-ledger-coverage.html
+++ b/.datacore/specs/task-lifecycle-and-ledger-coverage.html
@@ -1,0 +1,158 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Task lifecycle and ledger coverage</title>
+<style>
+  :root { color-scheme: light; }
+  body { margin:0; background:#f5f5f5; color:#2d3142;
+         font-family: ui-sans-serif,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif; }
+  main { max-width: 1300px; margin: 0 auto; padding: 28px 20px 60px; }
+  .wrap { overflow-x: auto; }
+  svg { min-width: 1100px; display:block; }
+  footer { margin-top: 26px; font-size: 12px; color:#4f5d75; line-height:1.55;
+            border-top:1px solid #d8d8dc; padding-top:14px; }
+  code { font-family: ui-monospace,SFMono-Regular,Menlo,monospace; font-size:11.5px; }
+</style></head>
+<body><main>
+<div class="wrap"><svg viewBox="0 0 1240 900" width="100%" xmlns="http://www.w3.org/2000/svg" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif">
+<rect width="100%" height="100%" fill="#f5f5f5"/>
+<defs>
+<marker id="a" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#4f5d75"/></marker>
+<marker id="acc" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#eb6c36"/></marker>
+</defs>
+<text x="60" y="52" font-family="Iowan Old Style,Palatino,Georgia,serif" font-size="27" fill="#2d3142">A task’s life, and the three records that watch it</text>
+<text x="60" y="74" font-size="12.5" fill="#4f5d75">Only one of the three can prove anything, and it is the one missing the middle.</text>
+<rect x="150" y="98" width="240" height="46" rx="7" fill="#ffffff" stroke="#2d3142" stroke-width="1.1"/>
+<text x="270.0" y="118" font-size="12.5" font-weight="600" text-anchor="middle" fill="#2d3142">Human capture</text>
+<text x="270.0" y="134" font-size="9.6" text-anchor="middle" fill="#8d99ae" font-family="ui-monospace,SFMono-Regular,Menlo,monospace">inbox.org, then processed</text>
+<path d="M270.0 144 V 186" stroke="#4f5d75" stroke-width="1.1" fill="none"/>
+<rect x="420" y="98" width="240" height="46" rx="7" fill="#ffffff" stroke="#2d3142" stroke-width="1.1"/>
+<text x="540.0" y="118" font-size="12.5" font-weight="600" text-anchor="middle" fill="#2d3142">/wrap-up</text>
+<text x="540.0" y="134" font-size="9.6" text-anchor="middle" fill="#8d99ae" font-family="ui-monospace,SFMono-Regular,Menlo,monospace">continuations + extracted</text>
+<path d="M540.0 144 V 186" stroke="#4f5d75" stroke-width="1.1" fill="none"/>
+<rect x="690" y="98" width="240" height="46" rx="7" fill="#ffffff" stroke="#2d3142" stroke-width="1.1"/>
+<text x="810.0" y="118" font-size="12.5" font-weight="600" text-anchor="middle" fill="#2d3142">Cadences</text>
+<text x="810.0" y="134" font-size="9.6" text-anchor="middle" fill="#8d99ae" font-family="ui-monospace,SFMono-Regular,Menlo,monospace">heartbeat, every 30 min</text>
+<path d="M810.0 144 V 186" stroke="#4f5d75" stroke-width="1.1" fill="none"/>
+<rect x="960" y="98" width="240" height="46" rx="7" fill="#ffffff" stroke="#2d3142" stroke-width="1.1"/>
+<text x="1080.0" y="118" font-size="12.5" font-weight="600" text-anchor="middle" fill="#2d3142">sprint_sync</text>
+<text x="1080.0" y="134" font-size="9.6" text-anchor="middle" fill="#8d99ae" font-family="ui-monospace,SFMono-Regular,Menlo,monospace">an active sprint.yaml</text>
+<path d="M1080.0 144 V 186" stroke="#4f5d75" stroke-width="1.1" fill="none"/>
+<path d="M207.5 186 H 1080.0" stroke="#4f5d75" stroke-width="1.1" fill="none"/>
+<path d="M207.5 186 V 236" stroke="#4f5d75" stroke-width="1.4" fill="none" marker-end="url(#a)"/>
+<text x="1088.0" y="179" font-size="9.4" fill="#8d99ae" font-family="ui-monospace,SFMono-Regular,Menlo,monospace">four doors, one pool</text>
+<rect x="150" y="242" width="115" height="54" rx="7" fill="#ffffff" stroke="#2d3142" stroke-width="1.1"/>
+<text x="207.5" y="264" font-size="11.6" font-weight="600" text-anchor="middle" fill="#2d3142">exists</text>
+<text x="207.5" y="278" font-size="8.6" text-anchor="middle" fill="#8d99ae" font-family="ui-monospace,SFMono-Regular,Menlo,monospace">a heading in an org</text>
+<text x="207.5" y="288" font-size="8.6" text-anchor="middle" fill="#8d99ae" font-family="ui-monospace,SFMono-Regular,Menlo,monospace">file</text>
+<path d="M265 269.0 H 280" stroke="#4f5d75" stroke-width="1.2" fill="none" marker-end="url(#a)"/>
+<rect x="283" y="242" width="115" height="54" rx="7" fill="#ffffff" stroke="#2d3142" stroke-width="1.1"/>
+<text x="340.5" y="264" font-size="11.6" font-weight="600" text-anchor="middle" fill="#2d3142">candidate</text>
+<text x="340.5" y="278" font-size="8.6" text-anchor="middle" fill="#8d99ae" font-family="ui-monospace,SFMono-Regular,Menlo,monospace">:AI: on its own line</text>
+<path d="M398 269.0 H 413" stroke="#4f5d75" stroke-width="1.2" fill="none" marker-end="url(#a)"/>
+<rect x="416" y="242" width="115" height="54" rx="7" fill="#ffffff" stroke="#2d3142" stroke-width="1.1"/>
+<text x="473.5" y="264" font-size="11.6" font-weight="600" text-anchor="middle" fill="#2d3142">queued</text>
+<text x="473.5" y="278" font-size="8.6" text-anchor="middle" fill="#8d99ae" font-family="ui-monospace,SFMono-Regular,Menlo,monospace">in nightshift.org</text>
+<path d="M531 269.0 H 546" stroke="#4f5d75" stroke-width="1.2" fill="none" marker-end="url(#a)"/>
+<rect x="549" y="242" width="115" height="54" rx="7" fill="#ffffff" stroke="#2d3142" stroke-width="1.1"/>
+<text x="606.5" y="264" font-size="11.6" font-weight="600" text-anchor="middle" fill="#2d3142">selected</text>
+<text x="606.5" y="278" font-size="8.6" text-anchor="middle" fill="#8d99ae" font-family="ui-monospace,SFMono-Regular,Menlo,monospace">build_queue, cap 20</text>
+<path d="M664 269.0 H 679" stroke="#4f5d75" stroke-width="1.2" fill="none" marker-end="url(#a)"/>
+<rect x="682" y="242" width="115" height="54" rx="7" fill="#fdeee7" stroke="#eb6c36" stroke-width="1.1"/>
+<text x="739.5" y="264" font-size="11.6" font-weight="600" text-anchor="middle" fill="#2d3142">claimed</text>
+<text x="739.5" y="278" font-size="8.6" text-anchor="middle" fill="#8d99ae" font-family="ui-monospace,SFMono-Regular,Menlo,monospace">git commit is the lock</text>
+<path d="M797 269.0 H 812" stroke="#4f5d75" stroke-width="1.2" fill="none" marker-end="url(#a)"/>
+<rect x="815" y="242" width="115" height="54" rx="7" fill="#fdeee7" stroke="#eb6c36" stroke-width="1.1"/>
+<text x="872.5" y="264" font-size="11.6" font-weight="600" text-anchor="middle" fill="#2d3142">executed</text>
+<text x="872.5" y="278" font-size="8.6" text-anchor="middle" fill="#8d99ae" font-family="ui-monospace,SFMono-Regular,Menlo,monospace">agent runs it</text>
+<path d="M930 269.0 H 945" stroke="#4f5d75" stroke-width="1.2" fill="none" marker-end="url(#a)"/>
+<rect x="948" y="242" width="115" height="54" rx="7" fill="#fdeee7" stroke="#eb6c36" stroke-width="1.1"/>
+<text x="1005.5" y="264" font-size="11.6" font-weight="600" text-anchor="middle" fill="#2d3142">evaluated</text>
+<text x="1005.5" y="278" font-size="8.6" text-anchor="middle" fill="#8d99ae" font-family="ui-monospace,SFMono-Regular,Menlo,monospace">six evaluators score</text>
+<path d="M1063 269.0 H 1078" stroke="#4f5d75" stroke-width="1.2" fill="none" marker-end="url(#a)"/>
+<rect x="1081" y="242" width="115" height="54" rx="7" fill="#ffffff" stroke="#2d3142" stroke-width="1.1"/>
+<text x="1138.5" y="264" font-size="11.6" font-weight="600" text-anchor="middle" fill="#2d3142">review / done</text>
+<text x="1138.5" y="278" font-size="8.6" text-anchor="middle" fill="#8d99ae" font-family="ui-monospace,SFMono-Regular,Menlo,monospace">a human closes it</text>
+<text x="60" y="264" font-size="9.6" font-weight="600" fill="#2d3142" font-family="ui-monospace,SFMono-Regular,Menlo,monospace">LADDER</text>
+<text x="60" y="278" font-size="8.4" fill="#8d99ae" font-family="ui-monospace,SFMono-Regular,Menlo,monospace">eligibility,</text>
+<text x="60" y="288" font-size="8.4" fill="#8d99ae" font-family="ui-monospace,SFMono-Regular,Menlo,monospace">not a switch</text>
+<text x="60" y="352" font-size="9.6" fill="#8d99ae" font-family="ui-monospace,SFMono-Regular,Menlo,monospace">WHAT EACH RECORD SEES</text>
+<rect x="144" y="366" width="1058" height="54" rx="7" fill="#ffffff" stroke="#d8d8dc" stroke-width="1"/>
+<text x="24" y="388" font-size="9.8" font-weight="600" fill="#2d3142" font-family="ui-monospace,SFMono-Regular,Menlo,monospace">ORG-MODE</text>
+<text x="24" y="401" font-size="8" fill="#8d99ae" font-family="ui-monospace,SFMono-Regular,Menlo,monospace">the working state</text>
+<text x="24" y="411" font-size="8" fill="#8d99ae" font-family="ui-monospace,SFMono-Regular,Menlo,monospace">not attested</text>
+<circle cx="207.5" cy="386" r="5.4" fill="#2d3142"/>
+<text x="207.5" y="406" font-size="8.1" text-anchor="middle" fill="#8d99ae" font-family="ui-monospace,SFMono-Regular,Menlo,monospace">heading</text>
+<circle cx="340.5" cy="386" r="5.4" fill="#2d3142"/>
+<text x="340.5" y="406" font-size="8.1" text-anchor="middle" fill="#8d99ae" font-family="ui-monospace,SFMono-Regular,Menlo,monospace">:AI: tag</text>
+<circle cx="473.5" cy="386" r="5.4" fill="#2d3142"/>
+<text x="473.5" y="406" font-size="8.1" text-anchor="middle" fill="#8d99ae" font-family="ui-monospace,SFMono-Regular,Menlo,monospace">queue entry</text>
+<path d="M602.0 386 H 611.0" stroke="#d8d8dc" stroke-width="2" stroke-linecap="round"/>
+<circle cx="739.5" cy="386" r="5.4" fill="#2d3142"/>
+<text x="739.5" y="406" font-size="8.1" text-anchor="middle" fill="#8d99ae" font-family="ui-monospace,SFMono-Regular,Menlo,monospace">NIGHTSHIFT_STARTED</text>
+<circle cx="872.5" cy="386" r="5.4" fill="#2d3142"/>
+<text x="872.5" y="406" font-size="8.1" text-anchor="middle" fill="#8d99ae" font-family="ui-monospace,SFMono-Regular,Menlo,monospace">STATUS</text>
+<circle cx="1005.5" cy="386" r="5.4" fill="#2d3142"/>
+<text x="1005.5" y="406" font-size="8.1" text-anchor="middle" fill="#8d99ae" font-family="ui-monospace,SFMono-Regular,Menlo,monospace">SCORE</text>
+<circle cx="1138.5" cy="386" r="5.4" fill="#2d3142"/>
+<text x="1138.5" y="406" font-size="8.1" text-anchor="middle" fill="#8d99ae" font-family="ui-monospace,SFMono-Regular,Menlo,monospace">DONE</text>
+<rect x="144" y="434" width="1058" height="54" rx="7" fill="#ffffff" stroke="#d8d8dc" stroke-width="1"/>
+<text x="24" y="456" font-size="9.8" font-weight="600" fill="#2d3142" font-family="ui-monospace,SFMono-Regular,Menlo,monospace">LEDGER</text>
+<text x="24" y="469" font-size="8" fill="#8d99ae" font-family="ui-monospace,SFMono-Regular,Menlo,monospace">hash-chained, signed, sealed</text>
+<circle cx="207.5" cy="454" r="5.4" fill="#2d3142"/>
+<text x="207.5" y="474" font-size="8.1" text-anchor="middle" fill="#8d99ae" font-family="ui-monospace,SFMono-Regular,Menlo,monospace">item.create</text>
+<path d="M336.0 454 H 345.0" stroke="#d8d8dc" stroke-width="2" stroke-linecap="round"/>
+<path d="M469.0 454 H 478.0" stroke="#d8d8dc" stroke-width="2" stroke-linecap="round"/>
+<path d="M602.0 454 H 611.0" stroke="#d8d8dc" stroke-width="2" stroke-linecap="round"/>
+<circle cx="739.5" cy="454" r="6.4" fill="none" stroke="#eb6c36" stroke-width="1.8" stroke-dasharray="3,2.4"/>
+<text x="739.5" y="474" font-size="8.1" text-anchor="middle" fill="#eb6c36" font-family="ui-monospace,SFMono-Regular,Menlo,monospace">no item.claim</text>
+<circle cx="872.5" cy="454" r="6.4" fill="none" stroke="#eb6c36" stroke-width="1.8" stroke-dasharray="3,2.4"/>
+<text x="872.5" y="474" font-size="8.1" text-anchor="middle" fill="#eb6c36" font-family="ui-monospace,SFMono-Regular,Menlo,monospace">nothing</text>
+<circle cx="1005.5" cy="454" r="6.4" fill="none" stroke="#eb6c36" stroke-width="1.8" stroke-dasharray="3,2.4"/>
+<text x="1005.5" y="474" font-size="8.1" text-anchor="middle" fill="#eb6c36" font-family="ui-monospace,SFMono-Regular,Menlo,monospace">nothing</text>
+<circle cx="1138.5" cy="454" r="5.4" fill="none" stroke="#2d3142" stroke-width="1.6"/>
+<path d="M1133.1 454 A 5.4 5.4 0 0 1 1143.9 454 Z" fill="#2d3142"/>
+<text x="1138.5" y="474" font-size="8.1" text-anchor="middle" fill="#8d99ae" font-family="ui-monospace,SFMono-Regular,Menlo,monospace">item.dismiss</text>
+<rect x="144" y="502" width="1058" height="54" rx="7" fill="#ffffff" stroke="#d8d8dc" stroke-width="1"/>
+<text x="24" y="524" font-size="9.8" font-weight="600" fill="#2d3142" font-family="ui-monospace,SFMono-Regular,Menlo,monospace">AGENT STREAM</text>
+<text x="24" y="537" font-size="8" fill="#8d99ae" font-family="ui-monospace,SFMono-Regular,Menlo,monospace">live telemetry</text>
+<text x="24" y="547" font-size="8" fill="#8d99ae" font-family="ui-monospace,SFMono-Regular,Menlo,monospace">not attested</text>
+<path d="M203.0 522 H 212.0" stroke="#d8d8dc" stroke-width="2" stroke-linecap="round"/>
+<path d="M336.0 522 H 345.0" stroke="#d8d8dc" stroke-width="2" stroke-linecap="round"/>
+<path d="M469.0 522 H 478.0" stroke="#d8d8dc" stroke-width="2" stroke-linecap="round"/>
+<circle cx="606.5" cy="522" r="5.4" fill="#2d3142"/>
+<text x="606.5" y="542" font-size="8.1" text-anchor="middle" fill="#8d99ae" font-family="ui-monospace,SFMono-Regular,Menlo,monospace">skipped</text>
+<path d="M735.0 522 H 744.0" stroke="#d8d8dc" stroke-width="2" stroke-linecap="round"/>
+<circle cx="872.5" cy="522" r="5.4" fill="#2d3142"/>
+<text x="872.5" y="542" font-size="8.1" text-anchor="middle" fill="#8d99ae" font-family="ui-monospace,SFMono-Regular,Menlo,monospace">started / failed</text>
+<circle cx="1005.5" cy="522" r="5.4" fill="#2d3142"/>
+<text x="1005.5" y="542" font-size="8.1" text-anchor="middle" fill="#8d99ae" font-family="ui-monospace,SFMono-Regular,Menlo,monospace">completed</text>
+<circle cx="1138.5" cy="522" r="5.4" fill="#2d3142"/>
+<text x="1138.5" y="542" font-size="8.1" text-anchor="middle" fill="#8d99ae" font-family="ui-monospace,SFMono-Regular,Menlo,monospace">completed</text>
+<rect x="672" y="426" width="401" height="70" rx="9" fill="none" stroke="#eb6c36" stroke-width="1.5" stroke-dasharray="5,4"/>
+<text x="872.5" y="514" font-size="10.4" font-weight="600" text-anchor="middle" fill="#eb6c36">the blind span — the ledger never sees the work itself</text>
+<circle cx="66" cy="612" r="5.4" fill="#2d3142"/><text x="80" y="616" font-size="10" fill="#4f5d75">recorded</text>
+<circle cx="176" cy="612" r="5.4" fill="none" stroke="#2d3142" stroke-width="1.6"/><path d="M170.6 612 A 5.4 5.4 0 0 1 181.4 612 Z" fill="#2d3142"/><text x="190" y="616" font-size="10" fill="#4f5d75">partial — records closure, not completion</text>
+<circle cx="470" cy="612" r="6.4" fill="none" stroke="#eb6c36" stroke-width="1.8" stroke-dasharray="3,2.4"/><text x="484" y="616" font-size="10" fill="#eb6c36">gap — the event type exists and is never written</text>
+<path d="M796 612 H 806" stroke="#d8d8dc" stroke-width="2" stroke-linecap="round"/><text x="816" y="616" font-size="10" fill="#4f5d75">not applicable at this stage</text>
+<line x1="60" y1="638" x2="1180" y2="638" stroke="#d8d8dc" stroke-width="1"/>
+<text x="60" y="660" font-size="11.4" font-weight="600" fill="#2d3142">Queued is priority, not eligibility.</text>
+<text x="60" y="675" font-size="10.1" fill="#4f5d75">run.py calls build_queue(include_pending=True), so a merely-tagged task is eligible too — nightshift.org decides what sorts first.</text>
+<text x="60" y="716" font-size="11.4" font-weight="600" fill="#2d3142">item.complete is never emitted for an org task.</text>
+<text x="60" y="731" font-size="10.1" fill="#4f5d75">The fold requires status == claimed, so completing an unclaimed item is a silent no-op. Fabricating a claim would put a lie in the audit trail, so</text>
+<text x="60" y="744" font-size="10.1" fill="#4f5d75">closure is item.dismiss: “a human closed this”.</text>
+<text x="60" y="772" font-size="11.4" font-weight="600" fill="#2d3142">ledger_claim.py skips org-mirrored items by design.</text>
+<text x="60" y="787" font-size="10.1" fill="#4f5d75">pending = [i for i in claimable if not (i.payload or {}).get(“org”)] — it stopped agents working unattended through a 342-item backlog, so no</text>
+<text x="60" y="800" font-size="10.1" fill="#4f5d75">item.claim is ever written for one.</text>
+<text x="60" y="828" font-size="11.4" font-weight="600" fill="#2d3142">Nightshift emits no ledger events at all.</text>
+<text x="60" y="843" font-size="10.1" fill="#4f5d75">claim.py imports ledger_transport only for a git converge helper; execution goes to the agent stream via _emit_lifecycle. The durable copy is missing,</text>
+<text x="60" y="856" font-size="10.1" fill="#4f5d75">not the data.</text>
+</svg></div>
+<footer>
+Read from the code on 2026-09-04, not from the design docs — the two had drifted in three places.
+Full write-up: <code>.datacore/specs/task-lifecycle-and-ledger-coverage.md</code>.
+The vocabulary to close the gap already exists in <code>EVENT_TYPES</code>: <code>item.claim</code>,
+<code>item.complete</code>, <code>item.clock.start</code>/<code>stop</code> are defined and simply never
+written for org-routed work.
+</footer>
+</main></body></html>

--- a/.datacore/specs/task-lifecycle-and-ledger-coverage.md
+++ b/.datacore/specs/task-lifecycle-and-ledger-coverage.md
@@ -1,0 +1,132 @@
+# Task lifecycle, and what the ledger actually records
+
+Written 2026-09-04, from reading the code rather than the design docs — the two
+had drifted apart in three places, each noted below.
+
+Companion diagram: `task-lifecycle-and-ledger-coverage.html` (open locally).
+
+---
+
+## The finding, in one paragraph
+
+**For org-routed work — which is all roadmap and sprint work — the ledger is a
+birth-and-death register, not a work record.** It sees `item.create` when the
+hourly sweep mirrors an org task, `item.update` when a date or state changes,
+and `item.dismiss` when org says DONE. It never sees the task claimed,
+executed, evaluated or completed. Those facts live in two other places, neither
+of which is hash-chained or sealed.
+
+So the question "who did this task, when, and at what cost" cannot be answered
+from the attested record. The evidence exists; it is just not in the chain.
+
+---
+
+## Three records, one task
+
+| | where | attested? | what it holds |
+|---|---|---|---|
+| **org-mode** | `<space>/org/*.org` | no | the working state — TODO/NEXT/REVIEW/DONE, `NIGHTSHIFT_*` telemetry, CLOCK entries |
+| **ledger** | `<space>/.datacore/events/<actor>.jsonl` | **yes** — sha256 hash chain, signed, sealed with watermarks | `item.create`, `item.update`, `item.dismiss` |
+| **agent stream** | `~/.datacore/cos/agent-stream/events-<date>.jsonl` | no | `started`, `completed`, `failed`, `skipped` + exec id, duration, tokens |
+
+The ledger is the only one of the three that can prove anything, and it is the
+one missing the middle of the story.
+
+---
+
+## The lifecycle, stage by stage
+
+Creation has four doors:
+
+1. **Human capture** → `inbox.org`, processed to `next_actions.org`
+2. **`/wrap-up`** → continuation and extracted tasks, always to `inbox.org`
+3. **Cadences** → `venture_heartbeat.py` every 30 min, role duties per `venture.yaml`
+4. **`sprint_sync.py`** → projects an active sprint into both the pool and the queue
+
+Then eligibility, which is a ladder and not a switch:
+
+| stage | what makes it true | who decides |
+|---|---|---|
+| exists | a heading in an org file | any writer |
+| **candidate** | carries `:AI:` on its own heading line | `sprint_sync`, or a hand edit the pre-commit gate checks |
+| **queued** | referenced from `<space>/org/nightshift.org` | `sprint_sync`, or a human |
+| **selected** | survives `build_queue` — priority sort, dedup, live-claim filter, `max_tasks_per_run: 20` | `task_queue.py` |
+| **claimed** | `NIGHTSHIFT_STARTED` newer than `NIGHTSHIFT_COMPLETED`, committed and pushed (git is the lock) | `claim.py` |
+| executed | agent runs; output to `<space>/0-inbox/` | `run.py` |
+| evaluated | six evaluators score the output | `run.py` |
+| review / done | `REVIEW` awaiting a human, or `DONE` | human |
+
+**Queued is priority, not eligibility.** `run.py` calls
+`build_queue(include_pending=True)`, so a merely-tagged task is eligible too —
+`nightshift.org` decides what sorts first. The module docstring said the
+opposite until 2026-09-04.
+
+---
+
+## Where the ledger stops, and why
+
+Three deliberate decisions, each defensible on its own, which together produce
+the gap:
+
+**1. `item.complete` is never emitted for an org task.** `ledger_ingest_org.py`
+says why: the fold requires `status == claimed` before completing, so
+completing an unclaimed item is a *silent no-op* — two full passes over
+org-DONE tasks did nothing and reported success. Fabricating a claim to satisfy
+the state machine "would put a lie in the audit trail". So a closed org task
+becomes `item.dismiss`, which means "a human closed this", not "an agent
+finished this".
+
+**2. `ledger_claim.py` skips org-mirrored items outright:**
+
+```python
+pending = [i for i in claimable if not (i.payload or {}).get("org")]
+```
+
+Deliberate — it stopped agents working unattended through a 342-item personal
+backlog. The consequence is that an org task can never be claimed *through the
+ledger*, so no `item.claim` is ever written for one.
+
+**3. Nightshift emits no ledger events at all.** `claim.py` imports from
+`ledger_transport` only for `converge` (a git sync helper); `run.py` mentions
+the ledger once, in a comment. Claiming writes org properties and a git commit.
+Execution writes to the agent stream via `_emit_lifecycle`.
+
+So the chain records that the task was born and that someone closed it. Between
+those two points it is silent, and the events that would fill the gap —
+`item.claim`, `item.complete`, `item.clock.start` / `item.clock.stop` — all
+exist in `EVENT_TYPES` and are simply never written for this class of work.
+
+---
+
+## What would close it
+
+The vocabulary is already there; only the emission is missing.
+
+- **`claim.py` emits `item.claim`** when it takes a task, with the same actor
+  string it writes to `NIGHTSHIFT_EXECUTOR`. That alone makes `item.complete`
+  legal later, because the fold's precondition (`status == claimed`) becomes
+  true honestly rather than by fabrication.
+- **`run.py` emits `item.complete` or `item.release`** at the point it already
+  calls `_emit_lifecycle('completed' | 'failed')`. Same call site, second sink.
+- **`item.clock.start` / `item.clock.stop`** around execution, which the schema
+  already models as events precisely because two machines can clock the same
+  task.
+
+That turns the agent stream from the only record of agent labour into a *live
+view* of it, with the durable copy in the chain — which is the relationship the
+two were presumably meant to have.
+
+Until then, state the limit plainly: **the audit chain covers what a task *is*,
+not what was *done to it*.**
+
+---
+
+## Two smaller drifts found on the way
+
+- `find_unqueued_ai_tasks` documented itself as describing tasks that "do not
+  run — by design", while the runner ran them. Fixed 2026-09-04: execution now
+  falls back only to executable tasks, reporting still shows everything.
+- `nightshift_parser.find_ai_tasks` reads **only the heading line** for tags, so
+  org tag inheritance does not apply to selection — a live child under a tagged
+  parent is invisible to the runner while `org_workspace` reports it as tagged.
+  Any tool mirroring the runner must use shallow tags.


### PR DESCRIPTION
Lands the agent-ready roadmap tooling that so far lived only on this branch: sprint_sync.py (the :AI: queue as a projection of the active sprint), ai_task_gate.py wired into the space pre-commit (an :AI: task must carry SURFACE and DONE_WHEN, mirroring the executor), agent_readiness corrections, the task-lifecycle spec and the handoff spec.

Order of landing: the unspecified pools in 0-personal (183), 6-meridian (27), 3-fds (2), 9-practice (1), 2-datacore and 5-plur were drained first, so the gate does not refuse the hosts autosaves when it goes fleet-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N565gr1tEwgK6DDVm8Mpfy