### PR TITLE
phase 1: write the org header copy once

### DIFF
--- a/.datacore/lib/ledger_project_org.py
+++ b/.datacore/lib/ledger_project_org.py
@@ -48,10 +48,14 @@ def _with_org_header(space: Path, target: Path, text: str) -> str:
                 header.append(line)
             elif line.strip() and not line.startswith("#"):
                 break
-    if header:
-        (space / HEADER_COPY).write_text("\n".join(header) + "\n")
-    elif (space / HEADER_COPY).exists():
-        header = (space / HEADER_COPY).read_text().splitlines()
+    copy = space / HEADER_COPY
+    if header and not copy.exists():
+        # WRITE ONCE. The copy is tracked; rewriting it on every cycle made
+        # every host a writer of the same file and the transport conflicted
+        # on it within the first hour of Phase 1 (2026-09-05).
+        copy.write_text("\n".join(header) + "\n")
+    elif not header and copy.exists():
+        header = copy.read_text().splitlines()
     body = [l for l in text.splitlines() if not l.startswith("# ")]
     note = "# Generated from the ledger (Phase 1, DIP-0046). Edits here are ingested hourly; the ledger is the record."
     return "\n".join(header + [note] + body) + "\n"

--- a/.datacore/lib/tests/test_ledger_phase1_tools.py
+++ b/.datacore/lib/tests/test_ledger_phase1_tools.py
@@ -85,3 +85,12 @@ def test_flip_refuses_until_ledger_and_org_agree_then_flips_and_reverses(tmp_pat
     assert subprocess.run(["git", "ls-files", "--error-unmatch", "org/next_actions.org"], cwd=space, capture_output=True).returncode == 0, "tracked again"
     assert not (space / ".datacore" / "ledger-phase").exists()
     assert "Alpha task" in (space / "org" / "next_actions.org").read_text()
+
+
+def test_header_copy_is_written_once(tmp_path):
+    G = _load("ledger_project_org"); space = _space(tmp_path)
+    (space / ".datacore" / "ledger-phase").write_text("1\n")
+    G.project_space(space); first = (space / ".datacore" / "ledger-org-header").read_text()
+    (space / "org" / "next_actions.org").write_text("#+TITLE: Changed by a host\n* TODO x\n")
+    G.project_space(space)
+    assert (space / ".datacore" / "ledger-org-header").read_text() == first, "the copy never changes after the flip"


### PR DESCRIPTION
Every host cycle rewrote the tracked header copy and the transport conflicted on it within the first hour of Phase 1. Write-once now, with a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N565gr1tEwgK6DDVm8Mpfy