### PR TITLE
job_verify: one failure per artifact, and a recurring failure files a task

### DIFF
--- a/.datacore/lib/job_verify.py
+++ b/.datacore/lib/job_verify.py
@@ -67,6 +67,7 @@ one broken job must never abort verification of the rest of the manifest.
 from __future__ import annotations
 
 import argparse
+import datetime as _dt
 import os
 import socket
 import subprocess
@@ -166,10 +167,83 @@ def _note_pass(job_name: str) -> None:
         _spec.loader.exec_module(_rec)
     if _NO_EMIT:
         return
-    _rec.record(job_name, failed=False)
+    rec = _rec.record(job_name, failed=False)
+    tid = rec.get("task_id") if isinstance(rec, dict) else None
+    if tid:
+        # The pass is the DONE_WHEN of the task the streak filed.
+        if _close_task(tid):
+            print(f"recovered: task {tid} closed for {job_name}", file=sys.stderr)
+        _rec.note_task(job_name, None)
 
 
-def _dispatch_alert(mode: str, job_name: str, failures: list[str]) -> None:
+def _artifact_signature(job) -> str:
+    """path + mtime of every artifact: the same signature is the same failure."""
+    parts = []
+    today = _dt.date.today().isoformat()
+    for a in getattr(job, "artifacts", []) or []:
+        raw = os.path.expanduser(str(a.path).replace("{today}", today))
+        try:
+            parts.append(f"{raw}@{int(os.stat(raw).st_mtime)}")
+        except OSError:
+            parts.append(f"{raw}@missing")
+    return "|".join(parts)
+
+
+#: Where a recurring failure becomes a task. 2-datacore is the system space; the
+#: machine goes on the task as SURFACE so the owner knows where to look.
+TASK_FILE = os.environ.get("JOB_VERIFY_TASK_FILE") or str(
+    DATACORE_ROOT / "2-datacore" / "org" / "next_actions.org")
+
+
+def _file_task(job, rec: dict, failures: list[str]) -> str | None:
+    """A recurring failure is a defect with no owner; give it one.
+
+    Escalation used to be a differently worded alert, once a day, forever:
+    mac-id-churn reached 48 recurrences with nobody assigned. The third
+    consecutive failure now files ONE task in the system space, with the
+    machine, the job and the failure text, and the pass that ends the streak
+    closes it. Best-effort: the adapter failing must not stop verification.
+    """
+    adapter = Path(__file__).resolve().parent / "org_workspace_adapter.py"
+    heading = (f"job-verify: {job.name} is failing on {job.machine} "
+               f"({rec.get('consecutive')} runs since {rec.get('first_failed')})")
+    body = ("Recurring failure (DIP-0031: 3 or more consecutive runs). Failures this run:\n"
+            + "\n".join(f"- {f}" for f in failures[:6])
+            + f"\nProducer: {getattr(job, 'cmd', '') or 'see manifest'}"
+            + f"\nSchedule: {getattr(job, 'schedule', '') or 'see manifest'}")
+    cmd = [sys.executable, str(adapter), "add", "--allow-any-file", "--file", TASK_FILE,
+           "--state", "TODO", "--heading", heading, "--tags", "datacore,ops,job_verify",
+           "--priority", "B", "--property", f"SURFACE={job.machine}", "--property", f"JOB={job.name}",
+           "--property", (f"DONE_WHEN=job {job.name} passes verification on {job.machine} "
+                          "(job_verify records the pass and closes this)"),
+           "--body", body]
+    try:
+        import json as _json
+        out = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+        for line in (out.stdout or "").splitlines():
+            line = line.strip()
+            if line.startswith("{"):
+                d = _json.loads(line)
+                if d.get("added") and d.get("id"):
+                    return str(d["id"])
+        print(f"task not filed for {job.name}: {(out.stderr or out.stdout or '').strip()[-200:]}",
+              file=sys.stderr)
+    except Exception as exc:  # noqa: BLE001 -- bookkeeping must not stop verification
+        print(f"task not filed for {job.name}: {type(exc).__name__}: {exc}", file=sys.stderr)
+    return None
+
+
+def _close_task(task_id: str) -> bool:
+    adapter = Path(__file__).resolve().parent / "org_workspace_adapter.py"
+    try:
+        out = subprocess.run([sys.executable, str(adapter), "complete", "--file", TASK_FILE,
+                              "--id", task_id], capture_output=True, text=True, timeout=120)
+        return out.returncode == 0
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _dispatch_alert(mode: str, job_name: str, failures: list[str], job=None) -> None:
     """Dispatch exactly one alert for one failing job.
 
     `log` mode is stderr-only -- no external call is made. `telegram` mode
@@ -199,7 +273,17 @@ def _dispatch_alert(mode: str, job_name: str, failures: list[str]) -> None:
     if _NO_EMIT:
         message = f"job.verify FAILED: {job_name} ({len(failures)} failure(s))"
     else:
-        _record = _rec.record(job_name, failed=True)
+        sig = _artifact_signature(job) if job is not None else None
+        _record = _rec.record(job_name, failed=True, artifact_sig=sig)
+        if _record.get("same_artifact"):
+            print(f"alert withheld: {job_name} failed on the same artifact already counted "
+                  f"({_record.get('consecutive')}x); nothing new to report", file=sys.stderr)
+            return
+        if _record.get("recurring") and job is not None and not _record.get("task_id"):
+            tid = _file_task(job, _record, failures)
+            if tid:
+                _rec.note_task(job_name, tid)
+                print(f"recurring: filed task {tid} for {job_name}", file=sys.stderr)
         message = _rec.describe(job_name, _record, len(failures))
         if not _rec.should_alert(_record):
             print(f"alert suppressed: {job_name} is recurring "
@@ -382,7 +466,7 @@ def main(argv: list[str] | None = None) -> None:
             for failure in failures:
                 print(f"  - {failure}", file=sys.stderr)
             effective_alert = args.alert if args.alert is not None else job.on_fail
-            _dispatch_alert(effective_alert, job.name, failures)
+            _dispatch_alert(effective_alert, job.name, failures, job=job)
         else:
             # Reset on every pass, not only on the transition. A job that
             # recovers must not carry its old count into an unrelated future

--- a/.datacore/lib/jobs/recurrence.py
+++ b/.datacore/lib/jobs/recurrence.py
@@ -99,7 +99,8 @@ def _save(d: dict) -> None:
         pass
 
 
-def record(job_name: str, failed: bool, *, today: str | None = None) -> dict:
+def record(job_name: str, failed: bool, *, today: str | None = None,
+           artifact_sig: str | None = None) -> dict:
     """Update and return this job's recurrence record.
 
     Returns {consecutive, first_failed, recurring}. A pass resets the count to
