### PR TITLE
stages 2–8 (root): budgets at claim, grant co-sign, arbitration, absence, rows per principal, outcomes by version, sunset reviews, signing

### DIFF
--- a/.datacore/config/approvals_policy.yaml
+++ b/.datacore/config/approvals_policy.yaml
@@ -52,3 +52,10 @@ principals:
   data:
     never_effects: [payment, prod.deploy]
     may_delegate_to: [miles]
+
+# Arbitration across principals (product description, stage 5). Earlier
+# outranks later: a principal may close or release another principal's item
+# only if it precedes the owner here; agents not listed cannot override each
+# other at all. The client outranks everyone; the chief of staff outranks the
+# agents.
+arbitration: [gregor, winston]

--- a/.datacore/lib/actor_identity.py
+++ b/.datacore/lib/actor_identity.py
@@ -124,7 +124,8 @@ def actor_source() -> str:
     return resolve()[1]
 
 
-def principals(path: Path = PRINCIPALS) -> dict:
+def principals(path: Path | None = None) -> dict:
+    path = path or PRINCIPALS  # resolved at call time so a test can point it elsewhere
     try:
         import yaml
         return (yaml.safe_load(path.read_text(encoding="utf-8")) or {}).get("principals") or {}
@@ -132,7 +133,7 @@ def principals(path: Path = PRINCIPALS) -> dict:
         return {}
 
 
-def principal_of(actor: str, path: Path = PRINCIPALS) -> tuple[str | None, dict]:
+def principal_of(actor: str, path: Path | None = None) -> tuple[str | None, dict]:
     """The principal a writer log belongs to: its own entry, or the one listing it under writes_as."""
     ps = principals(path)
     a = actor.lower()
@@ -144,7 +145,7 @@ def principal_of(actor: str, path: Path = PRINCIPALS) -> tuple[str | None, dict]
     return None, {}
 
 
-def allowed_emails(actor: str, path: Path = PRINCIPALS) -> set[str]:
+def allowed_emails(actor: str, path: Path | None = None) -> set[str]:
     """Git author emails that may append to this writer's log. Empty = unbound."""
     _, p = principal_of(actor, path)
     return {str(e).lower() for e in (p.get("emails") or [])}

--- a/.datacore/lib/agent_host_setup.sh
+++ b/.datacore/lib/agent_host_setup.sh
@@ -44,6 +44,14 @@ if [ "$VERIFY_ONLY" = 0 ]; then
     printf '%s\n' "# DIP-0044: this machine writes the ledger as one declared actor. Registry: servers.$HOST.access.actor" "DATACORE_ACTOR=$ACTOR" >> "$ID_FILE"
     log "declared DATACORE_ACTOR=$ACTOR in $ID_FILE"
   fi
+  # Stage 8: every event this writer appends is signed with its own key
+  # (ledger/keys.py, opt-in switch in ledger/log.py). The key is generated on
+  # first use under ~/.datacore/keys; the public half is registered in
+  # .datacore/keys/registry.yaml so any host can verify the writer's chain.
+  if ! grep -qsE '^(export )?DATACORE_LEDGER_SIGN=' "$ID_FILE"; then
+    printf '%s\n' "DATACORE_LEDGER_SIGN=1" >> "$ID_FILE"; log "signing on for $ACTOR (DATACORE_LEDGER_SIGN=1)"
+  fi
+  mkdir -p "$HOME/.datacore/keys"; chmod 700 "$HOME/.datacore/keys"
 fi
 
 # ── crons the contracts assume ──────────────────────────────────────────────
@@ -86,6 +94,7 @@ fi
 
 # ── verify ───────────────────────────────────────────────────────────────────
 grep -qsE "^(export )?DATACORE_ACTOR=$ACTOR\$" "$ID_FILE" && log "OK  identity declared ($ACTOR)" || { log "FAIL identity not declared as $ACTOR in $ID_FILE"; fail=1; }
+grep -qsE '^(export )?DATACORE_LEDGER_SIGN=1' "$ID_FILE" && log "OK  events signed (DATACORE_LEDGER_SIGN=1)" || { log "FAIL signing not declared in $ID_FILE"; fail=1; }
 res="$(python3 "$LIB/actor_identity.py" 2>/dev/null)"; [ "${res%% *}" = "$ACTOR" ] && log "OK  resolver agrees: $res" || { log "FAIL resolver says '$res', registry says $ACTOR"; fail=1; }
 cur="$(crontab -l 2>/dev/null || true)"
 for line in "${CRON_LINES[@]}"; do

