### PR TITLE
ledger: checkpoint verify compares what a restore can carry; fleet probe skips where no alias exists

### DIFF
--- a/.datacore/lib/ledger/projector.py
+++ b/.datacore/lib/ledger/projector.py
@@ -194,14 +194,22 @@ def _drawer(props: dict) -> list[str]:
 
 
 _TRAILING_TAG_BLOCK = re.compile(r"\s+:([^\s:]+(?::[^\s:]+)*):\s*$")
-_BAD_TAG_CHAR = re.compile(r"[^A-Za-z0-9_@#%]")
+# The alphabet is the PARSER'S, not org's. Org itself also admits `#` and `%`
+# in a tag, but the importer this projection must round-trip through (the
+# vendored orgparse behind org_workspace) does not: given
+# `:AI:enterprise#373:infra:pm:` it kept `infra`/`pm` and pushed
+# ` :AI:enterprise#373` back INTO the title. 5-plur's org-7aba0a999bc5 failed
+# the checkpoint restore on exactly that from 2026-08-31 -- a tag the renderer
+# considered valid and the parser could not read. What is written here has to
+# come back through that parser unchanged, so its alphabet is the constraint.
+_BAD_TAG_CHAR = re.compile(r"[^A-Za-z0-9_@]")
 
 
 def _clean_title_and_tags(title: str, tags) -> tuple[str, list[str]]:
     """Return (title without an embedded tag block, valid sorted org tags).
 
-    Org allows only [A-Za-z0-9_@#%] in a tag; one hyphen voids every tag on
-    the heading. A heading ingested with `:docs:wrap-up-extracted:` had the
+    Only [A-Za-z0-9_@] survive in a tag; one hyphen voids every tag on the
+    heading. A heading ingested with `:docs:wrap-up-extracted:` had the
     whole block left INSIDE its title (the parser saw no valid tags), and this
     renderer wrote it back verbatim -- so the checkpoint failed the org-tag
     hook and winston's 5-plur autosave was refused every 15 minutes from
@@ -300,6 +308,25 @@ def render_item(item, *, level: int | None = None) -> list[str]:
     return lines
 
 
+def projected_items(state: LedgerState, *, space: str | None = None) -> list:
+    """The items a projection of `state` contains -- the ONE definition.
+
+    Live work, plus work finished recently enough to still be worth seeing;
+    anything closed longer ago belongs to the archive, not the action list.
+    Exposed because the checkpoint verifier must know exactly which ancestors
+    are rendered: a child inherits tags from a parent that is in the file and
+    from nothing else, and deciding that with a second copy of this filter is
+    how the two drift apart.
+    """
+    return [
+        item for item in state.items.values()
+        if (item.status in LIVE_STATUSES
+            or (item.status in CLOSED_STATUSES
+                and _closed_within(item, CLOSED_RETENTION_DAYS)))
+        and (space is None or (item.payload or {}).get("space", space) == space)
+    ]
+
+
 def project(state: LedgerState, *, space: str | None = None) -> Projection:
     """Render live items from `state` as org text.
 
@@ -320,15 +347,7 @@ def project(state: LedgerState, *, space: str | None = None) -> Projection:
     # (which is the entire point of Phase 1) rendered as nothing. A valid event,
     # accepted by fold, producing a task nobody could see. Only an explicit
     # FOREIGN space is excluded now.
-    # Live work, plus work finished recently enough to still be worth seeing.
-    # Anything closed longer ago belongs to the archive, not the action list.
-    items = [
-        item for item in state.items.values()
-        if (item.status in LIVE_STATUSES
-            or (item.status in CLOSED_STATUSES
-                and _closed_within(item, CLOSED_RETENTION_DAYS)))
-        and (space is None or (item.payload or {}).get("space", space) == space)
-    ]
+    items = projected_items(state, space=space)
 
     # Depth-first by parent, so a child is emitted directly under its parent
     # rather than wherever its id happens to sort. Sorting the whole set by id

--- a/.datacore/lib/ledger_checkpoint.py
+++ b/.datacore/lib/ledger_checkpoint.py
@@ -50,7 +50,7 @@ sys.path.insert(0, str(LIB))
 from ledger.fold import fold  # noqa: E402
 from ledger.genesis import import_space  # noqa: E402
 from ledger.log import read_events  # noqa: E402
-from ledger.projector import _org_stamp, project  # noqa: E402
+from ledger.projector import _clean_title_and_tags, _org_stamp, project, projected_items  # noqa: E402
 
 LIVE = ("created", "claimed", "granted")
 CHECKPOINT_REL = Path(".datacore") / "checkpoints" / "next_actions.org"
