### PR TITLE
cadence liveness: a cadence owned by an external agent is that agent's liveness, not ours

### DIFF
--- a/.datacore/lib/cadence_liveness.py
+++ b/.datacore/lib/cadence_liveness.py
@@ -54,7 +54,7 @@ DEFAULT_GRACE = 3
 def collect(root: Path, grace: int, today: date | None = None) -> list:
     """Overdue cadences across every space, via the engine that owns this."""
     import yaml
-    from cadence_engine import (cadence_log_path_for, find_overdue_cadences,
+    from cadence_engine import (cadence_log_path_for, find_overdue_cadences, own_cadences,
                             load_cadence_log_safe)
 
     today = today or date.today()
@@ -87,7 +87,14 @@ def collect(root: Path, grace: int, today: date | None = None) -> list:
         except Exception:                       # noqa: BLE001
             continue
         try:
-            for c in find_overdue_cadences(roles, log, today=today):
+            # A cadence owned by an external agent (5-plur's cio is Tris on
+            # hermes) runs where that agent runs and records nothing in this
+            # fleet's shards, so this check can only ever call it overdue. The
+            # heartbeat already excludes those roles from its own work
+            # (own_cadences); the liveness must apply the same rule, or the
+            # box's contract is red by construction (2026-09-05: three of the
+            # last three "overdue" were Tris's).
+            for c in own_cadences(find_overdue_cadences(roles, log, today=today), roles):
                 if getattr(c, "days_overdue", 0) > grace:
                     rows.append((c.days_overdue, space.name, c.role,
                                  c.frequency, c.cadence_name))

--- a/.datacore/lib/tests/test_cadence_liveness.py
+++ b/.datacore/lib/tests/test_cadence_liveness.py
@@ -21,3 +21,26 @@ def test_archived_venture_contributes_no_overdue_rows(tmp_path):
     spaces = {r[1] for r in rows}
     assert "5-plur" in spaces, "a live venture with a never-run cadence is overdue"
     assert "4-forge" not in spaces, "an archived venture is off, not overdue"
+
+
+VENTURE_WITH_TRIS = """name: plur
+stage: growth
+roles:
+  cto:
+    cadences:
+      daily: [pr-review]
+  cio:
+    agent: tris
+    cadences:
+      weekly: [geo-sov-scan]
+"""
+
+
+def test_a_cadence_owned_by_an_external_agent_is_not_this_fleets_liveness(tmp_path):
+    """5-plur's cio is Tris on hermes; its runs never land in our shards, so
+    counting them made the box's contract red by construction (2026-09-05)."""
+    (tmp_path / "5-plur").mkdir(); (tmp_path / "5-plur" / "venture.yaml").write_text(VENTURE_WITH_TRIS)
+    rows = L.collect(tmp_path, grace=3, today=datetime.date(2026, 9, 5))
+    names = {(r[2], r[4]) for r in rows}
+    assert ("cto", "pr-review") in names, "our own never-run cadence is overdue"
+    assert ("cio", "geo-sov-scan") not in names, "Tris's cadence is Tris's liveness"


### PR DESCRIPTION
5-plur's cio role is Tris on hermes; its runs never land in this fleet's shards, so the liveness could only ever call its cadences overdue and the box's contract was red by construction. The heartbeat already excludes external-agent roles (own_cadences); the liveness now applies the same rule. One test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)