### PR TITLE
projector: the tag alphabet is the parser's — revert the # and % widening from #108

### DIFF
--- a/.datacore/lib/ledger/projector.py
+++ b/.datacore/lib/ledger/projector.py
@@ -208,7 +208,12 @@ _TRAILING_TAG_BLOCK = re.compile(r"\s+:([^\s:]+(?::[^\s:]+)*):\s*$")
 # the checkpoint restore on exactly that from 2026-08-31 -- a tag the renderer
 # considered valid and the parser could not read. What is written here has to
 # come back through that parser unchanged, so its alphabet is the constraint.
-_BAD_TAG_CHAR = re.compile(r"[^A-Za-z0-9_@#%]")  # org-mode's own tag alphabet: letters, digits, _ @ # %
+# The renderer's alphabet is the PARSER's, not Emacs's. Org admits `#` and `%`
+# in a tag, but the vendored orgparse this projection round-trips through does
+# not: `:AI:enterprise#373:infra:pm:` came back as tags (infra, pm) and a title
+# ending in ` :AI:enterprise#373`. Widening this to Emacs's alphabet (tried on
+# 2026-09-06, reverted the same hour) writes a tag the next ingest cannot read.
+_BAD_TAG_CHAR = re.compile(r"[^A-Za-z0-9_@]")
 
 
 def _clean_title_and_tags(title: str, tags) -> tuple[str, list[str]]:

--- a/.datacore/lib/tests/test_projector_tags.py
+++ b/.datacore/lib/tests/test_projector_tags.py
@@ -59,14 +59,3 @@ def test_hash_and_percent_are_outside_the_parsers_alphabet():
     node = loads(line + "\n").children[0]
     assert node.heading == "Plain title" and sorted(node.tags) == ["a_b", "enterprise_373", "ok"]
 
-
-def test_org_mode_tag_alphabet_is_kept_verbatim():
-    """`enterprise#373` is a legal org tag. Sanitising it to `enterprise_373`
-    made the projection disagree with the authored file forever (5-plur,
-    org-7aba0a999bc5, 2026-09-06)."""
-    from ledger.projector import _clean_title_and_tags
-    title, tags = _clean_title_and_tags("UX pass on 0.1.6 :AI:pm:enterprise#373:", None)
-    assert title == "UX pass on 0.1.6"
-    assert tags == ["AI", "enterprise#373", "pm"]
-    _, tags = _clean_title_and_tags("x", ["a b", "100%", "c:d"])
-    assert tags == ["100%", "a_b", "c_d"]


### PR DESCRIPTION
The widening wrote tags the vendored orgparse cannot read back (the documented corruption case). Reverted; the one authored file with such a tag is renamed instead. #108's other changes (drawer round-trip) stand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)