@@ -60,34 +60,81 @@ def _default_root() -> Path:
     return Path(os.environ.get("DATACORE_ROOT", str(Path.home() / "Data")))
 
 
-def _fingerprint(state, space_filetags: set | None = None) -> dict[str, tuple]:
+def _rendered_tags(state, known: set[str], iid: str) -> set[str]:
+    """The tags the projection carries for `iid`, derived from the LEDGER.
+
+    Org tag inheritance follows physical nesting, and the projector nests a
+    child under its parent whenever that parent is itself projected. So the
+    tags an item comes back with are its own (as rendered) plus every rendered
+    ancestor's own -- and that is computable from the ledger's `parent` links
+    without trusting anything recorded at import time.
+
+    The recorded `effective_tags` snapshot is NOT that. It is what the source
+    file said when the item was ingested, and nothing refreshes it when the
+    parent's tags change or the item is re-filed: 0-personal's
+    org-20260811-191903 was captured in inbox.org, later parented under
+    `* Routed from inbox :inbox:routed:`, and kept a snapshot without those two
+    tags -- so a projection that correctly nested it under that heading was
+    reported as having corrupted it (2026-08-31, together with five 5-plur
+    items whose parent had gained `AI`). Comparing the snapshot asked the
+    restore to reproduce a state the ledger no longer describes.
+
+    The one place the snapshot IS the truth is a promoted orphan: its parent is
+    not in the file, so the projector writes the snapshot as the item's own tags
+    (see projector.py). Mirrored here, for the same reason -- and mirrored for
+    ANCESTORS too: a child under a promoted parent inherits that parent's
+    rendered snapshot, not its declared tags. 3-fds org-2cd3c1c78434 (level 4,
+    under a level-3 task whose own parent had closed) came back with the four
+    tags its promoted parent now carries on its heading; a walk that read the
+    parent's declared tags reported that correct inheritance as an alteration.
+    """
+    tags = _heading_tags(state, known, iid)
+    cur, seen = (state.items[iid].payload or {}).get("parent"), set()
+    while cur and cur in known and cur not in seen:
+        seen.add(cur)
+        tags |= _heading_tags(state, known, cur)
+        cur = (state.items[cur].payload or {}).get("parent")
+    return tags
+
+
+def _heading_tags(state, known: set[str], iid: str) -> set[str]:
+    """The tags the projector writes on `iid`'s own heading: its declared tags,
+    or -- when its parent is not projected and it is promoted to top level --
+    its recorded effective set, so the tags it used to inherit travel with it.
+    Same rule as projector.project(); same normalisation as render_item()."""
+    item = state.items[iid]
+    p = item.payload or {}
+    parent = p.get("parent")
+    base = p.get("tags")
+    if parent and parent not in known:
+        base = p.get("effective_tags") or p.get("tags") or []
+    return set(_clean_title_and_tags(item.title, base)[1])
+
+
+def _fingerprint(state, space_filetags: set | None = None,
+                 space: str | None = None) -> dict[str, tuple]:
     """The fields a restore must preserve. Not the state root: a fresh import
     writes new events with new hashes and hlcs, so the CHAIN differs by design
-    — what must survive is the ITEMS.
+    -- what must survive is the ITEMS.
 
-    Tags are compared as EFFECTIVE tags — the item's own plus whatever it
-    inherits — because own-tags alone flag a correct transformation as damage.
-
-    When a task's parent is missing from a projection, the projector promotes
-    it to top level and writes its effective tags, so the tags it used to
-    inherit are not silently dropped (see projector.py). That is right: the
-    item keeps every tag it had. But its OWN tag set legitimately grows, and
-    comparing own-tags reported nine such items across 0-personal and 5-plur as
-    "altered" — a restore that preserved the tags perfectly, described as one
-    that corrupted them.
-
-    Effective tags are invariant under that promotion, which is exactly the
-    property a restore must hold: the item ends up tagged the same way, whether
-    or not the parent came along.
+    Both sides are reduced to what the PROJECTION renders, because that is the
+    only form a restore can travel through. Title and tags go through the
+    projector's own normalisation (`_clean_title_and_tags`): a tag block the
+    original parser left inside a title is split out, and characters the
+    parser cannot read become `_`. Tags are the RENDERED effective set --
+    derived from the ledger's parent links, see `_rendered_tags` -- not the
+    per-item snapshot recorded at import.
 
     FILE-LEVEL tags are subtracted from both sides. `#+FILETAGS: :gtd:` applies
-    to every item in the file, so it carries no per-item information — but the
-    two sides disagree about it: a recorded `effective_tags` omits filetags,
-    while re-importing a projection that reproduces the FILETAGS line picks
-    them up. That asymmetry reported 16 untagged items in 0-personal as
-    "altered", every one of them differing by exactly the same constant.
-    Subtracting it compares what is actually per-item.
+    to every item in the file, so it carries no per-item information -- but the
+    two sides disagree about it: a promoted orphan's snapshot may carry the
+    filetag of the file it was ingested from, while re-importing a projection
+    that reproduces the FILETAGS line picks up the projection's. That asymmetry
+    reported 16 untagged items in 0-personal as "altered", every one of them
+    differing by exactly the same constant. Subtracting it compares what is
+    actually per-item.
     """
