### PR TITLE
projector: a housekeeping closure leaves the projection at once

### DIFF
--- a/.datacore/lib/ledger/projector.py
+++ b/.datacore/lib/ledger/projector.py
@@ -33,7 +33,7 @@ import hashlib
 from dataclasses import dataclass, replace
 from pathlib import Path
 
-from .fold import LedgerState
+from .fold import LedgerState, closure_kind
 
 #: The projection MUST declare its own todo keywords. Without this line
 #: org-mode's custom states (DEFERRED, QUEUED, WORKING, REVIEW, FAILED) parse
@@ -318,11 +318,18 @@ def projected_items(state: LedgerState, *, space: str | None = None) -> list:
     from nothing else, and deciding that with a second copy of this filter is
     how the two drift apart.
     """
+    # A housekeeping closure is not finished work: a twin dismissed after an
+    # id regeneration, or an orphan reconciled away, was never done or dropped
+    # by anyone. Rendering it for the retention day put the same :ID: in the
+    # file twice (2-datacore, 2026-09-05: two subtrees under a CANCELLED twin
+    # and its live successor), which the churn detector counted as duplicates
+    # and org-workspace's dedup would have "repaired" by minting fresh ids.
     return [
         item for item in state.items.values()
         if (item.status in LIVE_STATUSES
             or (item.status in CLOSED_STATUSES
-                and _closed_within(item, CLOSED_RETENTION_DAYS)))
+                and _closed_within(item, CLOSED_RETENTION_DAYS)
+                and closure_kind(item) != "housekeeping"))
         and (space is None or (item.payload or {}).get("space", space) == space)
     ]
 

--- a/.datacore/lib/tests/test_projector_housekeeping.py
+++ b/.datacore/lib/tests/test_projector_housekeeping.py
@@ -1,0 +1,36 @@
+"""A housekeeping closure is not finished work; the projection drops it at once (2026-09-05)."""
+import pathlib, sys, time
+LIB = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(LIB))
+from ledger.fold import ItemState          # noqa: E402
+from ledger.projector import projected_items  # noqa: E402
+
+
+class _State:
+    def __init__(self, items):
+        self.items = {i.id: i for i in items}
+
+
+def _closed(iid, reason, kind=None, status="dismissed"):
+    it = ItemState(id=iid, title="Consider DIP for the guard pattern", owner=None, status=status,
+                   payload={"level": 1, "state": "CANCELLED", "tags": []})
+    it.closed_at = f"{int(time.time() * 1000)}.0000.mac"   # just now, inside retention
+    it.closed_reason = reason
+    if kind:
+        it.closed_kind = kind
+    return it
+
+
+def test_a_twin_dismissed_as_housekeeping_is_not_rendered_for_the_retention_day():
+    live = ItemState(id="org-new", title="Consider DIP for the guard pattern", owner=None, status="created",
+                     payload={"level": 1, "state": "TODO", "tags": []})
+    twin = _closed("org-old", "duplicate: superseded by org-new after the 2026-08-11 id regeneration", kind="housekeeping")
+    ids = {i.id for i in projected_items(_State([live, twin]))}
+    assert ids == {"org-new"}, ids
+
+
+def test_work_actually_finished_today_is_still_shown():
+    done = _closed("org-done", "finished", status="completed")
+    dropped = _closed("org-dropped", "not doing this after review", kind="dropped")
+    ids = {i.id for i in projected_items(_State([done, dropped]))}
+    assert ids == {"org-done", "org-dropped"}, ids


### PR DESCRIPTION
A twin dismissed after an id regeneration, or an orphan reconciled away, is not finished work; rendering it for the retention day put the same :ID: in 2-datacore's generated file twice today, which the churn detector counted as duplicates and org-workspace's dedup would have repaired by minting fresh ids. Closure kind housekeeping now leaves at once; done and dropped keep their day. Two tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)