### PR TITLE
pre-push: scope a new branch's ownership check to commits not on the default branch

### DIFF
--- a/.datacore/githooks/pre-push
+++ b/.datacore/githooks/pre-push
@@ -73,6 +73,21 @@ if [ -f "$OWNERSHIP" ] && command -v python3 >/dev/null 2>&1 && [ -n "$REFS_INPU
             if git rev-parse --quiet --verify "$TRACKING" >/dev/null 2>&1; then
                 OWN_BASE=$(git merge-base "$l_sha" "$TRACKING" 2>/dev/null || true)
             fi
+            if [ -z "$OWN_BASE" ]; then
+                # A branch origin has never seen (tonight's run branch) has no
+                # tracking ref of its own; its outgoing commits are the ones not
+                # on the remote's default branch, exactly as the content scan
+                # below reasons. Full history was the fallback here, and it
+                # refused every new run branch of a repo whose past holds
+                # another actor's log edits (6-meridian, 2026-09-05: no run
+                # branch could be pushed, so no claim there ever held).
+                for candidate in "refs/remotes/${REMOTE}/main" "refs/remotes/${REMOTE}/master" "refs/remotes/${REMOTE}/develop"; do
+                    if git rev-parse --quiet --verify "$candidate" >/dev/null 2>&1; then
+                        OWN_BASE=$(git merge-base "$l_sha" "$candidate" 2>/dev/null || true)
+                        [ -n "$OWN_BASE" ] && break
+                    fi
+                done
+            fi
             if [ -n "$OWN_BASE" ]; then
                 echo "pre-push: ownership guard: r_sha ${r_sha:0:12} not local — using merge-base ${OWN_BASE:0:12} (fetch first if this recurs)" >&2
                 echo "${OWN_BASE}..${l_sha}"


### PR DESCRIPTION
For a ref origin has never seen there is no tracking ref, and the ownership guard fell back to the branch's full history. In a repo whose past holds another actor's log edits, that refused every new run branch: on 2026-09-05 nightshift could not push 6-meridian's run branch, so no claim there ever held and the same task was retried all morning (the module-side fixes for the retry loop are in datacore-nightshift 7b93a5d).

The content scan in the same hook already bases a new branch on the remote's main/master/develop. The ownership guard now does the same before degrading to full history. Comment-only otherwise; `bash -n` clean.

Verification after deploy: on nightshift, `git -C ~/Data/6-meridian push -u origin <new-branch>` is accepted (it was refused with "modified another actor's event log" for logs in old history).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019j62DfTksDhxGCmZSs3hjB