+    known = {i.id for i in projected_items(state, space=space)}
     out = {}
     for iid, item in state.items.items():
         if item.status not in LIVE:
@@ -104,11 +151,11 @@ def _fingerprint(state, space_filetags: set | None = None) -> dict[str, tuple]:
         # "would NOT restore" while every task in it restored perfectly.
         if p.get("section"):
             continue
-        eff = set(p.get("effective_tags") or p.get("tags") or [])
+        eff = _rendered_tags(state, known, iid)
         # Subtract the item's OWN recorded filetags, and also the file the
         # round-trip actually goes through. The restored side is re-imported
         # from a projection carrying next_actions.org's `#+FILETAGS:`, so it
-        # always records and subtracts those — while an item that never sat in
+        # always records and subtracts those -- while an item that never sat in
         # next_actions.org has `filetags: None` and subtracts nothing.
         # 0-personal's org-20260831-203052 lives in inbox.org, carries `gtd`
         # (next_actions' filetag) in `tags`, and failed the round-trip on
@@ -117,20 +164,21 @@ def _fingerprint(state, space_filetags: set | None = None) -> dict[str, tuple]:
         # recorded something only the projection can know.
         eff -= set(p.get("filetags") or [])
         eff -= (space_filetags or set())
+        title = _clean_title_and_tags(item.title, p.get("tags"))[0]
         # Normalise timestamps before comparing. Some writers store a bare
         # `2026-08-14`; the projector renders the valid org form
         # `<2026-08-14 Fri>`. Those denote the SAME date, so comparing the raw
         # strings reported eight items as altered by a restore that preserved
-        # them exactly — the mirror of the bug just fixed in the projector.
+        # them exactly -- the mirror of the bug just fixed in the projector.
         # Normalise STATE the way the projector does. `projector.py` renders
         # `payload.get("state") or "TODO"`, so an item created without a state
-        # — every task the nightshift executor admits, for one — projects as
+        # -- every task the nightshift executor admits, for one -- projects as
         # TODO and re-imports as TODO, while the live side still reads None.
         # Comparing the raw values reported 30 such items in winston's
         # 0-personal as "altered" by a restore that preserved them exactly
         # (2026-08-30), the same false-alarm class as the timestamp and
         # filetag asymmetries above. A missing state MEANS TODO here.
