### PR TITLE
gtd: inbox.org is a collection point, closed entries leave it nightly

### DIFF
--- a/.datacore/lib/gtd_hygiene.py
+++ b/.datacore/lib/gtd_hygiene.py
@@ -24,6 +24,7 @@ invoked them. This script is the wiring, not new capability.
 
 import argparse
 import json
+import re
 import subprocess
 import sys
 from datetime import date, datetime, timezone
@@ -83,6 +84,29 @@ def process_space(org_file: Path, min_age: int, dry_run: bool) -> dict:
     return entry
 
 
+def process_inbox(space_dir: Path, dry_run: bool) -> dict:
+    """inbox.org is a collection point, nothing else.
+
+    archive-done never touched it: org-workspace treats level 1 as
+    structural and archives level 3 and deeper, which in a flat inbox is
+    nothing. Until 2026-09-05, 0-personal had 210 closed tasks at top level
+    and 105 open entries buried under them. inbox_cleanup.py keeps the
+    invariant: open entries under "* Inbox", closed ones out to
+    inbox-archive-<date>.org.
+    """
+    tool = Path(__file__).resolve().parent / 'inbox_cleanup.py'
+    cmd = [sys.executable, str(tool), str(space_dir)] + ([] if dry_run else ['--apply'])
+    proc = subprocess.run(cmd, capture_output=True, text=True, timeout=180)
+    entry = {}
+    if proc.returncode != 0:
+        entry['inbox_error'] = (proc.stderr or proc.stdout or 'unknown').strip()[-300:]
+    m = re.search(r'moved into Inbox: (\d+), archived: (\d+)', proc.stdout or '')
+    if m:
+        entry['inbox_moved'] = int(m.group(1))
+        entry['inbox_archived'] = int(m.group(2))
+    return entry
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument('--dry-run', action='store_true',
@@ -95,16 +119,22 @@ def main() -> int:
     for space in discover_spaces(DATA_DIR):
         space_dir = space.path
         org_file = space_dir / 'org' / 'next_actions.org'
-        if not org_file.exists():
-            continue
-        try:
-            spaces[space_dir.name] = process_space(
-                org_file, args.min_age, args.dry_run)
-        except Exception as exc:  # noqa: BLE001 — one bad space must not stop the rest
-            spaces[space_dir.name] = {
-                'file': str(org_file),
-                'error': f'{type(exc).__name__}: {exc}',
-            }
+        if org_file.exists():
+            try:
+                spaces[space_dir.name] = process_space(
+                    org_file, args.min_age, args.dry_run)
+            except Exception as exc:  # noqa: BLE001 — one bad space must not stop the rest
+                spaces[space_dir.name] = {
+                    'file': str(org_file),
+                    'error': f'{type(exc).__name__}: {exc}',
+                }
+        if (space_dir / 'org' / 'inbox.org').exists():
+            try:
+                spaces.setdefault(space_dir.name, {'file': str(org_file)}).update(
+                    process_inbox(space_dir, args.dry_run))
+            except Exception as exc:  # noqa: BLE001
+                spaces.setdefault(space_dir.name, {'file': str(org_file)})['inbox_error'] = (
+                    f'{type(exc).__name__}: {exc}')
 
     summary = {
         'generated_at': datetime.now(timezone.utc).isoformat(),
@@ -113,6 +143,8 @@ def main() -> int:
         'spaces': spaces,
         'totals': {
             'archived': sum(s.get('archived', 0) for s in spaces.values()),
+            'inbox_archived': sum(s.get('inbox_archived', 0) for s in spaces.values()),
+            'inbox_moved': sum(s.get('inbox_moved', 0) for s in spaces.values()),
             'ids_added': sum(s.get('ids_added', 0) for s in spaces.values()),
             'overdue_deadlines': sum(s.get('overdue_deadlines', 0)
                                      for s in spaces.values()),
@@ -133,6 +165,7 @@ def main() -> int:
     t = summary['totals']
     mode = 'DRY-RUN ' if args.dry_run else ''
     print(f"[gtd-hygiene] {mode}archived={t['archived']} "
+          f"inbox_archived={t['inbox_archived']} inbox_moved={t['inbox_moved']} "
           f"ids_added={t['ids_added']} overdue={t['overdue_deadlines']} "
           f"errors={t['errors']}")
     for name, s in spaces.items():

--- a/.datacore/lib/inbox_cleanup.py
+++ b/.datacore/lib/inbox_cleanup.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Keep a space's org/inbox.org a collection point, nothing else.
+
+The inbox collects captures that get sorted into their buckets. In
+practice agents close items in place and append new ones at the end of
+the file, so over months a file grows two layers that contradict each
+other: a "* Inbox" section with the open entries, then hundreds of DONE
+and CANCELLED tasks as top-level headings, with fresh captures nested
+under them because "**" headings appended at the end become children of
+whatever heading was last. On 2026-09-05, 0-personal held 210 closed
+tasks at top level and 105 open entries buried under them, 85 of them
+tabs captured that afternoon.
+
+This tool restores the invariant:
+
+  1. a "* Inbox" section exists (created after the preamble when missing);
+  2. every open entry (TODO/NEXT/WAITING/REVIEW) that sits under a closed
+     top-level task moves into the Inbox section;
+  3. every closed entry (DONE/CANCELLED/DEFERRED) leaves the file for
+     org/inbox-archive-<today>.org under "* Archived (processed <today>)",
+     in the convention of the earlier archive files: top-level entries are
+     demoted one level so the archive heading is their parent, deeper
+     entries move as they are.
+
+org-workspace's archive_done cannot do this: it treats level 1 as
+structural and only archives level 3 and deeper, which in a flat inbox is
+nothing -- that is why nightly hygiene reported archived=0 for months.
+
+Usage: inbox_cleanup.py <space-dir> [--apply] [--today YYYY-MM-DD]
+Without --apply it reports what it would do. Exit 0 either way; exit 2
+when the result would not parse.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from datetime import date
+from pathlib import Path
+
+OPEN = ("TODO", "NEXT", "WAITING", "REVIEW")
+CLOSED = ("DONE", "CANCELLED", "DEFERRED")
+HEAD = re.compile(r"^(\*+) (?:\[NEEDS_REVIEW\] )?(TODO|NEXT|WAITING|REVIEW|DONE|CANCELLED|DEFERRED)?\b\s*(.*)$")
+INBOX = re.compile(r"^\* +inbox\s*$", re.IGNORECASE)
+
+
+def state_of(line: str):
+    m = HEAD.match(line)
+    return m.group(2) if m else None
+
+
+def split_top(lines):
+    """-> (preamble, [top-level blocks])"""
+    blocks, cur = [], []
+    for l in lines:
+        if l.startswith("* "):
+            blocks.append(cur); cur = [l]
+        else:
+            cur.append(l)
+    blocks.append(cur)
+    return blocks[0], blocks[1:]
+
+
+def split_l2(block):
+    """top-level block -> (own lines, [level-2 subtrees])"""
+    own, subs, s = [], [], None
+    for l in block:
+        if l.startswith("** "):
+            s = [l]; subs.append(s)
+        elif s is None:
+            own.append(l)
+        else:
+            s.append(l)
+    return own, subs
+
+
+def demote(block):
+    return [("*" + l) if re.match(r"^\*+ ", l) else l for l in block]
+
+
+def clean(text: str, today: str):
+    lines = text.split("\n")
+    pre, tops = split_top(lines)
+    # 1. the Inbox section
+    idx = next((i for i, b in enumerate(tops) if INBOX.match(b[0])), None)
+    created = False
+    if idx is None:
+        tops.insert(0, ["* Inbox", ""]); idx = 0; created = True
+    moved, archived = [], []
+    new_tops = []
+    for i, b in enumerate(tops):
+        if i == idx:
+            new_tops.append(b); continue
+        st = state_of(b[0])
+        own, subs = split_l2(b)
+        if st in CLOSED:
+            # open children go to the Inbox; the rest leaves with the parent
+            orphans = [s for s in subs if state_of(s[0]) in OPEN]
+            keep = [s for s in subs if state_of(s[0]) not in OPEN]
+            moved.extend(orphans)
+            archived.append(demote(own + [l for s in keep for l in s]))
+            continue
+        # an open task or a section at top level stays; its closed children leave
+        closed_kids = [s for s in subs if state_of(s[0]) in CLOSED]
+        rest = [s for s in subs if state_of(s[0]) not in CLOSED]
+        archived.extend(closed_kids)
+        new_tops.append(own + [l for s in rest for l in s])
+    # the Inbox section itself: closed children leave, orphans arrive at its end
+    own, subs = split_l2(new_tops[idx])
+    closed_kids = [s for s in subs if state_of(s[0]) in CLOSED]
+    rest = [s for s in subs if state_of(s[0]) not in CLOSED]
+    archived.extend(closed_kids)
+    inbox = own + [l for s in rest for l in s]
+    while len(inbox) > 1 and inbox[-1].strip() == "":
+        inbox.pop()
+    inbox += [l for s in moved for l in s]
+    new_tops[idx] = inbox + [""]
+    out = "\n".join(pre + [l for b in new_tops for l in b]).rstrip("\n") + "\n"
+    arch = None
+    if archived:
+        arch = (f"#+TITLE: Inbox Archive {today}\n\n* Archived (processed {today})\n"
+                + "\n".join(l for b in archived for l in b).rstrip("\n") + "\n")
+    return out, arch, {"inbox_created": created, "moved_into_inbox": len(moved), "archived": len(archived)}
+
+
+def parses(path: Path) -> bool:
+    try:
+        sys.path.insert(0, str(Path(__file__).resolve().parent))
+        from org_workspace import OrgWorkspace
+        ws = OrgWorkspace(); ws.load(str(path)); return True
+    except Exception as e:  # noqa: BLE001
+        print(f"  does not parse: {e}", file=sys.stderr); return False
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("space"); ap.add_argument("--apply", action="store_true")
+    ap.add_argument("--today", default=date.today().isoformat())
+    a = ap.parse_args()
+    src = Path(a.space) / "org" / "inbox.org"
+    if not src.exists():
+        print(f"{a.space}: no org/inbox.org"); return 0
+    out, arch, stats = clean(src.read_text(), a.today)
+    target = src.with_name(f"inbox-archive-{a.today}.org")
+    if arch and target.exists():
+        # a second run the same day appends to the day's archive
+        arch = target.read_text().rstrip("\n") + "\n" + arch.split("\n", 3)[3]
+    verb = "applied" if a.apply else "would apply"
+    print(f"{a.space}: {verb} -- Inbox created: {stats['inbox_created']}, moved into Inbox: {stats['moved_into_inbox']}, archived: {stats['archived']}"
+          + (f" -> {target.name}" if arch else ""))
+    if not a.apply:
+        return 0
+    if out == src.read_text() and not arch:
+        return 0
+    backup = src.with_suffix(".org.pre-cleanup")
+    backup.write_text(src.read_text())
+    src.write_text(out)
+    if arch:
+        target.write_text(arch)
+    ok = parses(src) and (arch is None or parses(target))
+    if not ok:
+        src.write_text(backup.read_text())
+        if arch and not target.exists():
+            pass
+        print(f"{a.space}: result did not parse -- inbox.org restored from {backup.name}", file=sys.stderr)
+        return 2
+    backup.unlink()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.datacore/lib/tests/test_inbox_cleanup.py
+++ b/.datacore/lib/tests/test_inbox_cleanup.py
@@ -1,0 +1,67 @@
+"""inbox.org is a collection point: open entries under Inbox, closed ones out (2026-09-05)."""
+import importlib.util, pathlib, re
+
+LIB = pathlib.Path(__file__).resolve().parents[1]
+spec = importlib.util.spec_from_file_location("inbox_cleanup", LIB / "inbox_cleanup.py")
+M = importlib.util.module_from_spec(spec); spec.loader.exec_module(M)
+
+MESS = """#+TITLE: Inbox
+#+FILETAGS: :inbox:
+
+* Inbox
+** TODO first capture
+:PROPERTIES:
+:ID: a1
+:END:
+** DONE closed inside inbox
+CLOSED: [2026-09-01 Tue]
+* DONE [#A] processed task
+CLOSED: [2026-09-02 Wed]
+:PROPERTIES:
+:ID: p1
+:END:
+** TODO [[https://github.com/x/y][captured under a DONE parent]]
+:PROPERTIES:
+:SOURCE: https://github.com/x/y
+:ID: c1
+:END:
+** DONE closed child of a closed parent
+* CANCELLED dropped task
+:PROPERTIES:
+:ID: p2
+:END:
+* Half marathon block
+** NEXT run 20k
+** DONE run 15k
+"""
+
+
+def test_the_invariant_is_restored():
+    out, arch, stats = M.clean(MESS, "2026-09-05")
+    assert stats == {"inbox_created": False, "moved_into_inbox": 1, "archived": 4}, "four blocks leave: the closed child rides with its parent"
+    lines = out.split("\n")
+    tops = [l for l in lines if l.startswith("* ")]
+    assert tops == ["* Inbox", "* Half marathon block"], tops
+    assert not re.search(r"^\*+ (DONE|CANCELLED)\b", out, re.M), "nothing closed stays"
+    inbox_end = next(i for i in range(len(lines)) if lines[i].startswith("* Half"))
+    inbox = "\n".join(lines[:inbox_end])
+    assert "first capture" in inbox and "captured under a DONE parent" in inbox
+    assert inbox.index("first capture") < inbox.index("captured under a DONE parent"), "arrivals go to the end"
+    assert "** NEXT run 20k" in out
+    assert arch.startswith("#+TITLE: Inbox Archive 2026-09-05\n\n* Archived (processed 2026-09-05)\n")
+    assert "** DONE [#A] processed task" in arch and "*** DONE closed child of a closed parent" in arch, "top-level entries are demoted, their children with them"
+    assert "** CANCELLED dropped task" in arch and "** DONE closed inside inbox" in arch and "** DONE run 15k" in arch
+    assert ":ID: p1" in arch and ":ID: p1" not in out
+
+
+def test_a_file_without_an_inbox_section_gets_one_first():
+    out, arch, stats = M.clean("#+TITLE: x\n\n* DONE old\n** TODO orphan\n", "2026-09-05")
+    assert stats["inbox_created"] and stats["moved_into_inbox"] == 1 and stats["archived"] == 1
+    assert out.split("\n")[2:4] == ["* Inbox", "** TODO orphan"]
+
+
+def test_a_clean_file_is_left_alone():
+    text = "#+TITLE: x\n\n* Inbox\n** TODO a\n** NEXT b\n"
+    out, arch, stats = M.clean(text, "2026-09-05")
+    assert arch is None and stats["archived"] == 0 and stats["moved_into_inbox"] == 0
+    assert out.strip() == text.strip()


### PR DESCRIPTION
`inbox_cleanup.py` restores one invariant per space: a `* Inbox` section holds the open entries, and every DONE/CANCELLED/DEFERRED entry leaves for `inbox-archive-<date>.org` under "Archived (processed <date>)", the convention of the earlier archive files. Open entries found under a closed top-level task move into the Inbox section instead of leaving with it.

Why a new tool: org-workspace's `archive_done` treats level 1 as structural and archives level 3 and deeper, which in a flat inbox is nothing, so `gtd_hygiene` reported `archived=0` every night while 0-personal accumulated 210 closed tasks at top level with 105 open entries buried under them. Hygiene also only ever looked at `next_actions.org`; it now runs the inbox rule for every space with an `org/inbox.org` and reports `inbox_archived` and `inbox_moved`.

Applied by hand on 2026-09-05 to ten spaces. Three tests cover the invariant, the missing-section case and the no-op. Note for the overnight run: the tool writes a new `inbox-archive-<date>.org`; the run's per-space commit must pick up that untracked file or the next park will.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019j62DfTksDhxGCmZSs3hjB