@@ -114,13 +115,13 @@ def record(job_name: str, failed: bool, *, today: str | None = None) -> dict:
     # job stays "recurring".
     try:
         with _locked():
-            return _record_unlocked(job_name, failed, today)
+            return _record_unlocked(job_name, failed, today, artifact_sig)
     except OSError as exc:
         # A home where mkdir or flock fails (read-only, NFS without locks)
         # must not take down verification of every remaining job. Degrade to
         # the unserialised update -- an off-by-one counter, not an aborted run.
         print(f"recurrence: lock unavailable ({exc}); recording without it", file=sys.stderr)
-        return _record_unlocked(job_name, failed, today)
+        return _record_unlocked(job_name, failed, today, artifact_sig)
 
 
 @contextlib.contextmanager
@@ -136,17 +137,30 @@ def _locked():
             fcntl.flock(fh, fcntl.LOCK_UN)
 
 
-def _record_unlocked(job_name: str, failed: bool, today: str) -> dict:
+def _record_unlocked(job_name: str, failed: bool, today: str,
+                     artifact_sig: str | None = None) -> dict:
     state = _load()
     rec = state.get(job_name) or {"consecutive": 0, "first_failed": None}
-
     if failed:
-        rec["consecutive"] = int(rec.get("consecutive") or 0) + 1
-        rec["first_failed"] = rec.get("first_failed") or today
-        rec["last_failed"] = today
+        # ONE FAILURE PER ARTIFACT, not per look. The verifier runs every 30
+        # minutes; a producer runs three times a day. Re-reading the same
+        # failed artifact counted mac-config-drift 8x and mac-id-churn 48x on
+        # 2026-09-05 for one and two real failures -- the streak was a clock,
+        # not a count, and the operator learned to ignore it. A signature of
+        # the artifacts (path + mtime) that has not changed since the last
+        # recorded failure is the same failure: reported once, counted once.
+        if artifact_sig and rec.get("artifact_sig") == artifact_sig:
+            rec["same_artifact"] = True
+        else:
+            rec["consecutive"] = int(rec.get("consecutive") or 0) + 1
+            rec["first_failed"] = rec.get("first_failed") or today
+            rec["last_failed"] = today
+            rec["same_artifact"] = False
+            if artifact_sig:
+                rec["artifact_sig"] = artifact_sig
     else:
-        rec = {"consecutive": 0, "first_failed": None, "last_passed": today}
-
+        rec = {"consecutive": 0, "first_failed": None, "last_passed": today,
+               "task_id": rec.get("task_id")}
     rec["recurring"] = rec["consecutive"] >= RECURRING_AFTER
     state[job_name] = rec
     _save(state)
@@ -190,6 +204,23 @@ def should_alert(rec: dict, *, today: str | None = None) -> bool:
     if int(rec.get("consecutive") or 0) == RECURRING_AFTER:
         return True
     return rec.get("last_alerted") != today
+
+
+def note_task(job_name: str, task_id: str | None) -> None:
+    """Remember (or forget) the task filed for this job's recurrence."""
+    try:
+        with _locked():
+            state = _load()
+            rec = state.get(job_name)
+            if isinstance(rec, dict):
+                if task_id:
+                    rec["task_id"] = task_id
+                else:
+                    rec.pop("task_id", None)
+                state[job_name] = rec
+                _save(state)
+    except OSError:
+        pass
 
 
 def note_alerted(job_name: str, *, today: str | None = None) -> None:

