### PR TITLE
checkpoint: the round trip follows the projector (completed is REVIEW; a title is one line)

### DIFF
--- a/.datacore/lib/ledger/projector.py
+++ b/.datacore/lib/ledger/projector.py
@@ -227,6 +227,11 @@ def _clean_title_and_tags(title: str, tags) -> tuple[str, list[str]]:
     2026-09-03. The projection must always be valid org, whatever the ledger
     holds: embedded blocks are split out, invalid characters become `_`.
     """
+    # A heading is one line. A title that arrived with newlines (thirty
+    # dispatcher proof items created straight into the ledger in Aug 2026
+    # carried "...\nNo other content...") rendered only its first line, so a
+    # restore read back a different title and reported the item altered.
+    title = " ".join(str(title or "").split())
     title = title or ""
     found: list[str] = []
     m = _TRAILING_TAG_BLOCK.search(title)

--- a/.datacore/lib/ledger_checkpoint.py
+++ b/.datacore/lib/ledger_checkpoint.py
@@ -52,7 +52,12 @@ from ledger.genesis import import_space  # noqa: E402
 from ledger.log import read_events  # noqa: E402
 from ledger.projector import _clean_title_and_tags, _org_stamp, project, projected_items  # noqa: E402
 
-LIVE = ("created", "claimed", "granted")
+# The projector's own notion of live. Since 2026-09-06 `completed` is live
+# (an agent finished, nobody signed off: REVIEW in org), so a round-trip
+# through the projection carries those items and this side must count them
+# too — with the state the projector renders, or every completed item comes
+# back "invented" and 2-datacore reports 58 of them.
+from ledger.projector import LIVE_STATUSES as LIVE  # noqa: E402
 CHECKPOINT_REL = Path(".datacore") / "checkpoints" / "next_actions.org"
 
 
@@ -178,7 +183,8 @@ def _fingerprint(state, space_filetags: set | None = None,
         # 0-personal as "altered" by a restore that preserved them exactly
         # (2026-08-30), the same false-alarm class as the timestamp and
         # filetag asymmetries above. A missing state MEANS TODO here.
-        out[iid] = (title, p.get("state") or "TODO",
+        rendered_state = "REVIEW" if item.status == "completed" else (p.get("state") or "TODO")
+        out[iid] = (title, rendered_state,
                     tuple(sorted(eff)),
                     _org_stamp(p.get("scheduled")), _org_stamp(p.get("deadline")))
     return out

--- a/.datacore/lib/tests/test_ledger_checkpoint.py
+++ b/.datacore/lib/tests/test_ledger_checkpoint.py
@@ -115,3 +115,22 @@ def test_a_real_loss_is_still_reported():
     assert not ok and detail == "1 lost (e.g. b)", detail
     ok, detail = compare(live, {**live, "a": ("Renamed", "TODO", (), None, None)})
     assert not ok and detail == "1 altered (e.g. a)", detail
+
+
+def test_an_agents_completion_round_trips_as_review(tmp_path):
+    """completed is live and renders REVIEW (2026-09-06); the restore must
+    count it and read it back as the same item, not as one it invented."""
+    import importlib.util, pathlib as _pl, sys as _sys
+    LIB = _pl.Path(__file__).resolve().parents[1]
+    _sys.path.insert(0, str(LIB))
+    from ledger.log import EventLog
+    spec = importlib.util.spec_from_file_location("ck", LIB / "ledger_checkpoint.py")
+    ck = importlib.util.module_from_spec(spec); spec.loader.exec_module(ck)
+    space = tmp_path / "5-plur"; (space / ".datacore" / "events").mkdir(parents=True); (space / "org").mkdir()
+    log = EventLog(space, "nightshift")
+    log.append("item.create", {"id": "t1", "title": "Publish the trust page", "state": "TODO", "tags": ["plur"]})
+    log.append("item.claim", {"id": "t1", "executor": "server:nightshift"})
+    log.append("item.complete", {"id": "t1"})
+    ck.write(space)
+    ok, detail = ck.verify(space)
+    assert ok, detail

--- a/.datacore/lib/tests/test_projector_tags.py
+++ b/.datacore/lib/tests/test_projector_tags.py
@@ -59,3 +59,12 @@ def test_hash_and_percent_are_outside_the_parsers_alphabet():
     node = loads(line + "\n").children[0]
     assert node.heading == "Plain title" and sorted(node.tags) == ["a_b", "enterprise_373", "ok"]
 
+
+
+def test_a_multiline_title_renders_as_one_line():
+    """Thirty ledger-created proof items carried newlines in their titles;
+    the heading showed the first line and a restore read back a different
+    title. A heading is one line, whatever the writer sent."""
+    from ledger.projector import _clean_title_and_tags
+    title, tags = _clean_title_and_tags("Write a file\nNo other content.  Commit it.", ["x"])
+    assert title == "Write a file No other content. Commit it." and tags == ["x"]


### PR DESCRIPTION
The checkpoint fingerprint kept its own live set after #107 made completed live, so every agent-finished task came back 'invented' and the box's checklist failed. It now imports the projector's LIVE_STATUSES and compares the rendered state. Titles with newlines are rendered on one line. All 10 spaces restore identically locally; 32 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)