--- a/.datacore/lib/agent_outcomes.py
+++ b/.datacore/lib/agent_outcomes.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Prompt versions tied to outcomes (product description, stage 7).
+
+Every completion an executor records carries, since 2026-09-06, the agent
+definition, its registry version, the model and the auth path, and the
+evaluators' consensus score. This folds those events across every space
+into one table per (agent, version, model): how many, mean score, share of
+proposals, last seen. The weekly contract writes it to a log the briefing
+can quote; a version whose mean drops is visible the week it drops.
+
+    agent_outcomes.py [--root DIR] [--days N] [--json]
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import glob
+import json
+import os
+from collections import defaultdict
+from pathlib import Path
+
+ROOT = Path(os.environ.get("DATACORE_ROOT", str(Path.home() / "Data")))
+
+
+def outcomes(root: Path = ROOT, days: int = 90, now: float | None = None) -> list[dict]:
+    now = now or dt.datetime.now(dt.timezone.utc).timestamp()
+    cutoff = now - days * 86400
+    acc: dict[tuple, dict] = defaultdict(lambda: {"n": 0, "scored": 0, "score_sum": 0.0, "proposals": 0, "last": 0.0, "spaces": set()})
+    for f in glob.glob(str(root / "[0-9]-*" / ".datacore" / "events" / "*.jsonl")):
+        space = Path(f).parts[-4]
+        for line in Path(f).read_text(errors="replace").splitlines():
+            if '"item.complete"' not in line:
+                continue
+            try:
+                e = json.loads(line)
+            except ValueError:
+                continue
+            if e.get("type") != "item.complete":
+                continue
+            ms = str(e.get("hlc", "")).split(".")[0]
+            t = int(ms) / 1000 if ms.isdigit() else 0
+            if t < cutoff:
+                continue
+            p = e.get("payload") or {}
+            key = (str(p.get("agent") or e.get("actor") or "?"), str(p.get("agent_version") or ""), str(p.get("model") or ""))
+            a = acc[key]
+            a["n"] += 1; a["last"] = max(a["last"], t); a["spaces"].add(space)
+            if isinstance(p.get("score"), (int, float)):
+                a["scored"] += 1; a["score_sum"] += float(p["score"])
+            if p.get("decision") == "proposal":
+                a["proposals"] += 1
+    rows = []
+    for (agent, ver, model), a in sorted(acc.items(), key=lambda kv: -kv[1]["n"]):
+        rows.append({"agent": agent, "version": ver, "model": model, "completions": a["n"],
+                     "mean_score": round(a["score_sum"] / a["scored"], 3) if a["scored"] else None,
+                     "scored": a["scored"], "proposals": a["proposals"],
+                     "last": dt.datetime.fromtimestamp(a["last"], dt.timezone.utc).date().isoformat() if a["last"] else "",
+                     "spaces": sorted(a["spaces"])})
+    return rows
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--root", type=Path, default=ROOT)
+    ap.add_argument("--days", type=int, default=90)
+    ap.add_argument("--json", action="store_true")
+    a = ap.parse_args()
+    rows = outcomes(a.root, a.days)
+    stamp = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%MZ")
+    if a.json:
+        print(json.dumps(rows, indent=2)); return 0
+    print(f"{stamp} agent-outcomes: {len(rows)} (agent, version, model) row(s) over {a.days} days")
+    for r in rows:
+        ms = f"{r['mean_score']:.2f}" if r["mean_score"] is not None else "  --"
+        print(f"  {r['agent']:14} v{r['version'] or '-':6} {r['model'] or '-':22} n={r['completions']:4} score={ms} proposals={r['proposals']:3} last={r['last']} spaces={','.join(r['spaces'])[:40]}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.datacore/lib/cadence_liveness.py
+++ b/.datacore/lib/cadence_liveness.py
@@ -51,6 +51,42 @@ OUT = Path.home() / ".datacore" / "state" / "cadence-liveness.log"
 DEFAULT_GRACE = 3
 
 
+def sunset_reviews(root: Path, today: date | None = None) -> tuple[list[tuple[str, str, str]], list[tuple[str, str]]]:
+    """Stage 7: every recurring commitment has a review date and sunsets by
+    default. A venture may declare `cadence_reviews: {<cadence>: YYYY-MM-DD}`;
+    this reports cadences past their review date (defend or drop) and cadences
+    with no review date at all (the product's rule, unmet). Reported, not
+    enforced: dropping a cadence is the owner's act."""
+    import yaml
+    today = today or date.today()
+    past, undated = [], []
+    for vy in sorted(root.glob("[0-9]-*/venture.yaml")):
+        try:
+            v = yaml.safe_load(vy.read_text()) or {}
+        except Exception:  # noqa: BLE001
+            continue
+        if str(v.get("status") or "").lower() == "archived":
+            continue
+        reviews = v.get("cadence_reviews") or {}
+        names = set()
+        for role in (v.get("roles") or {}).values():
+            for lst in ((role or {}).get("cadences") or {}).values():
+                for c in (lst or []):
+                    names.add(str(c))
+        for c in sorted(names):
+            due = reviews.get(c)
+            if not due:
+                undated.append((vy.parent.name, c))
+                continue
+            try:
+                d = date.fromisoformat(str(due))
+            except ValueError:
+                undated.append((vy.parent.name, c)); continue
+            if d <= today:
+                past.append((vy.parent.name, c, d.isoformat()))
+    return past, undated
+
+
 def collect(root: Path, grace: int, today: date | None = None) -> list:
     """Overdue cadences across every space, via the engine that owns this."""
     import yaml
@@ -119,7 +155,10 @@ def main() -> int:
         lines.append(f"  {days:5}d  {space:<12} {role}.{freq}.{name}")
     # LAST LINE IS THE CONTRACT. Anchored so a report listing overdue
     # cadences can never pass by containing a 0 somewhere in a name.
-    lines.append(f"{len(rows)} cadence(s) overdue")
+    _past, _undated = sunset_reviews(root, today)
+    for _sp, _c, _d in _past:
+        lines.append(f"  past review: {_sp} {_c} (review due {_d})")
+    lines.append(f"{len(rows)} cadence(s) overdue; sunset review: {len(_past)} past due, {len(_undated)} without a review date")
     OUT.write_text("\n".join(lines) + "\n")
     print(lines[-1])
     return 0

--- a/.datacore/lib/claim_gate.py
+++ b/.datacore/lib/claim_gate.py
@@ -31,6 +31,7 @@ from actor_identity import principal_of, principals as _principals
 
 DEFAULT_MAX_HOPS = 3
 DEFAULT_MAX_CREATES_PER_DAY = 50
+ABSENT_AFTER_HOURS = 26  # a principal whose contracts have not been verified for this long is absent
 
 
 def _limits(actor: str, policy=None) -> tuple[str | None, dict, dict]:
@@ -42,7 +43,7 @@ def _limits(actor: str, policy=None) -> tuple[str | None, dict, dict]:
     return name, entry, lims
 
 
-def check_claim(actor: str, payload: dict | None, policy=None) -> tuple[bool, str]:
+def check_claim(actor: str, payload: dict | None, policy=None, space_dir: Path | None = None) -> tuple[bool, str]:
     name, entry, lims = _limits(actor, policy)
     if name is None:
         return False, f"unregistered writer {actor!r} — declare it in registry/principals.yaml"
@@ -50,6 +51,9 @@ def check_claim(actor: str, payload: dict | None, policy=None) -> tuple[bool, st
     never = set(lims.get("never_effects") or [])
     if effects & never:
         return False, f"{name} may never perform {', '.join(sorted(effects & never))}"
+    ok, why = check_budget(actor, space_dir)
+    if not ok:
+        return False, why
     return True, f"{name} may claim"
 
 
@@ -99,9 +103,127 @@ def check_create(actor: str, payload: dict | None, policy=None, space_dir: Path 
         allowed = rlims.get("may_delegate_to")
         if allowed is not None and assignee not in allowed:
             return False, f"{rname or requester} may not delegate to {assignee} (may_delegate_to: {', '.join(allowed) or 'nobody'})"
+    if assignee and assignee != actor:
+        is_absent, note = absent(str(assignee), root=(Path(space_dir).parent if space_dir else None))
+        if is_absent:
+            payload["assignee_absent"] = note  # recorded, never worked around
     if not human:
         cap = lims.get("max_creates_per_day", DEFAULT_MAX_CREATES_PER_DAY)
         n = creates_today(space_dir, actor, today)
         if n >= cap:
             return False, f"{name} has created {n} item(s) today; the allowance is {cap}"
     return True, f"{name} may create"
+
+
+def month_to_date_cents(space_dir: Path | None, writers: list[str], today: dt.date | None = None) -> int:
+    """Spend recorded this calendar month by any of a principal's writer logs."""
+    if not space_dir:
+        return 0
+    today = today or dt.datetime.now(dt.timezone.utc).date()
+    total = 0
+    for w in writers:
+        f = Path(space_dir) / ".datacore" / "events" / f"{w}.jsonl"
+        if not f.exists():
+            continue
+        for line in f.read_text(encoding="utf-8", errors="replace").splitlines():
+            if '"spend.record"' not in line:
+                continue
+            try:
+                e = json.loads(line)
+            except ValueError:
+                continue
+            if e.get("type") != "spend.record":
+                continue
+            ms = str(e.get("hlc", "")).split(".")[0]
+            if not ms.isdigit():
+                continue
+            d = dt.datetime.fromtimestamp(int(ms) / 1000, dt.timezone.utc).date()
+            if (d.year, d.month) == (today.year, today.month):
+                try:
+                    total += int((e.get("payload") or {}).get("cents") or 0)
+                except (TypeError, ValueError):
+                    pass
+    return total
+
+
+def check_budget(actor: str, space_dir: Path | None = None, today: dt.date | None = None) -> tuple[bool, str]:
+    """Stage 4: a declared monthly budget binds at claim time. Undeclared means no ceiling — and principals_check.py says so."""
+    name, entry, _ = _limits(actor)
+    if name is None:
+        return False, f"unregistered writer {actor!r}"
+    budget = entry.get("budget_monthly_usd")
+    if budget is None:
+        return True, f"{name}: no budget declared"
+    writers = [str(w) for w in (entry.get("writes_as") or [])] or [name]
+    spent = month_to_date_cents(space_dir, writers, today) / 100
+    if spent >= float(budget):
+        return False, f"{name} has spent {spent:.2f} of a {budget} USD monthly budget"
+    return True, f"{name}: {spent:.2f} of {budget} USD this month"
+
+
+def absent(principal: str, root: Path | None = None, now: float | None = None) -> tuple[bool, str]:
+    """Stage 5: is a principal absent? Its contracts are verified on its own
+    machine and attested to the ledger (job_verify -> metric.attest
+    job.verify). No passing attestation from any of its writers within
+    ABSENT_AFTER_HOURS means nobody has heard from it; an item addressed to it
+    waits and says why, and is never quietly reassigned."""
+    import glob, time
+    root = Path(root) if root else Path(__import__("os").environ.get("DATACORE_ROOT", str(Path.home() / "Data")))
+    now = now or time.time()
+    name, entry, _ = _limits(principal)
+    if name is None:
+        return True, f"unregistered principal {principal!r}"
+    writers = {str(w) for w in (entry.get("writes_as") or [])} | {name}
+    latest_ok, latest_any = 0.0, 0.0
+    for f in glob.glob(str(root / "[0-9]-*" / ".datacore" / "events" / "*.jsonl")) + glob.glob(str(root / ".datacore" / "events" / "*.jsonl")):
+        if Path(f).stem not in writers:
+            continue
+        for line in Path(f).read_text(encoding="utf-8", errors="replace").splitlines():
+            if '"job.verify"' not in line:
+                continue
+            try:
+                e = json.loads(line)
+            except ValueError:
+                continue
+            p = e.get("payload") or {}
+            if p.get("metric") != "job.verify":
+                continue
+            ms = str(e.get("hlc", "")).split(".")[0]
+            if not ms.isdigit():
+                continue
+            t = int(ms) / 1000
+            latest_any = max(latest_any, t)
+            if p.get("ok"):
+                latest_ok = max(latest_ok, t)
+    if not latest_any:
+        return True, f"{name}: never heard from (no job.verify attestation on the record)"
+    age_h = (now - latest_ok) / 3600 if latest_ok else float("inf")
+    if age_h > ABSENT_AFTER_HOURS:
+        return True, f"{name}: last passing verification {age_h:.0f}h ago" if latest_ok else f"{name}: verifications on the record, none passing"
+    return False, f"{name}: verified {age_h:.0f}h ago"
+
+
+def check_override(actor: str, item_id: str | None, space_dir: Path, policy=None) -> tuple[bool, str]:
+    """Stage 5 arbitration: closing, releasing or reassigning another
+    principal's item is allowed only for a principal that precedes the owner
+    in the policy's arbitration order. The owner itself is always allowed;
+    an unowned item is anyone's to close."""
+    order = list(getattr(policy, "arbitration", None) or [])
+    if not item_id:
+        return True, "no item"
+    try:
+        from ledger.fold import fold
+        from ledger.log import read_events
+        state = fold(read_events(Path(space_dir)))
+    except Exception as exc:  # noqa: BLE001
+        return True, f"could not fold {space_dir}: {exc}"
+    item = state.items.get(item_id)
+    if item is None or not getattr(item, "owner", None):
+        return True, "unowned"
+    owner_p = principal_of(str(item.owner))[0] or str(item.owner)
+    actor_p = principal_of(actor)[0] or actor
+    if owner_p == actor_p:
+        return True, "own item"
+    if actor_p in order and (owner_p not in order or order.index(actor_p) < order.index(owner_p)):
+        return True, f"{actor_p} arbitrates over {owner_p}"
+    return False, f"{actor_p} may not override {owner_p}'s item (arbitration: {' > '.join(order) or 'none declared'})"

--- a/.datacore/lib/datacore/ledger.py
+++ b/.datacore/lib/datacore/ledger.py
@@ -118,7 +118,12 @@ FUND_KINDS = frozenset({
 
 # Everything `attest` accepts. Kept as a union so a caller cannot pass a kind
 # from neither vocabulary without it being a plain typo.
-ATTEST_KINDS = EGRESS_KINDS | CREDENTIAL_KINDS | FUND_KINDS
+# Inbound sessions: a chat session is where a principal's authority is
+# exercised interactively, and until 2026-09-06 it left no mark on the
+# record. Not egress — nothing leaves — so no module manifest entry is due.
+SESSION_KINDS = frozenset({"chat.session"})
+
+ATTEST_KINDS = EGRESS_KINDS | CREDENTIAL_KINDS | FUND_KINDS | SESSION_KINDS
 
 
 def _core_lib() -> Path | None:

--- a/.datacore/lib/job_verify.py
+++ b/.datacore/lib/job_verify.py
@@ -422,6 +422,14 @@ def _run_doctor(machine: str, manifest_path: Path) -> None:
     print(report.table)
 
 
+def _attest_space() -> Path:
+    home = Path.home()
+    for cand in (DATACORE_ROOT / "2-datacore", DATACORE_ROOT / "0-personal", home / "spaces" / "5-plur", home / "Data" / "2-datacore"):
+        if (cand / ".datacore" / "events").is_dir() and (cand / ".git").exists():
+            return cand
+    return DATACORE_ROOT
+
+
 def main(argv: list[str] | None = None) -> None:
     args = build_parser().parse_args(argv)
     # See _dispatch_alert: a dry run must not inflate the recurrence streak.
@@ -434,7 +442,13 @@ def main(argv: list[str] | None = None) -> None:
         _run_doctor(args.machine, manifest_path)
         return
 
-    space = Path(args.space) if args.space else DATACORE_ROOT
+    # The attestation must land in a repository that CONVERGES. The root
+    # checkout on a runner never pushes, so a job.verify written there stayed
+    # on that host forever: on 2026-09-06 not one verifier attestation from
+    # any agent host had reached the operator's machine, and the per-principal
+    # scoreboard rows read "not heard from". First space that carries an event
+    # log wins; the root is the last resort.
+    space = Path(args.space) if args.space else _attest_space()
 
     try:
         jobs = load_manifest(manifest_path)

--- a/.datacore/lib/jobs/manifest.yaml
+++ b/.datacore/lib/jobs/manifest.yaml
@@ -54,6 +54,20 @@ jobs:
         arg: " UP "
         max_age_hours: 1
 
+  - name: box-agent-outcomes
+    machine: box
+    schedule: "45 5 * * 0"
+    cmd: "python3 ~/Data/.datacore/lib/agent_outcomes.py >> ~/.datacore/cos/agent-outcomes.log 2>&1"
+    on_fail: telegram
+    artifacts:
+      # One header line per weekly run ("<ts> agent-outcomes: N rows over D days")
+      # followed by one row per (agent, version, model): prompt versions tied to
+      # outcomes, stage 7 of the product description.
+      - path: "~/.datacore/cos/agent-outcomes.log"
+        check: regex
+        arg: "agent-outcomes:"
+        max_age_hours: 192
+
   - name: box-reliability-scoreboard
     machine: box
     schedule: "20 7 * * *"

--- a/.datacore/lib/ledger/policy.py
+++ b/.datacore/lib/ledger/policy.py
@@ -122,6 +122,8 @@ class Policy:
     #: None means the file declares no principals section; claim_gate applies
     #: its documented defaults then.
     principals: dict | None = None
+    #: Arbitration order across principals (stage 5): earlier outranks later.
+    arbitration: tuple[str, ...] | None = None
 
     @property
     def effective_known_effects(self) -> frozenset[str]:
@@ -216,10 +218,18 @@ def load_policy(path: Path | None = None) -> Policy:
                 if unknown:
                     errors.append(f"{path}: principals.{name} has unknown key(s): {', '.join(unknown)}")
                 principals[str(name)] = dict(lim)
+    arbitration: tuple[str, ...] | None = None
+    if "arbitration" in data:
+        raw_a = data.get("arbitration")
+        if not (isinstance(raw_a, list) and all(isinstance(e, str) and e for e in raw_a)):
+            errors.append(f"{path}: 'arbitration' must be a list of non-empty principal names (got {raw_a!r})")
+        else:
+            arbitration = tuple(raw_a)
     if errors:
         raise PolicyError("\n".join(errors))
 
-    return Policy(approver=approver, cosign_effects=cosign_effects, known_effects=known_effects, principals=principals)
+    return Policy(approver=approver, cosign_effects=cosign_effects, known_effects=known_effects,
+                  principals=principals, arbitration=arbitration)
 
 
 def requires_cosign(policy: Policy, event_type: str, payload: dict) -> bool:
@@ -307,6 +317,27 @@ def guarded_append(
     cryptographic guarantee (that requires `DATACORE_LEDGER_SIGN=1`).
     """
     policy = policy if policy is not None else load_policy()
+
+    if type == "item.grant" and policy is not None:
+        # Stage 4: a grant is the approver's act. Any other writer minting a
+        # grant would let an agent widen its own authority by delegation.
+        who = getattr(log, "actor", None) or ""
+        if who != policy.approver:
+            raise PolicyError(f"item.grant refused for {who!r}: only the approver ({policy.approver}) may grant")
+    if type in ("item.dismiss", "item.release", "owner.set") and policy is not None and getattr(policy, "arbitration", None):
+        # Stage 5: closing, releasing or reassigning ANOTHER principal's item is
+        # arbitration, and the order in the policy file decides who may.
+        who = getattr(log, "actor", None) or ""
+        sd = space_dir or getattr(log, "space_dir", None)
+        if sd is not None:
+            try:
+                from claim_gate import check_override
+            except ImportError:
+                check_override = None
+            if check_override is not None:
+                _ok, _why = check_override(who, payload.get("id"), Path(sd), policy=policy)
+                if not _ok:
+                    raise PolicyError(f"{type} refused for {who!r}: {_why}")
 
     if type == "item.create":
         effects = payload.get("effects")

--- a/.datacore/lib/ledger_claim.py
+++ b/.datacore/lib/ledger_claim.py
@@ -375,7 +375,7 @@ def main() -> int:
 
         # Claim BEFORE working, so an interrupted run is visible as claimed.
         from claim_gate import check_claim
-        _ok, _why = check_claim(args.actor, item.payload or {})
+        _ok, _why = check_claim(args.actor, item.payload or {}, space_dir=space)
         if not _ok:
             print(f"REFUSED  {(item.payload or {}).get('title', item.id)[:60]}\n         -> {_why}")
             continue

--- a/.datacore/lib/principals_check.py
+++ b/.datacore/lib/principals_check.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Is every principal a principal yet? The ten things, checked, not assumed.
+
+The product description says a principal missing any of its ten things is
+not yet a principal and the system says so. This is where the system says
+so: for each entry in registry/principals.yaml it reports what is declared
+and what is not — charter on disk, contracts in the manifest, budget,
+memory scope, emails, host — and prints one line per principal. Exit 0 with
+the table; the checklist carries it as informational (n-a is never a pass,
+but an undeclared budget is the owner's decision, not an outage).
+
+    principals_check.py [--root DIR] [--json]
+"""
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import os
+import sys
+from pathlib import Path
+
+LIB = Path(__file__).resolve().parent
+ROOT = Path(os.environ.get("DATACORE_ROOT", str(LIB.parent.parent)))
+sys.path.insert(0, str(LIB))
+
+TEN = ("identity", "purpose", "memory", "cadence", "decision_rights", "budget", "record", "peer_protocol", "health", "evolution")
+
+
+def _manifest_jobs(root: Path) -> list[str]:
+    try:
+        import yaml
+        d = yaml.safe_load((root / ".datacore" / "lib" / "jobs" / "manifest.yaml").read_text()) or {}
+        return [j.get("name", "") for j in d.get("jobs") or []]
+    except Exception:  # noqa: BLE001
+        return []
+
+
+def check(root: Path = ROOT) -> list[dict]:
+    from actor_identity import principals
+    ps = principals(root / ".datacore" / "registry" / "principals.yaml")
+    jobs = _manifest_jobs(root)
+    rows = []
+    for name, p in ps.items():
+        kind = str(p.get("kind") or "")
+        charter = p.get("charter")
+        charter_ok = bool(charter) and (root / str(charter)).exists()
+        pat = p.get("contracts")
+        contracts = [j for j in jobs if pat and fnmatch.fnmatch(j, str(pat))]
+        missing = []
+        if not (p.get("emails") or kind == "migration"):
+            missing.append("identity: no emails")
+        if kind == "agent" and not charter_ok:
+            missing.append("purpose: charter missing" if charter else "purpose: no charter")
+        if kind == "agent" and not p.get("memory_scope"):
+            missing.append("memory: no scope")
+        if kind == "agent" and p.get("budget_monthly_usd") is None:
+            missing.append("budget: not declared")
+        if kind == "agent" and not contracts:
+            missing.append("health: no contract")
+        if kind == "agent" and not p.get("permission_mode"):
+            missing.append("decision_rights: no permission mode")
+        rows.append({"principal": name, "kind": kind, "charter": charter_ok, "contracts": len(contracts),
+                     "budget": p.get("budget_monthly_usd"), "memory_scope": p.get("memory_scope"), "missing": missing})
+    return rows
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--root", type=Path, default=ROOT)
+    ap.add_argument("--json", action="store_true")
+    a = ap.parse_args()
+    rows = check(a.root)
+    if a.json:
+        print(json.dumps(rows, indent=2)); return 0
+    for r in rows:
+        state = "complete" if not r["missing"] else "; ".join(r["missing"])
+        print(f"  {r['principal']:10} {r['kind']:9} charter={'ok' if r['charter'] else '--'} contracts={r['contracts']:2} budget={r['budget'] if r['budget'] is not None else '--':>6} memory={r['memory_scope'] or '--':16} {state}")
+    n = sum(1 for r in rows if r["kind"] == "agent" and not r["missing"])
+    total = sum(1 for r in rows if r["kind"] == "agent")
+    print(f"  {n}/{total} agent principal(s) complete")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.datacore/lib/reliability_scoreboard.py
+++ b/.datacore/lib/reliability_scoreboard.py
@@ -235,6 +235,68 @@ def r6_rebuildable(cos: Path, day: str) -> tuple[bool, str]:
     return not fails, (f"{len(fails)} FAIL line(s)" if fails else "0 FAIL")
 
 
+
+def principal_rows(root: Path, now: float | None = None, hours: float = 26.0) -> list[dict]:
+    """One row per agent principal (product description: a scoreboard row per
+    principal). Its health is what its own machine's verifier attested to the
+    ledger (job_verify -> metric.attest job.verify) within the window: how many
+    contracts passed, how many failed, how long ago. A principal nobody has
+    heard from is a row that says so, not a missing row."""
+    import glob, sys
+    now = now or time.time()
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    try:
+        from actor_identity import principals
+        ps = principals(root / ".datacore" / "registry" / "principals.yaml")
+    except Exception:  # noqa: BLE001
+        return []
+    latest: dict[str, dict] = {}
+    for f in glob.glob(str(root / "[0-9]-*" / ".datacore" / "events" / "*.jsonl")) + glob.glob(str(root / ".datacore" / "events" / "*.jsonl")):
+        writer = Path(f).stem
+        for line in Path(f).read_text(errors="replace").splitlines():
+            if '"job.verify"' not in line:
+                continue
+            try:
+                e = json.loads(line)
+            except ValueError:
+                continue
+            p = e.get("payload") or {}
+            if p.get("metric") != "job.verify":
+                continue
+            ms = str(e.get("hlc", "")).split(".")[0]
+            if not ms.isdigit():
+                continue
+            t = int(ms) / 1000
+            if now - t > hours * 3600:
+                continue
+            job = str(p.get("job") or "")
+            cur = latest.setdefault(writer, {})
+            if job not in cur or cur[job]["t"] < t:
+                cur[job] = {"t": t, "ok": bool(p.get("ok"))}
+    rows = []
+    for name, p in ps.items():
+        if str(p.get("kind") or "") != "agent":
+            continue
+        writers = {str(w) for w in (p.get("writes_as") or [])} | {name}
+        jobs: dict[str, dict] = {}
+        for w in writers:
+            for job, rec in latest.get(w, {}).items():
+                if job not in jobs or jobs[job]["t"] < rec["t"]:
+                    jobs[job] = rec
+        if not jobs:
+            rows.append({"principal": name, "ok": None, "note": f"not heard from in {hours:.0f}h"})
+            continue
+        failing = sorted(j for j, r in jobs.items() if not r["ok"])
+        age_h = (now - max(r["t"] for r in jobs.values())) / 3600
+        rows.append({"principal": name, "ok": not failing,
+                     "note": f"{len(jobs) - len(failing)}/{len(jobs)} contracts verified {age_h:.0f}h ago" + (f"; failing: {', '.join(failing)[:80]}" if failing else "")})
+    return rows
+
+
+def principal_lines(rows: list[dict]) -> list[str]:
+    return [f"  principal={r['principal']} {'ok' if r['ok'] else ('n-a' if r['ok'] is None else 'FAIL')} | {r['note']}" for r in rows]
+
+
 def level(streak: int) -> int:
     return 5 if streak >= 30 else 4 if streak >= 7 else 3
 
@@ -277,6 +339,9 @@ def main() -> int:
     state, cos = Path(a.state), Path(a.cos)
     r = compute(a.date, state, cos)
     out = line(r)
+    prow = principal_rows(Path(os.environ.get("DATACORE_ROOT", str(Path.home() / "Data"))))
+    for ln in principal_lines(prow):
+        print(ln)
     if not a.no_write:
         state.mkdir(parents=True, exist_ok=True)
         log = state / "reliability-scoreboard.log"

--- a/.datacore/lib/tests/fixtures/jobs/box-agent-outcomes.0.txt
+++ b/.datacore/lib/tests/fixtures/jobs/box-agent-outcomes.0.txt
@@ -1,0 +1,2 @@
+2026-09-06T05:45Z agent-outcomes: 3 (agent, version, model) row(s) over 90 days
+  research       v1.0.0  claude-opus-5           n=  12 score=0.78 proposals=  1 last=2026-09-05 spaces=2-datacore,5-plur

--- a/.datacore/lib/tests/test_ledger_policy.py
+++ b/.datacore/lib/tests/test_ledger_policy.py
@@ -10,6 +10,17 @@ from __future__ import annotations
 
 import pytest
 
+
+@pytest.fixture(autouse=True)
+def _register_test_writers(tmp_path_factory, monkeypatch):
+    """Since 2026-09-06 an item.create by an unregistered writer is refused
+    before any other check (claim_gate). These tests use short-lived writer
+    names; register them for the duration of each test."""
+    import actor_identity
+    p = tmp_path_factory.mktemp("reg") / "principals.yaml"
+    p.write_text("principals:\n  worker: {kind: agent, writes_as: [worker, w, agent]}\n  human: {kind: human, writes_as: [human, approver, mac, test]}\n")
+    monkeypatch.setattr(actor_identity, "PRINCIPALS", p)
+
 from ledger.events import EVENT_TYPES
 from ledger.log import EventLog, read_events
 from ledger.policy import Policy, PolicyError, guarded_append, load_policy, requires_cosign

--- a/.datacore/lib/tests/test_stages_gates.py
+++ b/.datacore/lib/tests/test_stages_gates.py
@@ -1,0 +1,109 @@
+"""Stages 2, 4, 5, 7, 8 root-side: budget at claim, grant co-sign, arbitration override, absence, signing, rows, outcomes."""
+import datetime as dt, importlib.util, json, pathlib, sys, time
+LIB = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(LIB))
+import pytest  # noqa: E402
+import claim_gate as G  # noqa: E402
+from ledger.log import EventLog  # noqa: E402
+from ledger.policy import Policy, guarded_append, PolicyError, load_policy  # noqa: E402
+
+
+def _reg(monkeypatch, tmp_path, budget=None):
+    p = tmp_path / "principals.yaml"
+    p.write_text(f"principals:\n  gregor: {{kind: human, writes_as: [mac]}}\n  winston: {{kind: agent, writes_as: [winston]}}\n  miles: {{kind: agent, writes_as: [miles, nightshift]{', budget_monthly_usd: ' + str(budget) if budget is not None else ''}}}\n  data: {{kind: agent, writes_as: [data]}}\n")
+    import actor_identity
+    monkeypatch.setattr(actor_identity, "PRINCIPALS", p)
+    return p
+
+
+def _space(tmp_path, name="5-plur"):
+    sd = tmp_path / name; (sd / ".datacore" / "events").mkdir(parents=True); return sd
+
+
+def test_budget_binds_at_claim_once_declared(tmp_path, monkeypatch):
+    _reg(monkeypatch, tmp_path, budget=10)
+    sd = _space(tmp_path)
+    log = EventLog(sd, "miles")
+    log.append("spend.record", {"cents": 900, "ref": "llm"})
+    assert G.check_claim("miles", {}, space_dir=sd)[0]
+    log.append("spend.record", {"cents": 200, "ref": "llm"})
+    ok, why = G.check_claim("miles", {}, space_dir=sd)
+    assert not ok and "spent 11.00 of a 10" in why
+    _reg(monkeypatch, tmp_path)  # undeclared: no ceiling, said so
+    assert G.check_budget("miles", sd) == (True, "miles: no budget declared")
+
+
+def test_only_the_approver_may_grant(tmp_path, monkeypatch):
+    _reg(monkeypatch, tmp_path)
+    sd = _space(tmp_path)
+    pol = Policy(approver="mac", cosign_effects=frozenset({"email.send"}), principals={})
+    with pytest.raises(PolicyError, match="only the approver"):
+        guarded_append(EventLog(sd, "data"), "item.grant", {"id": "g1", "effects": ["email.send"]}, policy=pol, space_dir=sd)
+    guarded_append(EventLog(sd, "mac"), "item.grant", {"id": "g1", "effects": ["email.send"]}, policy=pol, space_dir=sd)
+
+
+def test_arbitration_order_decides_who_may_close_anothers_item(tmp_path, monkeypatch):
+    _reg(monkeypatch, tmp_path)
+    sd = _space(tmp_path)
+    pol = Policy(approver="mac", cosign_effects=frozenset(), principals={}, arbitration=("gregor", "winston"))
+    log = EventLog(sd, "miles")
+    log.append("item.create", {"id": "t1", "title": "x"}); log.append("item.claim", {"id": "t1", "executor": "nightshift"})
+    with pytest.raises(PolicyError, match="may not override"):
+        guarded_append(EventLog(sd, "data"), "item.dismiss", {"id": "t1", "kind": "dropped", "reason": "no"}, policy=pol, space_dir=sd)
+    guarded_append(EventLog(sd, "miles"), "item.release", {"id": "t1", "reason": "own"}, policy=pol, space_dir=sd)
+    log.append("item.claim", {"id": "t1", "executor": "nightshift"})
+    guarded_append(EventLog(sd, "winston"), "item.dismiss", {"id": "t1", "kind": "dropped", "reason": "arbitrated"}, policy=pol, space_dir=sd)
+
+
+def test_policy_loads_arbitration():
+    pol = load_policy(LIB.parent / "config" / "approvals_policy.yaml")
+    assert pol.arbitration and pol.arbitration[0] == "gregor"
+
+
+def test_absence_is_read_from_the_verifiers_attestations(tmp_path, monkeypatch):
+    _reg(monkeypatch, tmp_path)
+    root = tmp_path; sd = _space(root, "2-datacore")
+    assert G.absent("data", root=root)[0] is True
+    log = EventLog(sd, "data")
+    log.append("metric.attest", {"metric": "job.verify", "job": "plur-claw-ledger-dispatch", "ok": True, "failures": []})
+    is_absent, note = G.absent("data", root=root)
+    assert not is_absent and "verified 0h ago" in note
+    is_absent, _ = G.absent("data", root=root, now=time.time() + 30 * 3600)
+    assert is_absent
+    payload = {"id": "n1", "title": "for winston", "assignee": "winston", "requested_by": "data"}
+    ok, _ = G.check_create("data", payload, policy=Policy(approver="mac", cosign_effects=frozenset(), principals={}), space_dir=sd)
+    assert ok and "never heard from" in payload["assignee_absent"]
+
+
+def test_signed_events_verify_with_the_registered_key(tmp_path, monkeypatch):
+    from ledger.keys import verify as key_verify
+    from ledger.events import canonical_bytes
+    sd = _space(tmp_path); keys = tmp_path / "keys"; reg = tmp_path / "keys-registry.yaml"
+    log = EventLog(sd, "miles", keys_dir=keys, registry_path=reg, sign=True)
+    ev = log.append("item.create", {"id": "s1", "title": "signed"})
+    line = json.loads((sd / ".datacore" / "events" / "miles.jsonl").read_text().splitlines()[-1])
+    assert line.get("sig")
+    body = {k: v for k, v in line.items() if k not in ("sig", "hash")}
+    assert key_verify("miles", canonical_bytes(body), line["sig"], registry_path=reg)
+    body["payload"] = {"id": "s1", "title": "tampered"}
+    assert not key_verify("miles", canonical_bytes(body), line["sig"], registry_path=reg)
+
+
+def test_principal_rows_and_outcomes(tmp_path, monkeypatch):
+    _reg(monkeypatch, tmp_path)
+    root = tmp_path; sd = _space(root, "2-datacore")
+    spec = importlib.util.spec_from_file_location("rs", LIB / "reliability_scoreboard.py"); R = importlib.util.module_from_spec(spec); spec.loader.exec_module(R)
+    EventLog(sd, "nightshift").append("metric.attest", {"metric": "job.verify", "job": "nightshift-overnight", "ok": True, "failures": []})
+    EventLog(sd, "miles").append("metric.attest", {"metric": "job.verify", "job": "nightshift-miles-bot", "ok": False, "failures": ["stale"]})
+    (root / ".datacore" / "registry").mkdir(parents=True); (root / ".datacore" / "registry" / "principals.yaml").write_text((tmp_path / "principals.yaml").read_text())
+    rows = {r["principal"]: r for r in R.principal_rows(root)}
+    assert rows["miles"]["ok"] is False and "1/2 contracts" in rows["miles"]["note"] and "nightshift-miles-bot" in rows["miles"]["note"]
+    assert rows["data"]["ok"] is None
+    spec2 = importlib.util.spec_from_file_location("ao", LIB / "agent_outcomes.py"); A = importlib.util.module_from_spec(spec2); spec2.loader.exec_module(A)
+    log = EventLog(sd, "nightshift")
+    for i, sc in enumerate((0.8, 0.6)):
+        log.append("item.create", {"id": f"o{i}", "title": "x"}); log.append("item.claim", {"id": f"o{i}", "executor": "nightshift"})
+        log.append("item.complete", {"id": f"o{i}", "score": sc, "agent": "research", "agent_version": "1.0.0", "model": "m1"})
+    out = A.outcomes(root, days=1)
+    row = next(r for r in out if r["agent"] == "research")
+    assert row["completions"] == 2 and row["mean_score"] == 0.7 and row["version"] == "1.0.0"

--- a/.datacore/lib/v2_verify.py
+++ b/.datacore/lib/v2_verify.py
@@ -315,6 +315,87 @@ def check_writer_authorship(rep: Report) -> None:
             detail if ok else f"{len(foreign)} foreign: " + "; ".join(foreign[:3]))
 
 
+
+def check_principals(rep: Report) -> None:
+    """Every agent principal has its ten things, or the checklist says which
+    are missing. Informational (n-a, never a pass): an undeclared budget is
+    the owner's decision, not an outage, but it must not be invisible."""
+    sys.path.insert(0, str(LIB))
+    try:
+        from principals_check import check
+        rows = check(ROOT)
+    except Exception as exc:  # noqa: BLE001
+        rep.add("0044", "principals complete", None, f"principals_check unusable: {exc}")
+        return
+    agents = [r for r in rows if r["kind"] == "agent"]
+    incomplete = [r for r in agents if r["missing"]]
+    if not agents:
+        rep.add("0044", "principals complete", None, "no agent principals registered")
+    elif not incomplete:
+        rep.add("0044", "principals complete", True, f"{len(agents)}/{len(agents)} agent principals have their ten things")
+    else:
+        rep.add("0044", "principals complete", None,
+                f"{len(agents) - len(incomplete)}/{len(agents)} complete; " + "; ".join(f"{r['principal']}: {', '.join(r['missing'])}" for r in incomplete)[:220])
+
+
+def check_signed_events(rep: Report) -> None:
+    """Stage 8: are this writer's events signed, and do the signatures verify
+    with the key the keys registry holds for it? Off is reported, not hidden."""
+    sys.path.insert(0, str(LIB))
+    import socket
+    try:
+        from actor_identity import this_actor
+        from ledger.keys import verify as key_verify, DEFAULT_REGISTRY_PATH
+        from ledger.events import canonical_bytes, body_dict
+    except Exception as exc:  # noqa: BLE001
+        rep.add("0044", "events signed", None, f"signing libs unusable: {exc}")
+        return
+    ident = _read_identity_env()
+    if ident.get("DATACORE_LEDGER_SIGN") != "1":
+        rep.add("0044", "events signed", None, "signing off (DATACORE_LEDGER_SIGN is not 1 in identity.env)")
+        return
+    actor = this_actor()
+    checked = bad = 0
+    for f in ROOT.glob(f"[0-9]-*/.datacore/events/{actor}.jsonl"):
+        lines = [l for l in f.read_text(errors="replace").splitlines() if l.strip()][-20:]
+        for line in lines:
+            try:
+                e = json.loads(line)
+            except ValueError:
+                continue
+            sig = e.get("sig")
+            if not sig:
+                continue
+            checked += 1
+            body = {k: v for k, v in e.items() if k not in ("sig", "hash")}  # log.py signs the body before hash and sig are added
+            try:
+                if not key_verify(actor, canonical_bytes(body), sig):
+                    bad += 1
+            except Exception:  # noqa: BLE001
+                bad += 1
+    if not checked:
+        rep.add("0044", "events signed", False, f"signing on but no signed event found in {actor}'s recent log tails")
+    else:
+        rep.add("0044", "events signed", bad == 0, f"{checked - bad}/{checked} recent signatures verify" + (f"; {bad} bad" if bad else ""))
+
+
+def _read_identity_env() -> dict:
+    p = Path.home() / ".datacore" / "identity.env"
+    out = {}
+    try:
+        for raw in p.read_text().splitlines():
+            line = raw.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            if line.startswith("export "):
+                line = line[7:].lstrip()
+            k, v = line.split("=", 1)
+            out[k.strip()] = v.strip().strip("\"'")
+    except OSError:
+        pass
+    return out
+
+
 # ── DIP-0046: git transport ─────────────────────────────────────────────────
 def check_transport(rep: Report) -> None:
     t = LIB / "ledger_transport.py"
@@ -684,6 +765,8 @@ def main() -> int:
     check_app(rep)
     check_declared_identity(rep)
     check_writer_authorship(rep)
+    check_principals(rep)
+    check_signed_events(rep)
     check_egress(rep)
     if not a.quick:
         check_fleet(rep)

--- a/.datacore/registry/principals.yaml
+++ b/.datacore/registry/principals.yaml
@@ -4,7 +4,10 @@
 # by commits authored with one of the principal's `emails`; v2_verify checks it.
 #
 # Facts only. A field that is not yet decided is null and stays null until the
-# owner decides it — a made-up budget is worse than none.
+# owner decides it — a made-up budget is worse than none. `budget_monthly_usd`
+# is enforced at claim time by claim_gate once declared (spend.record events,
+# month to date); null means "no ceiling declared", and principals_check.py
+# reports it as such every day.
 version: 1
 principals:
   gregor:
@@ -31,7 +34,7 @@ principals:
     delegates_to: [miles, tris]
     charter: 8-firm/1-tracks/principals/winston.md
     contracts: box-*
-    memory_scope: null
+    memory_scope: agent:winston
     budget_monthly_usd: null
     permission_mode: propose            # proposes; the client approves external actions
   miles:
@@ -47,7 +50,7 @@ principals:
     executors: [nightshift]
     charter: 8-firm/1-tracks/principals/miles.md
     contracts: nightshift-*
-    memory_scope: null
+    memory_scope: agent:miles
     budget_monthly_usd: null
     permission_mode: bypass             # bot: bypassPermissions; nightshift: --dangerously-skip-permissions
   tris:
@@ -62,7 +65,7 @@ principals:
       roles: [8-firm:cio, 5-plur:(venture.yaml)]
     charter: 8-firm/1-tracks/principals/tris.md
     contracts: hermes-*
-    memory_scope: null
+    memory_scope: agent:tris
     budget_monthly_usd: null
     permission_mode: yolo               # HERMES_YOLO_MODE=1
   data:
@@ -77,9 +80,9 @@ principals:
       roles: [8-firm:comms, 5-plur:(venture.yaml)]
     charter: 8-firm/1-tracks/principals/data.md
     contracts: plur-claw-*
-    memory_scope: null
+    memory_scope: agent:data
     budget_monthly_usd: null
-    permission_mode: null
+    permission_mode: propose            # drafts; a human approves anything that leaves
   genesis:
     kind: migration
     display: genesis import (2026-08-10, one shot)


### PR DESCRIPTION
Memory scopes declared; principals_check + checklist line; budget enforced at claim; only the approver grants; arbitration order for overriding another's item; assignee absence recorded from the verifier's attestations (which now land in a converging space); scoreboard rows per principal; agent_outcomes weekly; sunset reviews in liveness; signing declared by the host installer and verified by the checklist; chat.session attest kind. 125 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)