-        out[iid] = (p.get("title"), p.get("state") or "TODO",
+        out[iid] = (title, p.get("state") or "TODO",
                     tuple(sorted(eff)),
                     _org_stamp(p.get("scheduled")), _org_stamp(p.get("deadline")))
     return out
@@ -147,13 +195,66 @@ def write(space: Path) -> Path:
     return dest                # than none, and this file only matters in a crisis
 
 
+def _space_filetags(space: Path) -> set:
+    """The filetags of the file the round-trip re-imports through. Both sides
+    are compared with these removed, so an item that never lived in
+    next_actions.org is not penalised for lacking a `filetags` record only
+    the projection could have given it."""
+    na = space / "org" / "next_actions.org"
+    try:
+        for _l in na.read_text(encoding="utf-8", errors="replace").splitlines()[:10]:
+            if _l.startswith("#+FILETAGS:"):
+                return {x for x in _l.split(":", 1)[1].split(":") if x.strip()}
+    except OSError:
+        pass
+    return set()
+
+
+def round_trip(state, space_name: str, space_ft: set | None = None):
+    """Project `state`, re-import the projection into a throwaway space, and
+    return (live_fingerprint, restored_fingerprint, fresh_projection_text).
+
+    The comparison core, separated from the on-disk checkpoint so it can be
+    exercised on a synthetic state -- every false alarm this tool has raised
+    was a fingerprint asymmetry, and those need a test that does not depend on
+    what happens to be in a real space today.
+    """
+    space_ft = space_ft or set()
+    live = _fingerprint(state, space_ft, space=space_name)
+    fresh = project(state, space=space_name).text
+    with tempfile.TemporaryDirectory() as td:
+        scratch = Path(td) / space_name
+        (scratch / ".datacore" / "events").mkdir(parents=True)
+        (scratch / "org").mkdir()
+        (scratch / "org" / "next_actions.org").write_text(fresh, encoding="utf-8")
+        import_space(scratch, org_file=scratch / "org" / "next_actions.org")
+        restored = _fingerprint(fold(read_events(scratch)), space_ft, space=space_name)
+    return live, restored, fresh
+
+
+def compare(live: dict, restored: dict) -> tuple[bool, str]:
+    missing = sorted(set(live) - set(restored))
+    extra = sorted(set(restored) - set(live))
+    changed = sorted(i for i in (set(live) & set(restored)) if live[i] != restored[i])
+    if not (missing or extra or changed):
+        return True, f"{len(live)} item(s) restore identically"
+    parts = []
+    if missing:
+        parts.append(f"{len(missing)} lost (e.g. {missing[0]})")
+    if extra:
+        parts.append(f"{len(extra)} invented")
+    if changed:
+        parts.append(f"{len(changed)} altered (e.g. {changed[0]})")
+    return False, "; ".join(parts)
+
+
 def verify(space: Path) -> tuple[bool, str]:
     """Rebuild from the checkpoint in a scratch space and compare.
 
     STALENESS IS NOT CORRUPTION, and conflating them made this tool lie.
 
     The checkpoint on disk is written once a day. Every item appended to the
-    ledger after that write is, trivially, absent from it — so comparing the
+    ledger after that write is, trivially, absent from it -- so comparing the
     stored file against the CURRENT ledger reported ordinary new work as data
     loss. On 2026-08-13 that read as "4 of 9 spaces would NOT restore, 23 items
     lost". Re-writing first and re-running dropped it to 1 lost item: 22 of the
@@ -162,11 +263,11 @@ def verify(space: Path) -> tuple[bool, str]:
     That is the worst failure mode available to this particular tool. Its whole
     purpose is answering "could we actually re-genesis from this?", and an
     answer that cries corruption on a healthy system is one the operator learns
-    to wave away — leaving nothing to raise the alarm when a restore genuinely
+    to wave away -- leaving nothing to raise the alarm when a restore genuinely
     breaks.
 
     So project FRESH from the same ledger being compared against. That isolates
-    the question this is meant to answer — does the projection round-trip? —
+    the question this is meant to answer -- does the projection round-trip? --
     from "is the file on disk current?", which is the write step's job and is
     reported separately below.
     """
@@ -175,53 +276,16 @@ def verify(space: Path) -> tuple[bool, str]:
         return False, "no checkpoint written yet"
 
     state = fold(read_events(space))
-    # The filetags of the file the round-trip re-imports through. Both sides
-    # are compared with these removed, so an item that never lived in
-    # next_actions.org is not penalised for lacking a `filetags` record only
-    # the projection could have given it.
-    space_ft: set = set()
-    na = space / "org" / "next_actions.org"
-    try:
-        for _l in na.read_text(encoding="utf-8", errors="replace").splitlines()[:10]:
-            if _l.startswith("#+FILETAGS:"):
-                space_ft = {x for x in _l.split(":", 1)[1].split(":") if x.strip()}
-                break
-    except OSError:
-        pass
-    live = _fingerprint(state, space_ft)
-
-    # Round-trip a projection of the CURRENT state, not yesterday's file.
-    fresh = project(state, space=space.name).text
-    with tempfile.TemporaryDirectory() as td:
-        scratch = Path(td) / space.name
-        (scratch / ".datacore" / "events").mkdir(parents=True)
-        (scratch / "org").mkdir()
-        (scratch / "org" / "next_actions.org").write_text(fresh, encoding="utf-8")
-        import_space(scratch, org_file=scratch / "org" / "next_actions.org")
-        restored = _fingerprint(fold(read_events(scratch)), space_ft)
-
-    missing = sorted(set(live) - set(restored))
-    extra = sorted(set(restored) - set(live))
-    changed = [i for i in (set(live) & set(restored)) if live[i] != restored[i]]
+    live, restored, fresh = round_trip(state, space.name, _space_filetags(space))
+    ok, detail = compare(live, restored)
 
     # Report the on-disk file's age as its own fact. A stale checkpoint is a
-    # real problem — it is what a restore would actually start from — but it is
+    # real problem -- it is what a restore would actually start from -- but it is
     # a DIFFERENT problem from a projection that cannot round-trip, and the two
     # need different fixes: run the write step, versus fix the projector.
-    stale = ""
     if cp.read_text(encoding="utf-8", errors="replace") != fresh:
-        stale = " [on-disk checkpoint is behind the ledger — run: write]"
-
-    if not (missing or extra or changed):
-        return True, f"{len(live)} item(s) restore identically{stale}"
-    parts = []
-    if missing:
-        parts.append(f"{len(missing)} lost (e.g. {missing[0]})")
-    if extra:
-        parts.append(f"{len(extra)} invented")
-    if changed:
-        parts.append(f"{len(changed)} altered (e.g. {changed[0]})")
-    return False, "; ".join(parts) + stale
+        detail += " [on-disk checkpoint is behind the ledger — run: write]"
+    return ok, detail
 
 
 def main() -> int:

--- a/.datacore/lib/tests/test_ledger_checkpoint.py
+++ b/.datacore/lib/tests/test_ledger_checkpoint.py
@@ -1,0 +1,117 @@
+"""The checkpoint round-trip must compare what a restore can actually carry.
+
+Every false alarm this tool has raised was an asymmetry between the two sides
+of the comparison, not a broken restore: filetags (2026-08-31), missing
+states (2026-08-30), and — the one that kept winston's v2-verify red from
+2026-08-31 to 2026-09-05 — a per-item `effective_tags` snapshot that nothing
+refreshes when a parent's tags change or an item is re-filed, plus a tag
+alphabet the renderer accepted and the parser did not. These tests pin the
+comparison to a synthetic state so the invariant is checked without a real
+space's contents being the fixture.
+"""
+import pathlib
+import sys
+
+LIB = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(LIB))
+from ledger.fold import ItemState, LedgerState                       # noqa: E402
+from ledger_checkpoint import _fingerprint, compare, round_trip      # noqa: E402
+
+
+def _item(iid, title, *, level, tags=(), effective=None, parent=None,
+          section=False, state="TODO", status="created"):
+    payload = {"level": level, "tags": sorted(tags),
+               "effective_tags": sorted(effective if effective is not None else tags),
+               "parent": parent}
+    if section:
+        payload.update({"section": True, "state": None})
+    else:
+        payload["state"] = state
+    return ItemState(id=iid, title=title, owner=None, status=status, payload=payload)
+
+
+def _state(*items):
+    return LedgerState(items={i.id: i for i in items})
+
+
+def test_stale_effective_tags_snapshot_does_not_fail_a_correct_restore():
+    """A child filed under `* Routed from inbox :inbox:routed:` after it was
+    captured keeps the snapshot it was captured with. The projection nests it
+    under that heading — as it must — and the re-import inherits the two tags.
+    That is the ledger's CURRENT structure, faithfully restored."""
+    st = _state(
+        _item("sec", "Routed from inbox", level=1, tags=["inbox", "routed"], section=True),
+        _item("task-stale", "Revise the digest", level=2, tags=["datacore"],
+              effective=["datacore"], parent="sec"),
+    )
+    live, restored, _ = round_trip(st, "0-testspace")
+    assert live["task-stale"][2] == ("datacore", "inbox", "routed"), live["task-stale"]
+    assert compare(live, restored) == (True, "1 item(s) restore identically")
+
+
+def test_parent_that_gained_a_tag_is_inherited_on_both_sides():
+    """5-plur: five children whose parent had gained `AI` after they were
+    recorded reported as 'altered' by a restore that preserved them."""
+    st = _state(
+        _item("epic", "Publish the article", level=1, tags=["AI", "comms", "plur"]),
+        _item("child", "Stage A", level=2, tags=["engineering", "plur"],
+              effective=["comms", "engineering", "plur"], parent="epic"),
+    )
+    live, restored, _ = round_trip(st, "5-testspace")
+    assert live["child"][2] == ("AI", "comms", "engineering", "plur")
+    assert compare(live, restored)[0], compare(live, restored)
+
+
+def test_tag_block_with_a_hash_round_trips():
+    """org-7aba0a999bc5: `:AI:pm:enterprise#373:` left inside a title by the
+    original parser. The renderer split it out but kept `#`, which the parser
+    cannot read, so the block came back half in the title and half as tags."""
+    st = _state(
+        _item("task-hash", "UX pass on 0.1.6 :AI:pm:enterprise#373:", level=1,
+              tags=[], effective=["infra", "plur"], parent="gone-parent"),
+    )
+    live, restored, fresh = round_trip(st, "5-testspace")
+    title, _state_, tags, *_ = live["task-hash"]
+    assert title == "UX pass on 0.1.6", title
+    assert tags == ("AI", "enterprise_373", "infra", "plur", "pm"), tags
+    assert "enterprise#373" not in fresh, "the projection must be in the parser's alphabet"
+    assert compare(live, restored)[0], compare(live, restored)
+
+
+def test_promoted_orphan_carries_its_snapshot():
+    """A parent absent from the projection cannot lend its tags, so the
+    snapshot is rendered as the item's own — on both sides of the comparison."""
+    st = _state(
+        _item("orphan", "Floating task", level=2, tags=["x"],
+              effective=["x", "inherited"], parent="closed-long-ago"),
+    )
+    live, restored, fresh = round_trip(st, "0-testspace")
+    assert live["orphan"][2] == ("inherited", "x")
+    assert "* TODO Floating task  :inherited:x:" in fresh
+    assert compare(live, restored)[0], compare(live, restored)
+
+
+def test_child_of_a_promoted_parent_inherits_the_parents_snapshot():
+    """3-fds org-2cd3c1c78434: level 4 under a level-3 task whose own parent
+    closed. The parent is promoted and renders its snapshot; the child, nested
+    under it, inherits that snapshot -- on both sides."""
+    st = _state(
+        _item("parent", "Strip the token", level=3, tags=["infra", "security"],
+              effective=["AI", "ceo", "infra", "security"], parent="closed-epic"),
+        _item("child", "Decide participation", level=4, tags=["fds", "giveth"],
+              effective=["fds", "giveth", "infra", "security"], parent="parent"),
+    )
+    live, restored, fresh = round_trip(st, "3-testspace")
+    assert live["child"][2] == ("AI", "ceo", "fds", "giveth", "infra", "security")
+    assert "* TODO Strip the token  :AI:ceo:infra:security:" in fresh
+    assert compare(live, restored)[0], compare(live, restored)
+
+
+def test_a_real_loss_is_still_reported():
+    st = _state(_item("a", "Kept", level=1), _item("b", "Lost", level=1))
+    live = _fingerprint(st)
+    restored = {k: v for k, v in live.items() if k != "b"}
+    ok, detail = compare(live, restored)
+    assert not ok and detail == "1 lost (e.g. b)", detail
+    ok, detail = compare(live, {**live, "a": ("Renamed", "TODO", (), None, None)})
+    assert not ok and detail == "1 altered (e.g. a)", detail

