### PR TITLE
hosts: installer for the agent hosts, contracts for every unattended principal, a working dispatcher tick

### DIFF
--- a/.datacore/lib/agent_host_setup.sh
+++ b/.datacore/lib/agent_host_setup.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Declare an agent host, or verify it: identity, the crons the job contracts
+# assume, the artifacts they read. Idempotent; run it again after every change.
+#
+#   agent_host_setup.sh --host nightshift|hermes|plur-claw          apply, then verify
+#   agent_host_setup.sh --host NAME --verify                        check, change nothing
+#
+# Why this exists: the box has had an installer with a verify step since
+# 2026-09-03; the other three hosts were configured by hand, so a cron line
+# lived only in a crontab, an identity only in a file someone once placed, and
+# a broken dispatcher tick (plur-claw, since 2026-08-13) had nothing to
+# compare itself against. The product description calls this stage 6:
+# every host rebuildable from its installer.
+set -uo pipefail
+HOST=""; VERIFY_ONLY=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --host) HOST="${2:?--host needs nightshift|hermes|plur-claw}"; shift ;;
+    --verify) VERIFY_ONLY=1 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac; shift
+done
+[ -n "$HOST" ] || { echo "--host is required" >&2; exit 2; }
+RUNNER="${DATACORE_RUNNER:-$HOME/.datacore/v2-runner}"
+LIB="$RUNNER/.datacore/lib"
+STATE="$HOME/.datacore/state"; mkdir -p "$STATE"
+ID_FILE="$HOME/.datacore/identity.env"
+log() { echo "[host-setup] $*"; }
+fail=0
+qgrep() { grep "$@" >/dev/null; }
+
+# ── identity (DIP-0044) ──────────────────────────────────────────────────────
+ACTOR="$(python3 - "$HOST" "$LIB/../registry/infrastructure.yaml" <<'PY'
+import sys, yaml
+host, reg = sys.argv[1], sys.argv[2]
+d = yaml.safe_load(open(reg)) or {}
+print(((d.get("servers") or {}).get(host) or {}).get("access", {}).get("actor", ""))
+PY
+)"
+[ -n "$ACTOR" ] || { log "FAIL registry declares no actor for host $HOST"; exit 2; }
+if [ "$VERIFY_ONLY" = 0 ]; then
+  if ! grep -qsE '^(export )?DATACORE_ACTOR=' "$ID_FILE"; then
+    mkdir -p "$(dirname "$ID_FILE")"
+    printf '%s\n' "# DIP-0044: this machine writes the ledger as one declared actor. Registry: servers.$HOST.access.actor" "DATACORE_ACTOR=$ACTOR" >> "$ID_FILE"
+    log "declared DATACORE_ACTOR=$ACTOR in $ID_FILE"
+  fi
+fi
+
+# ── crons the contracts assume ──────────────────────────────────────────────
+# One line per job, keyed on a marker substring; a stale line with the same
+# marker is replaced, so a path change here reaches the crontab on the next run.
+CRON_LINES=()
+case "$HOST" in
+  nightshift)
+    CRON_LINES+=("25 * * * * DATACORE_ROOT=$HOME/Data $LIB/ledger_phase1_cycle.sh >> $STATE/phase1-cycle.log 2>&1")
+    CRON_LINES+=("*/15 * * * * $LIB/unit_alive.sh datacore-telegram.service $STATE/miles-bot.alive 2>>$STATE/miles-bot.alive.err")
+    ;;
+  plur-claw)
+    CRON_LINES+=("25 * * * * DATACORE_ROOT=$HOME/spaces $LIB/ledger_phase1_cycle.sh >> $STATE/phase1-cycle.log 2>&1")
+    CRON_LINES+=("*/15 * * * * $LIB/ledger-claim-pull.sh >> $STATE/ledger-dispatch.log 2>&1")
+    ;;
+  hermes)
+    : # Tris's heartbeat is a systemd timer (tris-heartbeat.timer); no spaces to project here
+    ;;
+esac
+# lines this installer retires (superseded by one of the above)
+RETIRE=("/usr/local/bin/ledger-pull-data.sh")
+
+marker_of() { printf '%s' "$1" | sed -E 's/^[^ ]+ [^ ]+ [^ ]+ [^ ]+ [^ ]+ //' | cut -c1-60; }
+if [ "$VERIFY_ONLY" = 0 ]; then
+  cur="$(crontab -l 2>/dev/null || true)"
+  new="$cur"
+  for r in "${RETIRE[@]}"; do
+    if printf '%s\n' "$new" | qgrep -F "$r"; then new="$(printf '%s\n' "$new" | grep -vF "$r")"; log "retired cron line: $r"; fi
+  done
+  for line in "${CRON_LINES[@]}"; do
+    m="$(marker_of "$line")"
+    if printf '%s\n' "$new" | qgrep -F "$m"; then
+      new="$(printf '%s\n' "$new" | grep -vF "$m"; printf '%s\n' "$line")"
+    else
+      new="$(printf '%s\n' "$new"; printf '%s\n' "$line")"; log "cron added: $m"
+    fi
+  done
+  printf '%s\n' "$new" | grep -vE '^\s*$' | crontab -
+fi
+
+# ── verify ───────────────────────────────────────────────────────────────────
+grep -qsE "^(export )?DATACORE_ACTOR=$ACTOR\$" "$ID_FILE" && log "OK  identity declared ($ACTOR)" || { log "FAIL identity not declared as $ACTOR in $ID_FILE"; fail=1; }
+res="$(python3 "$LIB/actor_identity.py" 2>/dev/null)"; [ "${res%% *}" = "$ACTOR" ] && log "OK  resolver agrees: $res" || { log "FAIL resolver says '$res', registry says $ACTOR"; fail=1; }
+cur="$(crontab -l 2>/dev/null || true)"
+for line in "${CRON_LINES[@]}"; do
+  m="$(marker_of "$line")"
+  printf '%s\n' "$cur" | qgrep -F "$m" && log "OK  cron: $m" || { log "FAIL cron missing: $m"; fail=1; }
+done
+for r in "${RETIRE[@]}"; do printf '%s\n' "$cur" | qgrep -F "$r" && { log "FAIL retired cron still present: $r"; fail=1; }; done
+[ -x "$LIB/ledger_phase1_cycle.sh" ] && log "OK  runner lib present at $LIB" || { log "FAIL runner lib missing: $LIB"; fail=1; }
+case "$HOST" in
+  nightshift)
+    systemctl show -p Environment --value nightshift-overnight.service 2>/dev/null | tr ' ' '\n' | qgrep -x "DATACORE_ACTOR=nightshift" && log "OK  overnight executor declares its own writer (nightshift)" || { log "FAIL overnight unit does not declare DATACORE_ACTOR=nightshift"; fail=1; }
+    systemctl is-active --quiet datacore-telegram.service && log "OK  Miles bot unit active" || { log "FAIL datacore-telegram.service not active"; fail=1; }
+    systemctl is-active --quiet venture-heartbeat.service && log "OK  venture heartbeat active" || { log "FAIL venture-heartbeat.service not active"; fail=1; }
+    ;;
+  hermes)
+    systemctl is-active --quiet tris-heartbeat.timer && log "OK  tris-heartbeat.timer active" || { log "FAIL tris-heartbeat.timer not active"; fail=1; }
+    systemctl --user is-active --quiet hermes-gateway.service 2>/dev/null && log "OK  hermes gateway (user unit) active" || { log "FAIL hermes-gateway.service (user) not active"; fail=1; }
+    ;;
+  plur-claw)
+    [ -d "$HOME/spaces/5-plur/.git" ] && log "OK  dispatch space present" || { log "FAIL $HOME/spaces/5-plur is not a repository"; fail=1; }
+    ;;
+esac
+[ "$fail" = 0 ] && log "ALL CHECKS PASS ($HOST)" || log "SOME CHECKS FAILED ($HOST)"
+exit $fail

