### PR TITLE
scoreboard: R4 reads the fleet sync's own result and age, never a vacuous pass

### DIFF
--- a/.datacore/lib/reliability_scoreboard.py
+++ b/.datacore/lib/reliability_scoreboard.py
@@ -30,6 +30,7 @@ import json
 import os
 import re
 import subprocess
+import time
 from pathlib import Path
 
 HOME = Path(os.environ.get("COS_HOME", str(Path.home())))
@@ -132,10 +133,66 @@ def r4_data_safe(cos: Path, state: Path, now: float) -> tuple[bool, str]:
     rage = _age_hours(cos / "restore-check.log", now)
     if not rl or rage is None or rage > 8 * 24 or "restore-check ok" not in rl[-1]:
         ok = False; notes.append("restore check: " + (rl[-1][-60:] if rl else "never run"))
-    fs = _lines(state / "fleet-sync.log")
-    if fs and any(l.startswith("FAIL") for l in fs[-3:]):
-        ok = False; notes.append("fleet sync: " + next(l for l in reversed(fs) if l.startswith("FAIL"))[:70])
+    fs_ok, fs_note = _fleet_sync_state(state, now)
+    if not fs_ok:
+        ok = False; notes.append("fleet sync: " + fs_note)
     return ok, ("; ".join(notes) or "backup offsite, restore proven, fleet converging")
+
+
+FLEET_SYNC_UNIT = "datacore-fleet-sync.service"
+FLEET_SYNC_MAX_AGE_H = 14  # the timer fires at 06:10 and 18:10; a run older than this means the timer stopped
+
+
+def _unit_show(unit: str) -> dict:
+    """systemd's own record of a unit's last run, or {} where there is no such unit."""
+    try:
+        out = subprocess.run(["systemctl", "show", "-p", "LoadState", "-p", "Result", "-p", "ExecMainExitTimestamp", unit],
+                             capture_output=True, text=True, timeout=20).stdout
+    except (OSError, subprocess.SubprocessError):
+        return {}
+    d = dict(l.split("=", 1) for l in out.splitlines() if "=" in l)
+    return d if d.get("LoadState") == "loaded" else {}
+
+
+def _systemd_epoch(ts: str) -> float | None:
+    """'Sat 2026-09-05 18:20:32 UTC' -> epoch. Empty (never ran) -> None."""
+    m = re.search(r"(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) ?(\S*)", ts or "")
+    if not m:
+        return None
+    naive = dt.datetime.strptime(m.group(1), "%Y-%m-%d %H:%M:%S")
+    if m.group(2) in ("UTC", "GMT", "Z"):
+        return naive.replace(tzinfo=dt.timezone.utc).timestamp()
+    return time.mktime(naive.timetuple())
+
+
+def _fleet_sync_state(state: Path, now: float) -> tuple[bool, str]:
+    """Did the fleet sync run recently and succeed? Never vacuous.
+
+    Until 2026-09-05 this looked for a FAIL line in the last three lines of
+    whatever log was there, so a host with no log passed, and a host whose
+    timer had stopped kept passing on its last report. Where the sync is a
+    systemd unit, its own Result and exit time are the record; the log is
+    the fallback, and "nothing to read" is a failure, not a pass.
+    """
+    unit = _unit_show(FLEET_SYNC_UNIT)
+    if unit:
+        exit_at = _systemd_epoch(unit.get("ExecMainExitTimestamp", ""))
+        if exit_at is None:
+            return False, "unit never ran"
+        age_h = (now - exit_at) / 3600
+        if unit.get("Result") != "success":
+            return False, f"last run {unit.get('Result') or 'unknown'} ({age_h:.0f}h ago)"
+        if age_h > FLEET_SYNC_MAX_AGE_H:
+            return False, f"last run {age_h:.0f}h ago (timer stopped?)"
+        return True, "ok"
+    fs = _lines(state / "fleet-sync.log")
+    if not fs:
+        return False, "never observed (no unit, no log)"
+    age_h = _age_hours(state / "fleet-sync.log", now)
+    if age_h is None or age_h > FLEET_SYNC_MAX_AGE_H:
+        return False, f"log {age_h:.0f}h old" if age_h is not None else "log unreadable"
+    bad = [l for l in fs if l.startswith("FAIL")]
+    return (not bad), (bad[-1][:70] if bad else "ok")
 
 
 #: The off-box prober's address, as it appears in the daemon's request log.