--- a/.datacore/lib/tests/test_projector_tags.py
+++ b/.datacore/lib/tests/test_projector_tags.py
@@ -45,3 +45,16 @@ def test_typed_weekday_inside_body_text_is_recomputed():
     item.payload["org"] = {"body": "DEADLINE: <2026-07-30 Wed>\nGenerate the post."}
     text = "\n".join(render_item(item))
     assert "<2026-07-30 Thu>" in text and "Wed" not in text
+
+
+def test_hash_and_percent_are_outside_the_parsers_alphabet():
+    """Org admits `#` and `%` in a tag; the importer this projection must
+    round-trip through does not. `:AI:enterprise#373:infra:pm:` came back from
+    that parser as tags (infra, pm) and a title ending in ` :AI:enterprise#373`
+    (5-plur org-7aba0a999bc5, 2026-08-31). The renderer's alphabet is the
+    parser's, so what is written is what is read back."""
+    line = render_item(_item("Plain title", tags=["enterprise#373", "a%b", "ok"]))[0]
+    assert line.endswith("  :a_b:enterprise_373:ok:"), line
+    from org_workspace._vendor.orgparse import loads
+    node = loads(line + "\n").children[0]
+    assert node.heading == "Plain title" and sorted(node.tags) == ["a_b", "enterprise_373", "ok"]