--- a/.datacore/lib/jobs/manifest.yaml
+++ b/.datacore/lib/jobs/manifest.yaml
@@ -547,6 +547,35 @@ jobs:
         check: nonempty
         max_age_hours: 26
 
+  # ── the unattended principals (product description, stage 2): a contract
+  # and a scoreboard row for each, so "it continues" is measured, not claimed.
+  - name: nightshift-venture-heartbeat
+    machine: nightshift
+    schedule: "continuous (venture-heartbeat.service, one tick every 1800 s)"
+    cmd: "~/Data/.datacore/modules/ventures/server/venture-heartbeat.sh"
+    on_fail: telegram
+    artifacts:
+      # heartbeat_tick() appends one line per tick (venture_heartbeat.py,
+      # "Heartbeat tick: N active, M idle"). Two ticks an hour; two hours
+      # of silence means the loop is dead or wedged.
+      - path: "~/Data/.datacore/state/venture/heartbeat.log"
+        check: regex
+        arg: "Heartbeat tick"
+        max_age_hours: 2
+
+  - name: nightshift-miles-bot
+    machine: nightshift
+    schedule: "*/15 * * * *"
+    cmd: "~/.datacore/v2-runner/.datacore/lib/unit_alive.sh datacore-telegram.service ~/.datacore/state/miles-bot.alive 2>>~/.datacore/state/miles-bot.alive.err"
+    on_fail: telegram
+    artifacts:
+      # The bot has no artifact of its own; unit_alive.sh stamps this file
+      # every 15 minutes while datacore-telegram.service is active and
+      # leaves it alone when it is not, so age is the signal.
+      - path: "~/.datacore/state/miles-bot.alive"
+        check: nonempty
+        max_age_hours: 1
+
   - name: nightshift-github-triage
     machine: nightshift
     schedule: "30 4 * * *"
