### PR TITLE
shadow: an item that lives elsewhere is compared nowhere, on either side

### DIFF
--- a/.datacore/lib/ledger/shadow.py
+++ b/.datacore/lib/ledger/shadow.py
@@ -168,7 +168,13 @@ def compare(space_dir: Path, org_file: Path | None = None) -> ShadowDiff:
                                              other.read_text(errors="replace")))
             except OSError:
                 continue
+        # BOTH SIDES. In Phase 1 the real file IS a projection and carries every
+        # live item, including ones whose id also sits in inbox.org; dropping
+        # them from the projection only reported them "lost" from a file that
+        # had just been generated from the same ledger (12 in 0-personal on
+        # 2026-09-06). An item that lives elsewhere is compared nowhere.
         shadow = {k: v for k, v in shadow.items() if k not in elsewhere}
+        real = {k: v for k, v in real.items() if k not in elsewhere}
     diff.org_count, diff.projection_count = len(real), len(shadow)
     diff.only_in_org = sorted(set(real) - set(shadow))
     diff.only_in_projection = sorted(set(shadow) - set(real))

--- a/.datacore/lib/tests/test_shadow_symmetric.py
+++ b/.datacore/lib/tests/test_shadow_symmetric.py
@@ -1,0 +1,21 @@
+"""An item that also lives in inbox.org is compared nowhere, on either side (2026-09-06)."""
+import pathlib, sys
+LIB = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(LIB))
+from ledger.log import EventLog  # noqa: E402
+from ledger.shadow import compare  # noqa: E402
+
+
+def test_generated_file_with_an_inbox_twin_is_clean(tmp_path):
+    space = tmp_path / "0-personal"; (space / ".datacore" / "events").mkdir(parents=True); (space / "org").mkdir()
+    log = EventLog(space, "mac")
+    log.append("item.create", {"id": "cap-1", "title": "Captured tab", "state": "TODO", "tags": ["inbox"]})
+    log.append("item.create", {"id": "t-2", "title": "Real task", "state": "NEXT"})
+    (space / "org" / "inbox.org").write_text("* TODO Captured tab\n:PROPERTIES:\n:ID: cap-1\n:END:\n")
+    from ledger.fold import fold
+    from ledger.log import read_events
+    from ledger.projector import project
+    (space / "org" / "next_actions.org").write_text(project(fold(read_events(space)), space="0-personal").text)
+    d = compare(space)
+    assert d.clean, d
+    assert d.org_count == d.projection_count == 1


### PR DESCRIPTION
In Phase 1 the real file is a projection; excluding inbox twins only from the projection side reported live items as lost. Symmetric now; test added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)