### PR TITLE
gitignore: the box's miles_delivery scripts are deployed files, not repo content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -317,6 +317,7 @@ node_modules/
 .datacore/lib/cos-*
 .datacore/lib/winston_*
 .datacore/lib/data_deliver.*
+.datacore/lib/miles_delivery.*
 .datacore/lib/lens_analyze.py
 .datacore/lib/ws_chat_test.py
 


### PR DESCRIPTION
Like `cos_*`, `winston_*` and `data_deliver.*`, the two `miles_delivery` scripts are rsynced into the box's `.datacore/lib` by a module deploy. On 2026-09-05 a run staged them into the public Data repo and only a hand unstage kept them out of a commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)