### PR TITLE
transport: converge folds every writer's own ledger ref into main

### DIFF
--- a/.datacore/lib/ledger_transport.py
+++ b/.datacore/lib/ledger_transport.py
@@ -264,6 +264,27 @@ def _converge_locked(space: Path, *, publish: bool = True) -> Result:
         return Result(False, "merge conflict — human needed",
                       {"branch": db, "autosaved": autosaved,
                        "detail": err[:400]})
+    # PER-ACTOR LEDGER REFS. A satellite writer publishes its claims on its
+    # own ref (refs/heads/ledger/<actor>: plur-claw's dispatcher since
+    # 2026-08-10) because only that writer pushes there and a push can never
+    # race. But nothing ever folded those refs back into the default branch:
+    # Data's last claims sat on ledger/data from 2026-08-11 and reached main
+    # only by hand. Every converge now merges each origin/ledger/* ref into the
+    # branch before publishing. Per-writer logs are disjoint files, so this is
+    # a union; a conflict here is a genuine one and stops, like any other.
+    rc, refs_out, _ = _git(space, "for-each-ref", "--format=%(refname:short)", "refs/remotes/origin/ledger/")
+    merged_refs = []
+    for ref in (refs_out.split() if rc == 0 else []):
+        rc, ahead, _ = _git(space, "rev-list", "--count", f"HEAD..{ref}")
+        if rc != 0 or ahead.strip() == "0":
+            continue
+        rc, mout, err = _git(space, "merge", "--no-edit", ref)
+        if rc != 0:
+            err = "\n".join(x for x in (mout.strip(), err.strip()) if x)
+            _git(space, "merge", "--abort")
+            return Result(False, "merge conflict on a ledger ref — human needed",
+                          {"branch": db, "ref": ref, "autosaved": autosaved, "detail": err[:400]})
+        merged_refs.append(ref)
     # PUBLISH. Converge previously stopped here, which made it a one-way
     # operation: it pulled and never pushed. Every caller means both — `sync`,
     # `./sync pull`, and cos_sync on winston's 15-minute cron all report
@@ -274,13 +295,13 @@ def _converge_locked(space: Path, *, publish: bool = True) -> Result:
     # `publish=False` only for _push_with_retry, which calls this to resolve a
     # non-fast-forward and would otherwise recurse into pushing.
     if not publish:
-        return Result(True, "converged", {"branch": db, "autosaved": autosaved})
+        return Result(True, "converged", {"branch": db, "autosaved": autosaved, "ledger_refs": merged_refs})
     pr = _push_with_retry(space, db)
     if not pr.ok:
         return Result(False, f"converged but not published: {pr.reason}",
                       {"branch": db, "autosaved": autosaved, **pr.context})
     return Result(True, "converged", {"branch": db, "autosaved": autosaved,
-                                      "pushed": pr.context.get("attempts", 1)})
+                                      "pushed": pr.context.get("attempts", 1), "ledger_refs": merged_refs})
 
 
 def _push_with_retry(space: Path, db: str) -> Result:

--- a/.datacore/lib/tests/test_ledger_transport.py
+++ b/.datacore/lib/tests/test_ledger_transport.py
@@ -393,3 +393,25 @@ def test_orphan_gitlink_is_still_protected(repo_pair: Path, tmp_path: Path):
 
     assert git(repo_pair, "rev-parse", "HEAD:orphan").stdout.strip() == before, \
         "an orphan gitlink pointer must not be autosaved"
+
+
+def test_converge_folds_a_writers_own_ref_into_main(repo_pair: Path, tmp_path: Path):
+    """A satellite writer publishes on refs/heads/ledger/<actor>; the next
+    converge on any host merges it into main. Data's claims sat on ledger/data
+    from 2026-08-11 with nothing folding them back."""
+    import ledger_transport as lt
+    origin = tmp_path / "origin.git"
+    other = tmp_path / "other"
+    subprocess.run(["git", "clone", "-q", str(origin), str(other)], check=True)
+    git(other, "config", "user.email", "d@d"); git(other, "config", "user.name", "data")
+    git(other, "config", "core.hooksPath", str(other / ".git" / "hooks"))
+    ev = other / ".datacore" / "events"; ev.mkdir(parents=True)
+    (ev / "data.jsonl").write_text('{"actor":"data","type":"item.claim","payload":{"id":"x"}}\n')
+    git(other, "add", "-A"); git(other, "commit", "-qm", "ledger: data claim")
+    git(other, "push", "-q", "origin", "HEAD:refs/heads/ledger/data")
+    r = lt.converge(repo_pair)
+    assert r.ok, r
+    assert "origin/ledger/data" in r.context.get("ledger_refs", [])
+    assert (repo_pair / ".datacore" / "events" / "data.jsonl").exists()
+    # and it was published: origin/main now contains the writer's commit
+    assert git(repo_pair, "rev-list", "--count", "origin/main..origin/ledger/data").stdout.strip() == "0"


### PR DESCRIPTION
Per-actor refs (refs/heads/ledger/<actor>) were published but never merged back; converge now merges each one that is ahead before publishing, union on disjoint per-writer logs, conflict stops. Test with a second clone pushing to ledger/data. 21 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)