--- a/.datacore/lib/v2_verify.py
+++ b/.datacore/lib/v2_verify.py
@@ -45,14 +45,24 @@ class Check:
     name: str
     ok: bool | None          # True | False | None (could not run)
     detail: str = ""
+    # `skipped` is the fourth word, and it is narrower than n-a. n-a means
+    # "tried, could not tell" — a helper missing, a probe timing out — and it
+    # stays in the could-not-run count because it is a gap someone should
+    # close. `skipped` means the check is NOT APPLICABLE on this host by
+    # design (the fleet probe needs the operator's ssh aliases, which a server
+    # does not and must not hold), so counting it as could-not-run on every
+    # unattended run reported a permanent gap that no one on that host could
+    # close. The exit code never saw the difference; the summary line did.
+    skipped: bool = False
 
 
 @dataclass
 class Report:
     checks: list[Check] = field(default_factory=list)
 
-    def add(self, dip: str, name: str, ok: bool | None, detail: str = "") -> None:
-        self.checks.append(Check(dip, name, ok, detail))
+    def add(self, dip: str, name: str, ok: bool | None, detail: str = "",
+            *, skipped: bool = False) -> None:
+        self.checks.append(Check(dip, name, ok, detail, skipped))
 
     @property
     def failed(self) -> list[Check]:
