### PR TITLE
signing follows the identity file; plur-claw trusts GitHub by fingerprint; overnight contract reads the latest manifest

### DIFF
--- a/.datacore/lib/agent_host_setup.sh
+++ b/.datacore/lib/agent_host_setup.sh
@@ -67,6 +67,26 @@ case "$HOST" in
     CRON_LINES+=("25 * * * * DATACORE_ROOT=$HOME/spaces $LIB/ledger_phase1_cycle.sh >> $STATE/phase1-cycle.log 2>&1")
     CRON_LINES+=("*/15 * * * * $LIB/ledger-claim-pull.sh >> $STATE/ledger-dispatch.log 2>&1")
     ;;
+esac
+# ── known hosts the dispatch space needs (plur-claw fetches plur-space over ssh) ──
+# The runner user's known_hosts was empty after the /root -> /home/gregor move
+# (DIP-0044 §3), so every fetch since 2026-08-13 failed "host key verification"
+# and the dispatcher's pull error was swallowed. The key is added only when its
+# fingerprint matches the one GitHub publishes; never blindly.
+ensure_github_host_key() {
+  local kh="$HOME/.ssh/known_hosts"; mkdir -p "$HOME/.ssh"; chmod 700 "$HOME/.ssh"
+  if ssh-keygen -F github.com -f "$kh" >/dev/null 2>&1; then log "OK  github.com in known_hosts"; return 0; fi
+  [ "$VERIFY_ONLY" = 0 ] || { log "FAIL github.com not in known_hosts"; fail=1; return 0; }
+  local scanned; scanned="$(ssh-keyscan -t ed25519 github.com 2>/dev/null | grep -v '^#')"
+  local fp; fp="$(printf '%s\n' "$scanned" | ssh-keygen -lf - 2>/dev/null | awk '{print $2}')"
+  if [ "$fp" = "SHA256:+DiY3wvvV6TuJJhbpZisF/zLDA0zPMSvHdkr4UvCOqU" ]; then
+    printf '%s\n' "$scanned" >> "$kh"; chmod 600 "$kh"; log "github.com host key added (fingerprint verified against GitHub's published ed25519 key)"
+  else
+    log "FAIL github.com host key fingerprint did not match GitHub's published key ($fp) — not added"; fail=1
+  fi
+}
+case "$HOST" in
+  plur-claw) ensure_github_host_key ;;
   hermes)
     : # Tris's heartbeat is a systemd timer (tris-heartbeat.timer); no spaces to project here
     ;;

--- a/.datacore/lib/ledger/log.py
+++ b/.datacore/lib/ledger/log.py
@@ -90,6 +90,24 @@ class CorruptLogError(ValueError):
     """
 
 
+
+def _identity_file_value(key: str) -> str | None:
+    """A value from ~/.datacore/identity.env (the machine's declaration), or None."""
+    p = Path(os.environ.get("DATACORE_IDENTITY_FILE", str(Path.home() / ".datacore" / "identity.env")))
+    try:
+        for raw in p.read_text(encoding="utf-8", errors="replace").splitlines():
+            line = raw.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            if line.startswith("export "):
+                line = line[7:].lstrip()
+            k, v = line.split("=", 1)
+            if k.strip() == key:
+                return v.strip().strip("\"'")
+    except OSError:
+        pass
+    return None
+
 class EventLog:
     """Append-only event log for one actor within one space.
 
@@ -124,7 +142,15 @@ class EventLog:
         self.actor = actor
         self.keys_dir = keys_dir
         self.registry_path = registry_path
-        self.sign = sign if sign is not None else os.environ.get("DATACORE_LEDGER_SIGN") == "1"
+        # The switch lives with the identity (DIP-0044 §6): a cron or a unit
+        # rarely exports it, and on 2026-09-06 three hosts had declared signing
+        # in identity.env while every event they appended stayed unsigned.
+        if sign is None:
+            env = os.environ.get("DATACORE_LEDGER_SIGN")
+            if env is None:
+                env = _identity_file_value("DATACORE_LEDGER_SIGN")
+            sign = env == "1"
+        self.sign = sign
         # VALIDATE THE ACTOR NAME. It becomes a filename, so "../x" writes
         # <space>/x.jsonl — inside the space, but OUTSIDE events/, where
         # read_events never globs. The events are written, accepted, chained,

--- a/.datacore/lib/tests/test_stages_gates.py
+++ b/.datacore/lib/tests/test_stages_gates.py
@@ -107,3 +107,16 @@ def test_principal_rows_and_outcomes(tmp_path, monkeypatch):
     out = A.outcomes(root, days=1)
     row = next(r for r in out if r["agent"] == "research")
     assert row["completions"] == 2 and row["mean_score"] == 0.7 and row["version"] == "1.0.0"
+
+
+def test_signing_switch_is_read_from_the_identity_file(tmp_path, monkeypatch):
+    monkeypatch.delenv("DATACORE_LEDGER_SIGN", raising=False)
+    ident = tmp_path / "identity.env"; ident.write_text("DATACORE_ACTOR=miles\nDATACORE_LEDGER_SIGN=1\n")
+    monkeypatch.setenv("DATACORE_IDENTITY_FILE", str(ident))
+    sd = _space(tmp_path)
+    log = EventLog(sd, "miles", keys_dir=tmp_path / "k", registry_path=tmp_path / "r.yaml")
+    assert log.sign is True
+    log.append("item.create", {"id": "s2", "title": "signed by declaration"})
+    assert json.loads((sd / ".datacore" / "events" / "miles.jsonl").read_text().splitlines()[-1])["sig"]
+    ident.write_text("DATACORE_ACTOR=miles\n")
+    assert EventLog(sd, "miles", keys_dir=tmp_path / "k", registry_path=tmp_path / "r.yaml").sign is False


### PR DESCRIPTION
The signing switch is read from identity.env when the environment is silent (declared signing signed nothing). The plur-claw installer adds GitHub's host key only when its fingerprint matches the published one. The overnight contract reads manifest-latest.yaml. 71 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)