### PR TITLE
identity: one resolver for every writer, a principals registry, authorship verified per log

### DIFF
--- a/.datacore/lib/actor_identity.py
+++ b/.datacore/lib/actor_identity.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Who is writing? One declared answer per machine, never an inference (DIP-0044).
+
+Every ledger writer, sealer, verifier and adapter used to resolve its own
+identity with `os.environ.get("DATACORE_ACTOR") or socket.gethostname()`,
+copied into twenty-four files. The copies disagreed on case and on whether to
+strip the domain, and every one of them fell back to the hostname, which is
+how one laptop wrote under `mac`, `Mac`, `Mac.home` and `air-23.local`, and
+how nightshift's events were filed under a hostname instead of the actor the
+registry declares. This is the one resolver they all call.
+
+Order, first hit wins:
+
+  1. `DATACORE_ACTOR` in the environment (a service unit, a test).
+  2. `~/.datacore/identity.env` (the machine's declaration, written once).
+  3. The infrastructure registry: `servers.<name>.access.actor` where
+     `access.hostname` or the server name equals this hostname. The hostname
+     is a lookup key here, not the answer.
+  4. Nothing. `this_actor()` then returns the lowercase short hostname and
+     says so on stderr once, so an undeclared machine still writes (an event
+     lost is worse than an event misfiled) but never silently. `strict=True`
+     raises instead, for callers that must not guess.
+
+`principals.yaml` binds writers to principals: which git identities may
+append to a writer's log, which host it runs on, what it owns. `verify`
+uses it to check that a log was only ever appended by its own principal.
+"""
+from __future__ import annotations
+
+import os
+import socket
+import sys
+from pathlib import Path
+
+LIB = Path(__file__).resolve().parent
+REGISTRY_DIR = LIB.parent / "registry"
+INFRA = REGISTRY_DIR / "infrastructure.yaml"
+PRINCIPALS = REGISTRY_DIR / "principals.yaml"
+IDENTITY_FILE = Path(os.environ.get("DATACORE_IDENTITY_FILE", str(Path.home() / ".datacore" / "identity.env")))
+
+_warned = False
+
+
+class UndeclaredActor(RuntimeError):
+    """No declaration for this machine: no env, no identity file, no registry row."""
+
+
+def _parse_env_file(p: Path) -> dict:
+    out: dict[str, str] = {}
+    try:
+        text = p.read_text(encoding="utf-8")
+    except OSError:
+        return out
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        if line.startswith("export "):
+            line = line[len("export "):].lstrip()
+        k, v = line.split("=", 1)
+        v = v.strip()
+        if len(v) >= 2 and v[0] == v[-1] and v[0] in "\"'":
+            v = v[1:-1]
+        out[k.strip()] = v
+    return out
+
+
+def short_hostname() -> str:
+    return socket.gethostname().split(".")[0].lower()
+
+
+def registry_actor(hostname: str | None = None, infra: Path = INFRA) -> str | None:
+    """The actor the registry declares for this hostname, or None."""
+    host = (hostname or short_hostname()).lower()
+    try:
+        import yaml
+        reg = yaml.safe_load(infra.read_text(encoding="utf-8")) or {}
+    except Exception:  # noqa: BLE001 — a registry problem must not stop a writer
+        return None
+    for name, cfg in (reg.get("servers") or {}).items():
+        if not isinstance(cfg, dict):
+            continue
+        access = cfg.get("access") or {}
+        declared_host = str(access.get("hostname") or "").lower()
+        if host in (declared_host, str(name).lower()) and access.get("actor"):
+            return str(access["actor"]).strip().lower()
+    return None
+
+
+def resolve(identity_file: Path | None = None, infra: Path | None = None) -> tuple[str | None, str]:
+    """(actor, source). source is env | identity.env | registry | none."""
+    identity_file = identity_file or IDENTITY_FILE
+    infra = infra or INFRA
+    env = (os.environ.get("DATACORE_ACTOR") or "").strip().lower()
+    if env:
+        return env, "env"
+    declared = (_parse_env_file(identity_file).get("DATACORE_ACTOR") or "").strip().lower()
+    if declared:
+        return declared, "identity.env"
+    reg = registry_actor(infra=infra)
+    if reg:
+        return reg, "registry"
+    return None, "none"
+
+
+def this_actor(strict: bool = False) -> str:
+    global _warned
+    actor, source = resolve()
+    if actor:
+        return actor
+    host = short_hostname()
+    if strict:
+        raise UndeclaredActor(
+            f"no actor declared for {host!r}: set DATACORE_ACTOR in {IDENTITY_FILE} "
+            f"or add servers.<name>.access.actor to {INFRA} (DIP-0044)")
+    if not _warned:
+        _warned = True
+        print(f"actor_identity: no declaration for {host!r}; writing as {host!r}. "
+              f"Declare DATACORE_ACTOR in {IDENTITY_FILE} (DIP-0044).", file=sys.stderr)
+    return host
+
+
+def actor_source() -> str:
+    return resolve()[1]
+
+
+def principals(path: Path = PRINCIPALS) -> dict:
+    try:
+        import yaml
+        return (yaml.safe_load(path.read_text(encoding="utf-8")) or {}).get("principals") or {}
+    except Exception:  # noqa: BLE001
+        return {}
+
+
+def principal_of(actor: str, path: Path = PRINCIPALS) -> tuple[str | None, dict]:
+    """The principal a writer log belongs to: its own entry, or the one listing it under writes_as."""
+    ps = principals(path)
+    a = actor.lower()
+    if a in ps:
+        return a, ps[a]
+    for name, p in ps.items():
+        if a in [str(w).lower() for w in (p.get("writes_as") or [])]:
+            return name, p
+    return None, {}
+
+
+def allowed_emails(actor: str, path: Path = PRINCIPALS) -> set[str]:
+    """Git author emails that may append to this writer's log. Empty = unbound."""
+    _, p = principal_of(actor, path)
+    return {str(e).lower() for e in (p.get("emails") or [])}
+
+
+if __name__ == "__main__":
+    a, src = resolve()
+    print(f"{a or short_hostname()} ({src})")
+    raise SystemExit(0 if a else 1)

--- a/.datacore/lib/base.py
+++ b/.datacore/lib/base.py
@@ -148,7 +148,14 @@ def get_executor(name: str | None = None) -> "Executor":
 def _default_actor() -> str:
     """Actor resolution mirrors `ledger_cli.py` / `job_verify.py`:
     `$DATACORE_ACTOR`, else `socket.gethostname()`."""
-    return os.environ.get("DATACORE_ACTOR") or socket.gethostname()
+    try:
+        from actor_identity import this_actor
+    except ImportError:
+        import importlib.util as _ilu, pathlib as _pl
+        _spec = _ilu.spec_from_file_location("actor_identity", _pl.Path(__file__).resolve().parent / "actor_identity.py")
+        _m = _ilu.module_from_spec(_spec); _spec.loader.exec_module(_m)
+        this_actor = _m.this_actor
+    return this_actor()
 
 
 def _default_space_dir() -> Path:

--- a/.datacore/lib/executors/base.py
+++ b/.datacore/lib/executors/base.py
@@ -148,7 +148,14 @@ def get_executor(name: str | None = None) -> "Executor":
 def _default_actor() -> str:
     """Actor resolution mirrors `ledger_cli.py` / `job_verify.py`:
     `$DATACORE_ACTOR`, else `socket.gethostname()`."""
-    return os.environ.get("DATACORE_ACTOR") or socket.gethostname()
+    try:
+        from actor_identity import this_actor
+    except ImportError:
+        import importlib.util as _ilu, pathlib as _pl
+        _spec = _ilu.spec_from_file_location("actor_identity", _pl.Path(__file__).resolve().parent / "actor_identity.py")
+        _m = _ilu.module_from_spec(_spec); _spec.loader.exec_module(_m)
+        this_actor = _m.this_actor
+    return this_actor()
 
 
 def _default_space_dir() -> Path:

--- a/.datacore/lib/job_verify.py
+++ b/.datacore/lib/job_verify.py
@@ -88,7 +88,14 @@ WINSTON_SEND = (
 
 
 def _default_actor() -> str:
-    return os.environ.get("DATACORE_ACTOR") or socket.gethostname()
+    try:
+        from actor_identity import this_actor
+    except ImportError:
+        import importlib.util as _ilu, pathlib as _pl
+        _spec = _ilu.spec_from_file_location("actor_identity", _pl.Path(__file__).resolve().parent / "actor_identity.py")
+        _m = _ilu.module_from_spec(_spec); _spec.loader.exec_module(_m)
+        this_actor = _m.this_actor
+    return this_actor()
 
 
 def _default_manifest_path() -> Path:

--- a/.datacore/lib/ledger_attest.py
+++ b/.datacore/lib/ledger_attest.py
@@ -148,36 +148,22 @@ def _identity() -> dict:
 
 def _actor() -> str:
     """This machine's ledger identity. Never inferred from a hostname — see
-    DIP-0044: winston's hostname is `bridge`, hermes runs `tris`."""
+    DIP-0044: winston's hostname is `bridge`, hermes runs `tris`.
+
+    The env var and this module's own identity file are consulted first (the
+    attest path must keep working with the identity file it was told to use);
+    everything else is the shared resolver in actor_identity.py."""
     explicit = os.environ.get("DATACORE_ACTOR") or _identity().get("DATACORE_ACTOR")
     if explicit:
         return explicit.strip().lower()
-    host = socket.gethostname().split(".")[0].lower()
     try:
-        import yaml
-        # Find the registry relative to THIS FILE, not DATACORE_ROOT. On hermes
-        # and plur-claw `~/Data` is the AGENT'S OWN SPACE repo and the core
-        # lives in the runner, so a DATACORE_ROOT lookup finds no registry,
-        # falls through to the hostname, and files tris's events under
-        # `transporter` and data's under `holodeck` — the exact DIP-0044
-        # failure this function's own comment warns about. Verified on all five
-        # machines; two were wrong until this changed.
-        candidates = [LIB.parent.parent / ".datacore/registry/infrastructure.yaml",
-                      Path(os.environ.get("DATACORE_ROOT", str(Path.home() / "Data")))
-                      / ".datacore/registry/infrastructure.yaml"]
-        reg_path = next((c for c in candidates if c.is_file()), None)
-        if reg_path is None:
-            raise FileNotFoundError("no infrastructure registry")
-        reg = yaml.safe_load(reg_path.read_text())
-        for name, cfg in (reg.get("servers") or {}).items():
-            if not isinstance(cfg, dict):
-                continue
-            access = cfg.get("access") or {}
-            if host in (access.get("hostname"), name) and access.get("actor"):
-                return str(access["actor"]).lower()
-    except Exception:  # noqa: BLE001 — a registry problem must not stop a post
-        pass
-    return host
+        from actor_identity import this_actor
+    except ImportError:
+        import importlib.util as _ilu, pathlib as _pl
+        _spec = _ilu.spec_from_file_location("actor_identity", _pl.Path(__file__).resolve().parent / "actor_identity.py")
+        _m = _ilu.module_from_spec(_spec); _spec.loader.exec_module(_m)
+        this_actor = _m.this_actor
+    return this_actor()
 
 
 def _roots() -> list[Path]:

--- a/.datacore/lib/ledger_cli.py
+++ b/.datacore/lib/ledger_cli.py
@@ -42,7 +42,14 @@ from ledger.verify import check_not_rewound, verify_chain  # noqa: E402
 
 
 def _default_actor() -> str:
-    return os.environ.get("DATACORE_ACTOR") or socket.gethostname()
+    try:
+        from actor_identity import this_actor
+    except ImportError:
+        import importlib.util as _ilu, pathlib as _pl
+        _spec = _ilu.spec_from_file_location("actor_identity", _pl.Path(__file__).resolve().parent / "actor_identity.py")
+        _m = _ilu.module_from_spec(_spec); _spec.loader.exec_module(_m)
+        this_actor = _m.this_actor
+    return this_actor()
 
 
 def _json_dict(raw: str) -> dict:

--- a/.datacore/lib/ledger_dismiss_orphans.py
+++ b/.datacore/lib/ledger_dismiss_orphans.py
@@ -77,7 +77,14 @@ ID_RE = re.compile(r":ID:\s*(\S+)")
 
 
 def _actor() -> str:
-    return os.environ.get("DATACORE_ACTOR") or socket.gethostname().split(".")[0]
+    try:
+        from actor_identity import this_actor
+    except ImportError:
+        import importlib.util as _ilu, pathlib as _pl
+        _spec = _ilu.spec_from_file_location("actor_identity", _pl.Path(__file__).resolve().parent / "actor_identity.py")
+        _m = _ilu.module_from_spec(_spec); _spec.loader.exec_module(_m)
+        this_actor = _m.this_actor
+    return this_actor()
 
 
 #: Generated org, which must NOT count as evidence org still has the task.

--- a/.datacore/lib/ledger_ingest_org.py
+++ b/.datacore/lib/ledger_ingest_org.py
@@ -81,25 +81,14 @@ def _this_actor() -> str:
     default actor silently breaks that for every machine except the one the
     default names.
     """
-    import socket
-    explicit = os.environ.get("DATACORE_ACTOR")
-    if explicit:
-        return explicit.strip().lower()
-    host = socket.gethostname().split(".")[0].lower()
     try:
-        import yaml
-        reg = yaml.safe_load(
-            (LIB.parent / "registry" / "infrastructure.yaml").read_text())
-        for name, cfg in (reg.get("servers") or {}).items():
-            if not isinstance(cfg, dict):
-                continue
-            access = cfg.get("access") or {}
-            if host in (access.get("hostname"), name) and access.get("actor"):
-                return str(access["actor"]).lower()
-    except Exception:  # noqa: BLE001
-        pass
-    return host
-
+        from actor_identity import this_actor
+    except ImportError:
+        import importlib.util as _ilu, pathlib as _pl
+        _spec = _ilu.spec_from_file_location("actor_identity", _pl.Path(__file__).resolve().parent / "actor_identity.py")
+        _m = _ilu.module_from_spec(_spec); _spec.loader.exec_module(_m)
+        this_actor = _m.this_actor
+    return this_actor()
 
 def sync_state(space: Path, actor: str | None = None, dry_run: bool = False) -> dict:
     """Reconcile an already-imported task with what org says about it NOW.

--- a/.datacore/lib/ledger_phase1_prepare.py
+++ b/.datacore/lib/ledger_phase1_prepare.py
@@ -137,7 +137,8 @@ def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
     ap.add_argument("--root", type=Path, default=Path(os.environ.get("DATACORE_ROOT", Path.home() / "Data")))
     ap.add_argument("--space", required=True)
-    ap.add_argument("--actor", default=os.environ.get("DATACORE_ACTOR") or os.uname().nodename.split(".")[0])
+    from actor_identity import this_actor
+    ap.add_argument("--actor", default=this_actor())
     ap.add_argument("--apply", action="store_true")
     a = ap.parse_args(argv)
     space = a.root / a.space

--- a/.datacore/lib/ledger_probe.py
+++ b/.datacore/lib/ledger_probe.py
@@ -38,7 +38,8 @@ PROBE_TITLE = "ledger probe — end to end"
 
 def main() -> int:
     ap = argparse.ArgumentParser()
-    ap.add_argument("--actor", default=socket.gethostname())
+    from actor_identity import this_actor
+    ap.add_argument("--actor", default=this_actor())
     args = ap.parse_args()
     actor = args.actor
 

--- a/.datacore/lib/ledger_seal.py
+++ b/.datacore/lib/ledger_seal.py
@@ -30,8 +30,14 @@ SEQUENCER = os.environ.get("DATACORE_SEQUENCER", "winston")
 
 
 def _actor() -> str:
-    return (os.environ.get("DATACORE_ACTOR")
-            or socket.gethostname().split(".")[0].lower())
+    try:
+        from actor_identity import this_actor
+    except ImportError:
+        import importlib.util as _ilu, pathlib as _pl
+        _spec = _ilu.spec_from_file_location("actor_identity", _pl.Path(__file__).resolve().parent / "actor_identity.py")
+        _m = _ilu.module_from_spec(_spec); _spec.loader.exec_module(_m)
+        this_actor = _m.this_actor
+    return this_actor()
 
 
 def _root() -> Path:

--- a/.datacore/lib/org_workspace_adapter.py
+++ b/.datacore/lib/org_workspace_adapter.py
@@ -202,7 +202,8 @@ def _ledger_emit(file_path, event_type, payload):
             return None
         _sys.path.insert(0, str(Path(__file__).resolve().parent))
         from ledger.log import EventLog
-        actor = _os.environ.get("DATACORE_ACTOR") or _socket.gethostname().split(".")[0].lower()
+        from actor_identity import this_actor
+        actor = this_actor()
         EventLog(space, actor).append(event_type, payload)
         return actor
     except Exception:      # noqa: BLE001 — see the note above

--- a/.datacore/lib/tests/fixtures/jobs/box-reliability-scoreboard.0.txt
+++ b/.datacore/lib/tests/fixtures/jobs/box-reliability-scoreboard.0.txt
@@ -1,0 +1,1 @@
+2026-09-05 FAIL streak=0 level=3 R1=FAIL R2=FAIL R3=FAIL R4=ok R5=FAIL R6=ok | R1: recurring: box-cadence-liveness; R2: 2 unit alert(s) burst-suppressed; failed without a sent alert: v2-verify.service; R3: 5 hand intervention(s) logged; R5: 26/82 probe hits from 100.101.159.42 today

--- a/.datacore/lib/tests/test_actor_identity.py
+++ b/.datacore/lib/tests/test_actor_identity.py
@@ -1,0 +1,58 @@
+"""One resolver, one order: env, identity file, registry, then hostname with a warning."""
+import importlib.util, os, pathlib, sys
+
+LIB = pathlib.Path(__file__).resolve().parents[1]
+spec = importlib.util.spec_from_file_location("ai", LIB / "actor_identity.py")
+AI = importlib.util.module_from_spec(spec); spec.loader.exec_module(AI)
+
+
+def _infra(tmp_path, hostname="bridge", actor="winston"):
+    p = tmp_path / "infrastructure.yaml"
+    p.write_text(f"servers:\n  winston:\n    access:\n      actor: {actor}\n      hostname: {hostname}\n")
+    return p
+
+
+def test_env_wins_then_identity_file_then_registry(tmp_path, monkeypatch):
+    ident = tmp_path / "identity.env"; ident.write_text("export DATACORE_ACTOR='data'\n")
+    infra = _infra(tmp_path, hostname=AI.short_hostname())
+    monkeypatch.setenv("DATACORE_ACTOR", "Tris")
+    assert AI.resolve(ident, infra) == ("tris", "env")
+    monkeypatch.delenv("DATACORE_ACTOR")
+    assert AI.resolve(ident, infra) == ("data", "identity.env")
+    ident.unlink()
+    assert AI.resolve(ident, infra) == ("winston", "registry")
+
+
+def test_registry_matches_hostname_or_server_name_and_lowercases(tmp_path):
+    infra = _infra(tmp_path, hostname="Bridge", actor="Winston")
+    assert AI.registry_actor("bridge", infra) == "winston"
+    assert AI.registry_actor("winston", infra) == "winston"
+    assert AI.registry_actor("nowhere", infra) is None
+
+
+def test_undeclared_machine_warns_once_and_strict_raises(tmp_path, monkeypatch, capsys):
+    monkeypatch.delenv("DATACORE_ACTOR", raising=False)
+    monkeypatch.setattr(AI, "IDENTITY_FILE", tmp_path / "none.env")
+    monkeypatch.setattr(AI, "INFRA", tmp_path / "none.yaml")
+    monkeypatch.setattr(AI, "_warned", False)
+    assert AI.this_actor() == AI.short_hostname()
+    assert AI.this_actor() == AI.short_hostname()
+    assert capsys.readouterr().err.count("no declaration") == 1
+    import pytest
+    with pytest.raises(AI.UndeclaredActor):
+        AI.this_actor(strict=True)
+
+
+def test_principal_binds_writer_logs_to_emails(tmp_path):
+    p = tmp_path / "principals.yaml"
+    p.write_text("principals:\n  miles:\n    emails: [miles@datacore.one]\n    writes_as: [miles, nightshift]\n")
+    assert AI.principal_of("nightshift", p)[0] == "miles"
+    assert AI.allowed_emails("NIGHTSHIFT", p) == {"miles@datacore.one"}
+    assert AI.allowed_emails("unknown", p) == set()
+
+
+def test_the_real_registry_declares_every_known_writer():
+    ps = AI.principals()
+    bound = {w for p in ps.values() for w in (p.get("writes_as") or [])} | set(ps)
+    for writer in ("mac", "winston", "miles", "nightshift", "tris", "data", "genesis", "bridge"):
+        assert writer in bound, writer

--- a/.datacore/lib/v2_verify.py
+++ b/.datacore/lib/v2_verify.py
@@ -271,6 +271,50 @@ def check_identity(rep: Report) -> None:
             "aligned" if not split else f"differ on: {', '.join(split)}")
 
 
+
+def check_writer_authorship(rep: Report) -> None:
+    """Was each writer's log only ever appended by its own principal?
+
+    A per-writer chain is tamper-evident, not authenticated: any account that
+    can push can append to any log. The principals registry binds each writer
+    log to the git identities that may commit to it (Miles commits the
+    executor's `nightshift.jsonl`; the owner commits `mac.jsonl`). Non-merge
+    commits only — a merge that carries another writer's lines is a courier,
+    not an author — and counted from 2026-09-05, the day this check began
+    measuring. Two earlier autosave commits had carried another writer's log
+    (0-personal/nightshift by winston, 6-meridian/mac by miles); they are on
+    the record in the 2026-09-05 architecture audit and are not re-flagged.
+    """
+    sys.path.insert(0, str(LIB))
+    try:
+        from actor_identity import allowed_emails, principals
+    except Exception as exc:  # noqa: BLE001
+        rep.add("0044", "writer logs authored by their principal", None, f"actor_identity unusable: {exc}")
+        return
+    if not principals():
+        rep.add("0044", "writer logs authored by their principal", None, "principals.yaml absent or empty")
+        return
+    foreign, unbound, seen = [], set(), 0
+    for f in sorted(ROOT.glob("[0-9]-*/.datacore/events/*.jsonl")):
+        space, writer = f.parts[-4], f.stem
+        allowed = allowed_emails(writer)
+        if not allowed:
+            unbound.add(writer)
+            continue
+        rc, out = run(["git", "-C", str(ROOT / space), "log", "--no-merges", "--since=2026-09-05",
+                       "--format=%ae", "--", str(f.relative_to(ROOT / space))], 60)
+        if rc != 0:
+            continue
+        seen += 1
+        bad = sorted({e.strip().lower() for e in out.splitlines() if e.strip()} - allowed)
+        if bad:
+            foreign.append(f"{space}/{writer} by {', '.join(bad)[:60]}")
+    ok = not foreign
+    detail = f"{seen} log(s) checked" + (f"; unbound writer(s): {', '.join(sorted(unbound))}" if unbound else "")
+    rep.add("0044", "writer logs authored by their principal", ok,
+            detail if ok else f"{len(foreign)} foreign: " + "; ".join(foreign[:3]))
+
+
 # ── DIP-0046: git transport ─────────────────────────────────────────────────
 def check_transport(rep: Report) -> None:
     t = LIB / "ledger_transport.py"
@@ -639,6 +683,7 @@ def main() -> int:
     check_finality(rep)
     check_app(rep)
     check_declared_identity(rep)
+    check_writer_authorship(rep)
     check_egress(rep)
     if not a.quick:
         check_fleet(rep)

--- a/.datacore/registry/principals.yaml
+++ b/.datacore/registry/principals.yaml
@@ -1,0 +1,100 @@
+# Principals: who acts in this installation, and which ledger writer logs are
+# theirs (DIP-0044 identity; product description "the contract of being a
+# principal"). A writer log named under `writes_as` may only ever be appended
+# by commits authored with one of the principal's `emails`; v2_verify checks it.
+#
+# Facts only. A field that is not yet decided is null and stays null until the
+# owner decides it — a made-up budget is worse than none.
+version: 1
+principals:
+  gregor:
+    kind: human
+    display: Gregor
+    emails: [gregor@plur.si, gregor@ethswarm.org, dev@datacore.one]
+    github: plur9
+    hosts: [mac]
+    writes_as: [mac]
+    decision: final
+    memory_scope: user:plur:gregor
+    permission_mode: human
+  winston:
+    kind: agent
+    display: Winston
+    role: chief of staff
+    emails: [winston@datacore.one]
+    github: null                        # deliberately under the owner's account (DIP-0044 §4)
+    hosts: [winston]
+    writes_as: [winston, bridge]        # bridge: the hostname-derived log from before DIP-0044
+    owns:
+      roles: [8-firm:cos]
+      cadences: [briefing 04:00, verify-daily 07:10, liveness 07:40, scoreboard 08:10]
+    delegates_to: [miles, tris]
+    charter: .datacore/modules/chief-of-staff/CLAUDE.md
+    contracts: box-*
+    memory_scope: null
+    budget_monthly_usd: null
+    permission_mode: propose            # proposes; the client approves external actions
+  miles:
+    kind: agent
+    display: Miles
+    role: chief of operations
+    emails: [miles@datacore.one, gregor+miles@datafund.io]
+    github: miles-on-nightshift
+    hosts: [nightshift]
+    writes_as: [miles, nightshift]      # nightshift: the executor's log; it commits as Miles
+    owns:
+      roles: [8-firm:coo, 6-meridian:trader, 6-meridian:operations]
+    executors: [nightshift]
+    charter: null
+    contracts: nightshift-*
+    memory_scope: null
+    budget_monthly_usd: null
+    permission_mode: bypass             # bot: bypassPermissions; nightshift: --dangerously-skip-permissions
+  tris:
+    kind: agent
+    display: Tris
+    role: chief intelligence officer
+    emails: [tris@datacore.one]
+    github: tris-on-hermes
+    hosts: [hermes]
+    writes_as: [tris]
+    owns:
+      roles: [8-firm:cio, 5-plur:(venture.yaml)]
+    charter: null
+    contracts: hermes-*
+    memory_scope: null
+    budget_monthly_usd: null
+    permission_mode: yolo               # HERMES_YOLO_MODE=1
+  data:
+    kind: agent
+    display: Mr Data
+    role: communications
+    emails: [mrdata@datacore.one, data@plur.ai]
+    github: data-on-claw
+    hosts: [plur-claw]
+    writes_as: [data]
+    owns:
+      roles: [8-firm:comms, 5-plur:(venture.yaml)]
+    charter: null
+    contracts: plur-claw-*
+    memory_scope: null
+    budget_monthly_usd: null
+    permission_mode: null
+  genesis:
+    kind: migration
+    display: genesis import (2026-08-10, one shot)
+    emails: [gregor@plur.si, winston@datacore.one, miles@datacore.one]
+    hosts: [mac, winston, nightshift]
+    writes_as: [genesis]
+  practice:
+    kind: agent
+    display: The Practice (John, Mick)
+    role: health and longevity practice
+    emails: []
+    github: null
+    hosts: [mac]
+    writes_as: []                       # keeps its own intervention ledger; not yet an event-ledger writer
+    charter: 9-practice/CLAUDE.md
+    memory_scope: agent:john
+    decision: proposes; the client approves every protocol change
+    permission_mode: propose


### PR DESCRIPTION
One resolver (env, identity file, registry by hostname, then hostname with a warning or strict raise) replaces twelve hostname-fallback sites in lib. A principals registry binds each writer log to a principal (emails, account, host, owns, executors). v2_verify checks that non-merge commits touching a writer's log since 2026-09-05 are authored by its principal; the two earlier courier commits are recorded in the audit. Adds the scoreboard fixture the grounded jobs test wanted. 332 passed with modules present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)