### PR TITLE
checklist: reviewed authorship incidents stay on the record and stop re-flagging

### DIFF
--- a/.datacore/config/authorship-reviewed.yaml
+++ b/.datacore/config/authorship-reviewed.yaml
@@ -1,0 +1,13 @@
+# Commits the authorship check has flagged and a human has reviewed. Each entry
+# is an incident on the record, not a pardon: the writer's principal, who
+# actually committed, what happened, and what was done about it. The check
+# skips a listed commit and keeps flagging everything else.
+version: 1
+reviewed:
+  - commit: e3c8068e
+    space: 5-plur
+    writer: winston
+    committed_by: tris@datacore.one
+    date: 2026-09-06
+    what: "A geo cadence run on hermes (clone ~/Data/2-plur) committed with `git add -A` and swept two ingest events that a process on that host had written under actor winston (hlc .winston) — a misattributed writer on the wrong host, carried under Tris's name."
+    action: "Reviewed 2026-09-06 08:00. Source fix: the hermes clone must write as tris only and stage its own paths; tracked in the 2-datacore inbox."

--- a/.datacore/lib/v2_verify.py
+++ b/.datacore/lib/v2_verify.py
@@ -272,6 +272,17 @@ def check_identity(rep: Report) -> None:
 
 
 
+def _reviewed_commits() -> set[str]:
+    """Short hashes a human has reviewed (config/authorship-reviewed.yaml)."""
+    p = ROOT / ".datacore" / "config" / "authorship-reviewed.yaml"
+    try:
+        import yaml
+        d = yaml.safe_load(p.read_text()) or {}
+        return {str(e.get("commit", "")).strip() for e in (d.get("reviewed") or []) if e.get("commit")}
+    except Exception:  # noqa: BLE001
+        return set()
+
+
 def check_writer_authorship(rep: Report) -> None:
     """Was each writer's log only ever appended by its own principal?
 
@@ -294,6 +305,7 @@ def check_writer_authorship(rep: Report) -> None:
     if not principals():
         rep.add("0044", "writer logs authored by their principal", None, "principals.yaml absent or empty")
         return
+    reviewed = _reviewed_commits()
     foreign, unbound, seen = [], set(), 0
     for f in sorted(ROOT.glob("[0-9]-*/.datacore/events/*.jsonl")):
         space, writer = f.parts[-4], f.stem
@@ -302,13 +314,21 @@ def check_writer_authorship(rep: Report) -> None:
             unbound.add(writer)
             continue
         rc, out = run(["git", "-C", str(ROOT / space), "log", "--no-merges", "--since=2026-09-05",
-                       "--format=%ae", "--", str(f.relative_to(ROOT / space))], 60)
+                       "--format=%h %ae", "--", str(f.relative_to(ROOT / space))], 60)
         if rc != 0:
             continue
         seen += 1
-        bad = sorted({e.strip().lower() for e in out.splitlines() if e.strip()} - allowed)
+        bad = set()
+        for line in out.splitlines():
+            parts = line.strip().split()
+            if len(parts) < 2:
+                continue
+            sha, email = parts[0], parts[1].lower()
+            if email in allowed or any(sha.startswith(r) for r in reviewed):
+                continue  # a reviewed incident stays on the record in authorship-reviewed.yaml
+            bad.add(email)
         if bad:
-            foreign.append(f"{space}/{writer} by {', '.join(bad)[:60]}")
+            foreign.append(f"{space}/{writer} by {', '.join(sorted(bad))[:60]}")
     ok = not foreign
     detail = f"{seen} log(s) checked" + (f"; unbound writer(s): {', '.join(sorted(unbound))}" if unbound else "")
     rep.add("0044", "writer logs authored by their principal", ok,


### PR DESCRIPTION
config/authorship-reviewed.yaml lists flagged commits a human reviewed (with what happened and what was done); the check skips them and keeps flagging everything else. First entry: the 2026-09-06 hermes geo-cadence commit that swept two winston-actor events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)