@@ -676,6 +705,19 @@ jobs:
   # entirely unverified. Found by TESTING the claim "every deployment gap is
   # closed" instead of asserting it -- the claim was false.
 
+  - name: hermes-tris-heartbeat
+    machine: hermes
+    schedule: "tris-heartbeat.timer (every 30 min)"
+    cmd: "/home/gregor/tris-heartbeat.sh"
+    on_fail: telegram
+    artifacts:
+      # tris-heartbeat.sh writes the last report it managed to send to
+      # STATE_FILE (line 81); a report it could not send is logged but not
+      # stamped, so age here means "Tris has not been heard from".
+      - path: "/home/gregor/.hermes/state/heartbeat-last-report"
+        check: nonempty
+        max_age_hours: 2
+
   - name: hermes-creds-sync
     machine: hermes
     schedule: "0 * * * *"
@@ -745,6 +787,22 @@ jobs:
       # all_clean assertion is dropped. Progress belongs in the briefing, where
       # "7/9 spaces clean, streak 0" reads as a number to move rather than a
       # failure to triage.
+
+  - name: plur-claw-ledger-dispatch
+    machine: plur-claw
+    schedule: "*/15 * * * *"
+    cmd: "~/.datacore/v2-runner/.datacore/lib/ledger-claim-pull.sh >> ~/.datacore/state/ledger-dispatch.log 2>&1"
+    on_fail: telegram
+    artifacts:
+      # Every tick ends with one dated "dispatch rc=N" line (ledger-claim-pull.sh).
+      # The previous tick (a root-owned copy) had failed silently on every run
+      # since 2026-08-13 into a log its user could not write; this is the
+      # contract that would have said so on day one.
+      - path: "~/.datacore/state/ledger-dispatch.log"
+        check: regex
+        arg: "dispatch rc="
+        max_age_hours: 1
+
   - name: mac-shadow-diff
     machine: mac
     schedule: "0 7 * * *"

--- a/.datacore/lib/ledger-claim-pull.sh
+++ b/.datacore/lib/ledger-claim-pull.sh
@@ -1,28 +1,29 @@
-#!/bin/bash
-# Data's pull cycle: fetch delegations, work, publish claims.
+#!/usr/bin/env bash
+# The dispatcher's cron tick on a satellite host (plur-claw runs it as Data):
+# bring the space up to date, claim and execute up to N delegated items,
+# publish the claims on this actor's own ref. Never rebase, never force.
 #
-# The git steps are not optional decoration. Without the pull Data never sees
-# what winston delegated; without the push its claim and completion exist only
-# on this box, and every other actor still believes the item is unclaimed.
+# Until 2026-09-06 the tick on plur-claw was a root-owned copy of this script
+# with the old /root layout, `git pull --rebase` and a python file that no
+# longer existed, logging into a root-owned file the cron user could not
+# write. It had failed silently on every tick since 2026-08-13. Paths come
+# from the environment now, with the DIP-0044 layout as the default, and every
+# tick prints one dated line so a job contract can see it ran.
 set -uo pipefail
