### PR TITLE
projector: an agent's completion renders as REVIEW and stays until signed off

### DIFF
--- a/.datacore/lib/ledger/projector.py
+++ b/.datacore/lib/ledger/projector.py
@@ -57,11 +57,17 @@ GENERATED_HEADER = (
     "# append an event; this file is a view.\n"
 )
 
-#: Statuses that still represent live work.
-LIVE_STATUSES = ("created", "claimed", "granted")
+#: Statuses that still represent live work. `completed` is live: an agent
+#: has finished, nobody has looked. In org that is REVIEW (DIP-0009), the
+#: state that exists for exactly this hand-off, and it stays in the file until
+#: a human verifies it (item.verify) or closes it in org (ingest -> dismiss).
+#: Until 2026-09-05 completed counted as closed and fell out of the projection
+#: after the retention day: 24 agent-finished tasks in 2-datacore had vanished
+#: from the human's list with nobody having signed them off.
+LIVE_STATUSES = ("created", "claimed", "granted", "completed")
 
-#: Statuses that mean the work is finished.
-CLOSED_STATUSES = ("completed", "verified", "dismissed")
+#: Statuses that mean the work is finished and signed off.
+CLOSED_STATUSES = ("verified", "dismissed")
 
 #: How long finished work stays visible in the projection, as DONE, before it
 #: is archived.
@@ -257,6 +263,8 @@ def render_item(item, *, level: int | None = None) -> list[str]:
     if item.status in CLOSED_STATUSES:
         from .fold import was_finished
         state = "DONE" if was_finished(item) else "CANCELLED"
+    elif item.status == "completed":
+        state = "REVIEW"  # finished by an agent, awaiting a human's sign-off
     else:
         state = payload.get("state") or "TODO"
     priority = org.get("priority")

--- a/.datacore/lib/tests/test_projector_review.py
+++ b/.datacore/lib/tests/test_projector_review.py
@@ -1,0 +1,43 @@
+"""An agent's completion is a hand-off, not a closure: it renders as REVIEW and never expires."""
+import importlib.util, pathlib, sys
+LIB = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(LIB))
+from ledger.log import EventLog  # noqa: E402
+from ledger.fold import fold  # noqa: E402
+from ledger.projector import project, projected_items  # noqa: E402
+
+
+def _space(tmp_path):
+    sd = tmp_path / "5-plur"; (sd / ".datacore" / "events").mkdir(parents=True); return sd
+
+
+def test_completed_item_renders_as_review_and_does_not_expire(tmp_path):
+    sd = _space(tmp_path)
+    log = EventLog(sd, "nightshift")
+    log.append("item.create", {"id": "t1", "title": "Publish the trust page", "state": "TODO", "tags": ["plur"]})
+    log.append("item.claim", {"id": "t1", "executor": "server:nightshift"})
+    # closed_at is an HLC; fake one nine days old so a retention window would have dropped it
+    old_ms = 1_700_000_000_000
+    log.append("item.complete", {"id": "t1", "hlc": f"{old_ms}.0000.nightshift"})
+    from ledger.log import read_events
+    state = fold(list(read_events(sd)))
+    items = projected_items(state, space="5-plur")
+    assert [i.id for i in items] == ["t1"]
+    text = project(state, space="5-plur").text
+    assert "REVIEW Publish the trust page" in text
+    assert "DONE Publish" not in text
+
+
+def test_verified_and_dismissed_still_close(tmp_path):
+    sd = _space(tmp_path)
+    log = EventLog(sd, "mac")
+    log.append("item.create", {"id": "a", "title": "A", "state": "TODO"})
+    log.append("item.claim", {"id": "a", "executor": "mac"})
+    log.append("item.complete", {"id": "a"})
+    log.append("item.verify", {"id": "a"})
+    log.append("item.create", {"id": "b", "title": "B", "state": "TODO"})
+    log.append("item.dismiss", {"id": "b", "reason": "no longer needed", "kind": "dropped"})
+    from ledger.log import read_events
+    state = fold(list(read_events(sd)))
+    text = project(state, space="5-plur").text
+    assert "DONE A" in text and "CANCELLED B" in text


### PR DESCRIPTION
completed counted as closed, so agent-finished tasks rendered DONE and left the generated file after a day with nobody having looked (24 of 58 in 2-datacore). completed is now live and renders as REVIEW until a human verifies (DONE) or closes it in org (dismiss). Two tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)