@@ -60,7 +70,11 @@ class Report:
 
     @property
     def unknown(self) -> list[Check]:
-        return [c for c in self.checks if c.ok is None]
+        return [c for c in self.checks if c.ok is None and not c.skipped]
+
+    @property
+    def skipped(self) -> list[Check]:
+        return [c for c in self.checks if c.skipped]
 
 
 def run(args: list[str], timeout: int = 180) -> tuple[int, str]:
@@ -470,12 +484,32 @@ def check_fleet(rep: Report) -> None:
     # server, every host is simply unreachable — which reports n-a, honestly,
     # but means an unattended run there verifies only itself. Say so in the
     # detail rather than letting "0 ok, 4 unreachable" read as a fleet outage.
-    unreachable, failing, ok_hosts = [], [], []
+    #
+    # And decide that BEFORE probing. Whether an alias exists is a local fact
+    # (`ssh -G` resolves the config without connecting); a host with none is
+    # not a host whose fleet is down, it is a host this check does not apply
+    # to. Probing anyway cost four 10s connect timeouts per run and produced
+    # a "could-not-run" that winston's every-12-hours run has carried since
+    # the checklist shipped — a gap that host cannot close and should not
+    # (servers must not hold fleet keys). Report it as skipped, once, in a
+    # line that says where to run it instead.
+    targets = []
     for name, cfg in servers.items():
-        access = cfg.get("access") or {}
         alias = cfg.get("ssh_alias") or name
         if alias == "-" or name == "mac":
             continue
+        targets.append((name, cfg, alias))
+    configured = [t for t in targets if _alias_configured(t[2])]
+    if targets and not configured:
+        rep.add("fleet", "remote job contracts", None,
+                f"n-a here: none of the {len(targets)} fleet ssh aliases exists "
+                "on this host — run from the operator machine", skipped=True)
+        return
+    no_alias = [name for name, _c, _a in targets if (name, _c, _a) not in configured]
+
+    unreachable, failing, ok_hosts = [], [], []
+    for name, cfg, alias in configured:
+        access = cfg.get("access") or {}
         actor = access.get("actor") or name
         # RUNNER FIRST. On hermes and plur-claw `~/Data` is the AGENT'S OWN
         # SPACE repo (tris-space / data-space), not the Datacore core — the
@@ -505,13 +539,36 @@ def check_fleet(rep: Report) -> None:
 
     note = ""
     if unreachable and not ok_hosts:
-        note = " — no ssh aliases here; run this from the operator machine"
+        note = " — every configured alias failed to connect"
     rep.add("fleet", "remote job contracts",
             None if (unreachable and not failing) else not failing,
             f"{len(ok_hosts)} ok"
             + (f", FAILING: {', '.join(failing)}" if failing else "")
             + (f", {len(unreachable)} unreachable" if unreachable else "")
+            + (f", {len(no_alias)} without an alias here ({', '.join(no_alias)})"
+               if no_alias else "")
             + note)
