### PR TITLE
scoreboard: R5 and R2 are measured on the box, not assumed

### DIFF
--- a/.datacore/lib/reliability_scoreboard.py
+++ b/.datacore/lib/reliability_scoreboard.py
@@ -62,8 +62,14 @@ def r1_delivered(state: Path) -> tuple[bool, str]:
 
 
 def r2_loud(cos: Path, day: str) -> tuple[bool, str]:
+    """Every unit that failed TODAY has a sent alert, and no unit alert was
+    burst-suppressed. "Failed today" comes from the journal, not from
+    `systemctl --state=failed` at scoreboard time: a unit that failed at 03:00
+    and was green again by 08:10 is exactly the failure this must not miss.
+    When the journal is unreadable the currently failed units are the
+    fallback and the note says so."""
     sup = [l for l in _lines(cos / "alerts" / "suppressed.log") if l.startswith(f"[{day}") and "burst" in l and "unit-failed:" in l]
-    failed = _failed_units()
+    failed, source = _failed_units_today(day)
     sent = _lines(cos / "alerts" / ".sent-log")
     day_start = dt.datetime.fromisoformat(day).timestamp()
     sent_units = {l.split("unit-failed:", 1)[1].strip() for l in sent
@@ -75,7 +81,31 @@ def r2_loud(cos: Path, day: str) -> tuple[bool, str]:
         notes.append(f"{len(sup)} unit alert(s) burst-suppressed")
     if silent:
         notes.append("failed without a sent alert: " + ", ".join(silent))
-    return ok, ("; ".join(notes) or f"{len(sent_units)} unit alert(s) sent, none suppressed")
+    return ok, ("; ".join(notes) or f"{len(failed)} unit failure(s) today, {len(sent_units)} alerted, none suppressed ({source})")
+
+
+def _journal(args: list[str]) -> str:
+    """The system journal. Plain first (the installer puts the CoS user in
+    systemd-journal); `sudo -n` as the fallback on a box where that has not
+    happened yet, so the day is measured rather than reported unreadable."""
+    for cmd in (["journalctl"], ["sudo", "-n", "journalctl"]):
+        try:
+            out = subprocess.run([*cmd, "--no-pager", "-q", *args], capture_output=True, text=True, timeout=60).stdout
+        except (OSError, subprocess.SubprocessError):
+            out = ""
+        if out.strip():
+            return out
+    return ""
+
+
+_FAILED_RE = re.compile(r"systemd\[1\]: ([A-Za-z0-9@._-]+\.service): Failed with result")
+
+
+def _failed_units_today(day: str) -> tuple[set[str], str]:
+    out = _journal(["--since", f"{day} 00:00"])
+    if out:
+        return {m.group(1) for m in _FAILED_RE.finditer(out) if not m.group(1).startswith("alert@")}, "journal"
+    return _failed_units(), "journal unreadable; currently failed units only"
 
 
 def _failed_units() -> set[str]:
@@ -108,13 +138,35 @@ def r4_data_safe(cos: Path, state: Path, now: float) -> tuple[bool, str]:
     return ok, ("; ".join(notes) or "backup offsite, restore proven, fleet converging")
 
 
-def r5_reachable(state: Path, day: str) -> tuple[bool, str]:
+#: The off-box prober's address, as it appears in the daemon's request log.
+PROBER_IP = os.environ.get("COS_PROBER_IP", "100.101.159.42")
+PROBE_MINUTES = int(os.environ.get("COS_PROBE_MINUTES", "15"))
+
+
+def r5_reachable(state: Path, day: str, now: float | None = None) -> tuple[bool, str]:
+    """Measured ON THE BOX from the prober's own hits.
+
+    The probe runs on another host and writes its log there; reading that
+    log here passed vacuously ("no probe log on this host") on 2026-09-05.
+    The daemon logs every GET /health with the caller's address, so the
+    number of hits from the prober today, against the number of probes the
+    day has had time for, is the reachability record the box itself holds.
+    The prober's own log stays the answer on the prober."""
     rows = [l for l in _lines(state / "cos-uptime.log") if l.startswith(day)]
-    if not rows:
-        return True, "no probe log on this host (measured on the prober)"
-    up = sum(1 for l in rows if " UP " in l)
-    ratio = up / len(rows)
-    return ratio >= 0.995, f"{up}/{len(rows)} probes UP ({ratio:.1%})"
+    if rows:
+        up = sum(1 for l in rows if " UP " in l)
+        return up / len(rows) >= 0.995, f"{up}/{len(rows)} probes UP (prober log)"
+    out = _journal(["-u", "datacored", "--since", f"{day} 00:00"])
+    if not out:
+        return False, "no probe log here and the daemon journal is unreadable"
+    hits = sum(1 for l in out.splitlines() if "GET /health" in l and PROBER_IP in l)
+    now = now or dt.datetime.now().timestamp()
+    elapsed_min = max(0.0, (now - dt.datetime.fromisoformat(day).timestamp()) / 60)
+    expected = int(elapsed_min // PROBE_MINUTES)
+    if expected < 4:
+        return True, f"{hits} probe hit(s) so far; too early to judge"
+    ok = hits >= expected - max(1, expected // 200)
+    return ok, f"{hits}/{expected} probe hits from {PROBER_IP} today"
 
 
 def r6_rebuildable(cos: Path, day: str) -> tuple[bool, str]:
@@ -134,7 +186,7 @@ def compute(day: str, state: Path, cos: Path, now: float | None = None) -> dict:
     now = now or dt.datetime.now().timestamp()
     checks = {
         "R1": r1_delivered(state), "R2": r2_loud(cos, day), "R3": r3_unattended(cos, day),
-        "R4": r4_data_safe(cos, state, now), "R5": r5_reachable(state, day), "R6": r6_rebuildable(cos, day),
+        "R4": r4_data_safe(cos, state, now), "R5": r5_reachable(state, day, now), "R6": r6_rebuildable(cos, day),
     }
     passed = all(ok for ok, _ in checks.values())
     log = state / "reliability-scoreboard.log"

--- a/.datacore/lib/tests/test_reliability_scoreboard.py
+++ b/.datacore/lib/tests/test_reliability_scoreboard.py
@@ -54,3 +54,30 @@ def test_each_failure_class_fails_its_own_condition(tmp_path, monkeypatch):
     assert not M.compute(day, state, cos)["checks"]["R6"]["ok"]
     (state / "cos-uptime.log").write_text(f"{day}T01:00:01Z DOWN\n" + "".join(f"{day}T{h:02d}:00:01Z UP\n" for h in range(2, 24)))
     assert not M.compute(day, state, cos)["checks"]["R5"]["ok"]
+
+
+def test_r5_is_measured_from_the_probers_hits_when_no_probe_log_is_here(tmp_path, monkeypatch):
+    day = "2026-09-05"; state, cos = _good_box(tmp_path, day)
+    (state / "cos-uptime.log").unlink()
+    now = dt.datetime.fromisoformat(day).timestamp() + 8 * 3600          # 08:00 -> 32 probes expected
+    hits = "\n".join(f"Sep 05 0{i//4}:{(i%4)*15:02d}:01 bridge python[1]: INFO:     100.101.159.42:5 - \"GET /health HTTP/1.1\" 200 OK" for i in range(32))
+    monkeypatch.setattr(M, "_journal", lambda args: hits if "-u" in args else "")
+    monkeypatch.setattr(M, "_failed_units", lambda: set())
+    r = M.compute(day, state, cos, now=now)
+    assert r["checks"]["R5"]["ok"] and "32/32" in r["checks"]["R5"]["note"], r["checks"]["R5"]
+    few = "\n".join(hits.splitlines()[:20])
+    monkeypatch.setattr(M, "_journal", lambda args: few if "-u" in args else "")
+    r = M.compute(day, state, cos, now=now)
+    assert not r["checks"]["R5"]["ok"] and "20/32" in r["checks"]["R5"]["note"]
+
+
+def test_r2_sees_a_unit_that_failed_and_recovered_during_the_day(tmp_path, monkeypatch):
+    day = "2026-09-05"; state, cos = _good_box(tmp_path, day)
+    journal = "Sep 05 03:00:01 bridge systemd[1]: v2-verify.service: Failed with result 'exit-code'.\n"
+    monkeypatch.setattr(M, "_journal", lambda args: journal if "-u" not in args else "")
+    monkeypatch.setattr(M, "_failed_units", lambda: set())          # green again by scoreboard time
+    r = M.compute(day, state, cos)
+    assert not r["checks"]["R2"]["ok"] and "v2-verify.service" in r["checks"]["R2"]["note"]
+    (cos / "alerts" / ".sent-log").write_text(f"{int(dt.datetime.fromisoformat(day).timestamp()) + 3600} unit http=200 unit-failed:v2-verify.service\n")
+    r = M.compute(day, state, cos)
+    assert r["checks"]["R2"]["ok"], r["checks"]["R2"]


### PR DESCRIPTION
R5 read the prober's log, which lives on the prober, and passed vacuously on the box; it now counts the prober's GET /health hits in the daemon journal against the probes the day has had time for. R2 read the currently failed units at scoreboard time and missed a unit that failed and recovered; it now takes the day's failures from the journal and checks each has a sent alert. Two tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)