-S=/root/spaces/5-plur
-cd "$S" || exit 1
-# MERGE, NEVER REBASE (DIP-0046). This box publishes its claims to its own
-# branch (refs/heads/ledger/data, below) rather than to main, so a rebase here
-# rewrites exactly the commits it is about to push. When that push is rejected
-# the claims survive only under hashes no other actor has ever seen, and the
-# item still reads as unclaimed everywhere else — the failure this script's
-# own header warns about.
-#
-# Merge is also simply correct for the payload: per-writer event logs are
-# disjoint files, so receiving another actor's log is a union, not a conflict.
+RUNNER="${DATACORE_RUNNER:-$HOME/.datacore/v2-runner}"
+S="${DISPATCH_SPACE:-$HOME/spaces/5-plur}"
+LIMIT="${DISPATCH_LIMIT:-2}"
+PY="${DATACORE_PYTHON:-python3}"
+ACTOR="$("$PY" "$RUNNER/.datacore/lib/actor_identity.py" 2>/dev/null | cut -d' ' -f1)"
+[ -n "$ACTOR" ] || { echo "$(date -Is) dispatch rc=2 no declared actor (DIP-0044)"; exit 2; }
+cd "$S" || { echo "$(date -Is) dispatch rc=2 space missing: $S"; exit 2; }
 git pull --no-rebase -q 2>&1 | tail -2
-/usr/bin/python3 /root/.datacore/v2-runner/.datacore/lib/ledger_claim.py \
-  --space "$S" --actor data --limit 2 --execute
+"$PY" "$RUNNER/.datacore/lib/ledger_claim.py" --space "$S" --actor "$ACTOR" --limit "$LIMIT" --execute
 rc=$?
 git add .datacore/events/ 2>/dev/null
-# Nothing to commit is the normal case (no items claimed this tick).
-git -c user.email=data@plur.ai -c user.name='Data (plur-claw)' \
-  commit -q -m 'ledger: Data claim/completion' 2>/dev/null && \
-  git push -q --force-with-lease origin HEAD:refs/heads/ledger/data 2>&1 | tail -1
+if ! git diff --cached --quiet 2>/dev/null; then
+  git commit -q -m "ledger: $ACTOR claim/completion" 2>/dev/null
+  git push -q origin "HEAD:refs/heads/ledger/$ACTOR" 2>&1 | tail -1
+fi
+echo "$(date -Is) dispatch rc=$rc actor=$ACTOR space=$(basename "$S")"
 exit $rc

--- a/.datacore/lib/tests/fixtures/jobs/nightshift-venture-heartbeat.0.txt
+++ b/.datacore/lib/tests/fixtures/jobs/nightshift-venture-heartbeat.0.txt
@@ -1,0 +1,1 @@
+2026-09-05T20:23:06 Heartbeat tick: 2 active, 6 idle, 8 ventures observed

--- a/.datacore/lib/tests/fixtures/jobs/plur-claw-ledger-dispatch.0.txt
+++ b/.datacore/lib/tests/fixtures/jobs/plur-claw-ledger-dispatch.0.txt
@@ -1,0 +1,1 @@
+2026-09-06T00:15:03+00:00 dispatch rc=0 actor=data space=5-plur

--- a/.datacore/lib/unit_alive.sh
+++ b/.datacore/lib/unit_alive.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Stamp an artifact while a long-running unit is active, so a job contract
+# can see a service that has no artifact of its own (the Miles bot).
+#   unit_alive.sh <unit> <artifact>     writes an ISO stamp; leaves the file alone when the unit is down
+set -u
+unit="${1:?unit}"; out="${2:?artifact path}"
+mkdir -p "$(dirname "$out")"
+if systemctl is-active --quiet "$unit"; then date -u +%FT%TZ > "$out"; else echo "$(date -u +%FT%TZ) $unit not active" >&2; exit 1; fi


### PR DESCRIPTION
agent_host_setup.sh declares identity, installs the crons the contracts assume, retires superseded lines, and verifies units. Four new contracts: venture heartbeat, Miles bot (unit_alive.sh stamp), Tris heartbeat, plur-claw dispatcher. The dispatcher tick had failed silently since 2026-08-13 (root-owned copy, rebase, missing file, unwritable log); rewritten with declared paths, merge-only pull, no force. 69 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)