--- a/.datacore/lib/tests/test_job_verify.py
+++ b/.datacore/lib/tests/test_job_verify.py
@@ -706,3 +706,40 @@ def test_a_real_run_forgets_recurrence_records_for_jobs_no_longer_in_the_manifes
     assert "ghost-job" not in state, "a record for a job the manifest no longer names must be forgotten"
     assert "backup-notes" in state, "the live job's pass must still be recorded"
     assert "forgot ghost-job" in err
+
+
+# --- one failure per artifact; a recurring failure files a task -----------------
+
+
+def test_a_recurring_failure_is_counted_per_artifact_and_files_one_task(tmp_path, monkeypatch, capsys):
+    """2026-09-05: mac-id-churn reached 48 'recurrences' for two real failures
+    (verifier every 30 min, producer hourly) and nobody owned it."""
+    import jobs.recurrence as R
+    monkeypatch.setattr(R, "STATE", tmp_path / "rec.json")
+    artifact = tmp_path / "churn.log"
+    manifest = _write_manifest(tmp_path, [_job("mac-id-churn", "mac", str(artifact),
+                                              artifacts=[{"path": str(artifact), "check": "regex", "arg": "0 with findings"}])])
+    space = _space(tmp_path)
+    monkeypatch.setenv("DATACORE_ACTOR", "test-actor")
+    sent, filed, closed = [], [], []
+    monkeypatch.setattr(job_verify, "_send_telegram", lambda msg: sent.append(msg) or True)
+    monkeypatch.setattr(job_verify, "_file_task", lambda job, rec, failures: filed.append(job.name) or "org-task-1")
+    monkeypatch.setattr(job_verify, "_close_task", lambda tid: closed.append(tid) or True)
+    argv = ["--machine", "mac", "--manifest", str(manifest), "--space", str(space), "--alert", "telegram"]
+
+    for i in range(1, 4):                      # three regenerated, still-failing artifacts
+        artifact.write_text(f"id-churn: 11 space(s), 2 with findings (run {i})")
+        os.utime(artifact, (1_700_000_000 + i * 100, 1_700_000_000 + i * 100))
+        assert _run_main(argv) == 1
+    assert filed == ["mac-id-churn"], "the third consecutive failure files exactly one task"
+    assert len(sent) == 3
+
+    assert _run_main(argv) == 1                # same artifact, looked at again
+    assert filed == ["mac-id-churn"] and len(sent) == 3, "an unchanged artifact is neither counted nor alerted again"
+    assert R._load()["mac-id-churn"]["consecutive"] == 3
+
+    artifact.write_text("id-churn: 11 space(s), 0 with findings")
+    os.utime(artifact, (1_700_000_900, 1_700_000_900))
+    assert _run_main(argv) == 0
+    assert closed == ["org-task-1"], "the pass closes the task the streak filed"
+    assert "task_id" not in R._load()["mac-id-churn"]

--- a/.datacore/lib/tests/test_jobs_recurrence.py
+++ b/.datacore/lib/tests/test_jobs_recurrence.py
@@ -163,3 +163,24 @@ def test_recurring_failures_alert_at_escalation_then_once_a_day(rec):
     rec.record("j", failed=False, today="2026-09-04")
     r = rec.record("j", failed=True, today="2026-09-04")
     assert rec.should_alert(r, today="2026-09-04") is True, "a pass resets: the next failure is a first failure again"
+
+
+def test_the_same_failed_artifact_is_counted_once(rec):
+    """2026-09-05: the verifier ran every 30 min, the producer three times a day;
+    the streak was a clock. A signature that has not changed is the same failure."""
+    r1 = rec.record("j", failed=True, today="2026-09-05", artifact_sig="log@100")
+    r2 = rec.record("j", failed=True, today="2026-09-05", artifact_sig="log@100")
+    r3 = rec.record("j", failed=True, today="2026-09-05", artifact_sig="log@200")
+    assert (r1["consecutive"], r1["same_artifact"]) == (1, False)
+    assert (r2["consecutive"], r2["same_artifact"]) == (1, True), "unchanged artifact: not counted again"
+    assert (r3["consecutive"], r3["same_artifact"]) == (2, False), "a regenerated artifact that still fails counts"
+
+
+def test_a_pass_keeps_the_task_id_for_the_verifier_to_close(rec):
+    for i in range(3):
+        rec.record("j", failed=True, today="2026-09-05", artifact_sig=f"log@{i}")
+    rec.note_task("j", "org-task-1")
+    r = rec.record("j", failed=False, today="2026-09-06")
+    assert r["consecutive"] == 0 and r["task_id"] == "org-task-1"
+    rec.note_task("j", None)
+    assert "task_id" not in rec._load()["j"]


### PR DESCRIPTION
The verifier runs every 30 minutes and a producer hourly or three times a day, so re-reading the same failed artifact counted mac-config-drift 8x and mac-id-churn 48x today for one and two real failures. A signature of the job's artifacts (path + mtime) is now recorded with each failure; an unchanged one is the same failure, neither counted nor alerted. The third consecutive failure files one task in the system space (SURFACE = machine, JOB = name, DONE_WHEN = the job passes), and the pass that ends the streak closes it. Tests cover both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)