+
+
+def _alias_configured(alias: str) -> bool:
+    """Does ssh on THIS host know `alias`? Decided without connecting.
+
+    `ssh -G` prints the effective config for a name; for a name that no
+    `Host` block matches it prints exactly what it prints for any unknown
+    name, hostname aside. So an alias is configured iff its resolved config
+    differs from that baseline in some option other than `host`/`hostname`. A bare
+    resolver lookup is deliberately NOT the test: on winston, MagicDNS resolves
+    `nightshift`/`hermes`/`plur-claw` while the box holds no key for any of
+    them, and treating "resolves" as "configured" put the probe right back to
+    four connect failures per run.
+    """
+    rc_base, base = run(["ssh", "-G", "datacore-no-such-alias-probe"], 15)
+    rc, out = run(["ssh", "-G", alias], 15)
+    if rc != 0 or rc_base != 0:
+        return False
+    def opts(text):
+        return {l for l in text.splitlines() if not l.startswith(("host ", "hostname "))}
+    return opts(out) != opts(base)
 
 
 # ── DIP-0042: sequencer / finality ──────────────────────────────────────────
@@ -589,20 +646,23 @@ def main() -> int:
     if a.json:
         print(json.dumps({"checks": [c.__dict__ for c in rep.checks],
                           "failed": len(rep.failed),
-                          "unknown": len(rep.unknown)}, indent=2))
+                          "unknown": len(rep.unknown),
+                          "skipped": len(rep.skipped)}, indent=2))
         return 1 if rep.failed else 0
 
     mark = {True: "\033[32mok  \033[0m", False: "\033[31mFAIL\033[0m", None: "\033[33mn-a \033[0m"}
+    skip = "\033[2mskip\033[0m"
     last_dip = None
     for c in rep.checks:
         if c.dip != last_dip:
             print(f"\n  \033[1mDIP-{c.dip}\033[0m")
             last_dip = c.dip
-        print(f"    {mark[c.ok]} {c.name:<32} {c.detail}")
+        print(f"    {skip if c.skipped else mark[c.ok]} {c.name:<32} {c.detail}")
 
     print(f"\n  {len(rep.checks)} check(s): "
           f"{sum(1 for c in rep.checks if c.ok is True)} ok, "
-          f"{len(rep.failed)} FAIL, {len(rep.unknown)} could-not-run")
+          f"{len(rep.failed)} FAIL, {len(rep.unknown)} could-not-run"
+          + (f", {len(rep.skipped)} not applicable here" if rep.skipped else ""))
     if rep.failed:
         print("  \033[31mv2 REGRESSED\033[0m — " + "; ".join(c.name for c in rep.failed))
     return 1 if rep.failed else 0


### PR DESCRIPTION
## Why

`v2_verify.py` on winston has been red since 2026-08-31 on check 0043 "checkpoint restores": `ledger_checkpoint.py verify` reported 2 of 9 spaces "would NOT restore". None of the seven flagged items was actually damaged by the round trip — the fingerprint asked the restore to reproduce a state the ledger no longer describes, and the projector wrote tags the importer's parser cannot read.

## What

- **`ledger_checkpoint.py`** — `_fingerprint` derives each item's effective tags from the ledger's `parent` links the way the projector renders them (declared tags, or the recorded snapshot for a promoted orphan, unioned up the projected chain), instead of trusting the per-item `effective_tags` snapshot recorded at import (stale after a re-parent or a parent tag change). Titles are normalised with the projector's own `_clean_title_and_tags`. `round_trip()` / `compare()` expose the comparison for tests.
- **`ledger/projector.py`** — `_BAD_TAG_CHAR` no longer admits `#`/`%`: the vendored orgparse parser stops at them, so `:AI:pm:enterprise#373:` round-tripped as `pm` + a title ending in ` :AI:enterprise#373`. `projected_items()` is the single definition of what a projection contains, shared with the verifier.
- **`v2_verify.py`** — the fleet probe (`remote job contracts`) reports an explicit `skip` with a one-line reason on hosts with no fleet ssh aliases, counted as "not applicable here" rather than could-not-run; aliases are detected via `ssh -G` against a baseline (MagicDNS resolves the names on winston without any key, so DNS is not the test). `Check.skipped` is in the JSON output.
- **Tests** — `tests/test_ledger_checkpoint.py` (6 cases, one per false alarm plus a real-loss guard); `test_projector_tags.py` gains the alphabet test that parses the rendered line back.

## Verified

- winston, live ledgers, patched lib: `checkpoint-verify: 9 space(s), 0 that would NOT restore` (was 2).
- winston, patched `v2_verify.py`: `ok checkpoint restores`, `skip remote job contracts — n-a here: none of the 4 fleet ssh aliases exists on this host — run from the operator machine`, summary `... 3 could-not-run, 1 not applicable here`.
- mac (operator): `ok remote job contracts 4 ok`.
- `.datacore/lib/tests`: 1364 passed; the same 10 environment-grounded failures as a clean `origin/main` worktree (verified by diffing the failure sets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