--- a/.datacore/lib/tests/test_reliability_scoreboard.py
+++ b/.datacore/lib/tests/test_reliability_scoreboard.py
@@ -4,6 +4,7 @@ import datetime as dt, importlib.util, json, os, pathlib, time
 LIB = pathlib.Path(__file__).resolve().parents[1]
 spec = importlib.util.spec_from_file_location("rs", LIB / "reliability_scoreboard.py")
 M = importlib.util.module_from_spec(spec); spec.loader.exec_module(M)
+M._unit_show = lambda unit: {}  # no systemd in the test box; each test says what the unit reports
 
 
 def _good_box(tmp_path, day):
@@ -81,3 +82,32 @@ def test_r2_sees_a_unit_that_failed_and_recovered_during_the_day(tmp_path, monke
     (cos / "alerts" / ".sent-log").write_text(f"{int(dt.datetime.fromisoformat(day).timestamp()) + 3600} unit http=200 unit-failed:v2-verify.service\n")
     r = M.compute(day, state, cos)
     assert r["checks"]["R2"]["ok"], r["checks"]["R2"]
+
+
+def test_r4_fleet_sync_is_never_vacuous(tmp_path, monkeypatch):
+    day = "2026-09-05"; state, cos = _good_box(tmp_path, day)
+    (state / "fleet-sync.log").unlink()
+    r = M.compute(day, state, cos)
+    assert not r["checks"]["R4"]["ok"] and "never observed" in r["checks"]["R4"]["note"]
+    (state / "fleet-sync.log").write_text("1-datafund  [main]\n  clean (pulled)\n")
+    old = time.time() - 20 * 3600
+    os.utime(state / "fleet-sync.log", (old, old))
+    r = M.compute(day, state, cos)
+    assert not r["checks"]["R4"]["ok"] and "20h old" in r["checks"]["R4"]["note"]
+
+
+def test_r4_reads_the_units_own_result_where_there_is_one(tmp_path, monkeypatch):
+    day = "2026-09-05"; state, cos = _good_box(tmp_path, day)
+    now = time.time()
+    stamp = lambda h: dt.datetime.fromtimestamp(now - h * 3600, dt.timezone.utc).strftime("%a %Y-%m-%d %H:%M:%S UTC")
+    monkeypatch.setattr(M, "_unit_show", lambda unit: {"LoadState": "loaded", "Result": "exit-code", "ExecMainExitTimestamp": stamp(1)})
+    r = M.compute(day, state, cos, now=now)
+    assert not r["checks"]["R4"]["ok"] and "last run exit-code" in r["checks"]["R4"]["note"]
+    monkeypatch.setattr(M, "_unit_show", lambda unit: {"LoadState": "loaded", "Result": "success", "ExecMainExitTimestamp": stamp(20)})
+    r = M.compute(day, state, cos, now=now)
+    assert not r["checks"]["R4"]["ok"] and "timer stopped" in r["checks"]["R4"]["note"]
+    monkeypatch.setattr(M, "_unit_show", lambda unit: {"LoadState": "loaded", "Result": "success", "ExecMainExitTimestamp": ""})
+    assert "never ran" in M.compute(day, state, cos, now=now)["checks"]["R4"]["note"]
+    (state / "fleet-sync.log").write_text("FAIL: stale text from a run that has since succeeded\n")
+    monkeypatch.setattr(M, "_unit_show", lambda unit: {"LoadState": "loaded", "Result": "success", "ExecMainExitTimestamp": stamp(2)})
+    assert M.compute(day, state, cos, now=now)["checks"]["R4"]["ok"]


### PR DESCRIPTION
R4's fleet-sync branch passed on a missing log, on a stopped timer, and on a FAIL line above the trailing Note. It now reads the unit's Result and exit time (fails on any result but success, on a run older than 14h, on never-ran) and falls back to a fresh, FAIL-free log only where there is no unit. Nothing to read is a failure. Six new assertions, 7 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)