### PR TITLE
verify keys distributed; one clone per writer on plur-claw; hermes converges; plur-claw runs openclaw

### DIFF
--- a/.datacore/lib/agent_host_setup.sh
+++ b/.datacore/lib/agent_host_setup.sh
@@ -52,6 +52,11 @@ if [ "$VERIFY_ONLY" = 0 ]; then
     printf '%s\n' "DATACORE_LEDGER_SIGN=1" >> "$ID_FILE"; log "signing on for $ACTOR (DATACORE_LEDGER_SIGN=1)"
   fi
   mkdir -p "$HOME/.datacore/keys"; chmod 700 "$HOME/.datacore/keys"
+  # The executor this host runs delegated items through (ledger_claim ->
+  # executors/base.get_executor). plur-claw has no claude binary; it has openclaw.
+  if [ "$HOST" = plur-claw ] && ! grep -qsE '^(export )?DATACORE_EXECUTOR=' "$ID_FILE"; then
+    printf '%s\n' "DATACORE_EXECUTOR=openclaw" >> "$ID_FILE"; log "executor declared: openclaw"
+  fi
 fi
 
 # ── crons the contracts assume ──────────────────────────────────────────────
@@ -64,8 +69,17 @@ case "$HOST" in
     CRON_LINES+=("*/15 * * * * $LIB/unit_alive.sh datacore-telegram.service $STATE/miles-bot.alive 2>>$STATE/miles-bot.alive.err")
     ;;
   plur-claw)
-    CRON_LINES+=("25 * * * * DATACORE_ROOT=$HOME/spaces $LIB/ledger_phase1_cycle.sh >> $STATE/phase1-cycle.log 2>&1")
-    CRON_LINES+=("*/15 * * * * $LIB/ledger-claim-pull.sh >> $STATE/ledger-dispatch.log 2>&1")
+    # ONE clone per writer per host. Data attests X posts into ~/Data/2-plur-space
+    # (DATACORE_ATTEST_SPACE) and the dispatcher used ~/spaces/5-plur: two copies
+    # of the same writer log forked at seq 22 (found 2026-09-06). The dispatcher
+    # now works in the same clone, and the hourly cycle converges it.
+    CRON_LINES+=("25 * * * * DATACORE_ROOT=$HOME/Data $LIB/ledger_phase1_cycle.sh >> $STATE/phase1-cycle.log 2>&1")
+    CRON_LINES+=("*/15 * * * * DISPATCH_SPACE=$HOME/Data/2-plur-space $LIB/ledger-claim-pull.sh >> $STATE/ledger-dispatch.log 2>&1")
+    ;;
+  hermes)
+    # Tris keeps a 5-plur clone at ~/Data/2-plur; the hourly cycle converges it
+    # so its verifier attestations and cadence commits leave the host within the hour.
+    CRON_LINES+=("25 * * * * DATACORE_ROOT=$HOME/Data $LIB/ledger_phase1_cycle.sh >> $STATE/phase1-cycle.log 2>&1")
     ;;
 esac
 # ── known hosts the dispatch space needs (plur-claw fetches plur-space over ssh) ──
@@ -134,7 +148,8 @@ case "$HOST" in
     systemctl --user is-active --quiet hermes-gateway.service 2>/dev/null && log "OK  hermes gateway (user unit) active" || { log "FAIL hermes-gateway.service (user) not active"; fail=1; }
     ;;
   plur-claw)
-    [ -d "$HOME/spaces/5-plur/.git" ] && log "OK  dispatch space present" || { log "FAIL $HOME/spaces/5-plur is not a repository"; fail=1; }
+    [ -d "$HOME/Data/2-plur-space/.git" ] && log "OK  dispatch space present ($HOME/Data/2-plur-space)" || { log "FAIL $HOME/Data/2-plur-space is not a repository"; fail=1; }
+    grep -qsE '^(export )?DATACORE_EXECUTOR=openclaw' "$ID_FILE" && log "OK  executor declared: openclaw" || { log "FAIL executor not declared in $ID_FILE"; fail=1; }
     ;;
 esac
 [ "$fail" = 0 ] && log "ALL CHECKS PASS ($HOST)" || log "SOME CHECKS FAILED ($HOST)"

--- a/.datacore/lib/job_verify.py
+++ b/.datacore/lib/job_verify.py
@@ -423,10 +423,19 @@ def _run_doctor(machine: str, manifest_path: Path) -> None:
 
 
 def _attest_space() -> Path:
+    """First space checkout that converges: 2-datacore where present, else any
+    `[0-9]-*` repository with an event log under the root, then under ~/Data
+    (hermes keeps a 5-plur clone at ~/Data/2-plur), then ~/spaces."""
     home = Path.home()
-    for cand in (DATACORE_ROOT / "2-datacore", DATACORE_ROOT / "0-personal", home / "spaces" / "5-plur", home / "Data" / "2-datacore"):
-        if (cand / ".datacore" / "events").is_dir() and (cand / ".git").exists():
-            return cand
+    roots = [DATACORE_ROOT, home / "Data", home / "spaces"]
+    for r in roots:
+        c = r / "2-datacore"
+        if (c / ".datacore" / "events").is_dir() and (c / ".git").exists():
+            return c
+    for r in roots:
+        for c in sorted(r.glob("[0-9]-*")):
+            if (c / ".datacore" / "events").is_dir() and (c / ".git").exists():
+                return c
     return DATACORE_ROOT
 
 

--- a/.datacore/lib/ledger-claim-pull.sh
+++ b/.datacore/lib/ledger-claim-pull.sh
@@ -11,9 +11,15 @@
 # tick prints one dated line so a job contract can see it ran.
 set -uo pipefail
 RUNNER="${DATACORE_RUNNER:-$HOME/.datacore/v2-runner}"
-S="${DISPATCH_SPACE:-$HOME/spaces/5-plur}"
+S="${DISPATCH_SPACE:-${DATACORE_ATTEST_SPACE:-$HOME/spaces/5-plur}}"
 LIMIT="${DISPATCH_LIMIT:-2}"
 PY="${DATACORE_PYTHON:-python3}"
+# The host's declarations travel with the tick: executor, agent name, attest space.
+if [ -f "$HOME/.datacore/identity.env" ]; then
+  while IFS='=' read -r k v; do
+    case "$k" in DATACORE_EXECUTOR|OPENCLAW_AGENT|DATACORE_ATTEST_SPACE|DATACORE_LEDGER_SIGN) export "$k=$(printf '%s' "$v" | sed -E "s/^['\"]//; s/['\"]$//")";; esac
+  done < <(grep -E '^(DATACORE_EXECUTOR|OPENCLAW_AGENT|DATACORE_ATTEST_SPACE|DATACORE_LEDGER_SIGN)=' "$HOME/.datacore/identity.env")
+fi
 ACTOR="$("$PY" "$RUNNER/.datacore/lib/actor_identity.py" 2>/dev/null | cut -d' ' -f1)"
 [ -n "$ACTOR" ] || { echo "$(date -Is) dispatch rc=2 no declared actor (DIP-0044)"; exit 2; }
 cd "$S" || { echo "$(date -Is) dispatch rc=2 space missing: $S"; exit 2; }

--- a/.datacore/lib/ledger/keys.py
+++ b/.datacore/lib/ledger/keys.py
@@ -136,6 +136,25 @@ def sign(actor: str, data: bytes, keys_dir: Path | None = None) -> str:
     return private_key.sign(data).hex()
 
 
+def known_verify_key(actor: str, registry_path: Path | None = None) -> bool:
+    """Do we hold ANY verify key for this writer (local registry or principals.yaml)?"""
+    registry = _load_registry(registry_path or DEFAULT_REGISTRY_PATH)
+    return bool(registry["actors"].get(actor) or principals_verify_key(actor))
+
+
+def principals_verify_key(actor: str) -> str | None:
+    """The writer's public key as distributed in registry/principals.yaml
+    (`verify_keys`), for hosts that hold no local registry entry for it."""
+    p = DATACORE_ROOT / ".datacore" / "registry" / "principals.yaml"
+    try:
+        import yaml
+        d = yaml.safe_load(p.read_text(encoding="utf-8")) or {}
+        v = (d.get("verify_keys") or {}).get(actor)
+        return str(v) if v else None
+    except Exception:  # noqa: BLE001
+        return None
+
+
 def verify(
     actor: str,
     data: bytes,
@@ -149,7 +168,9 @@ def verify(
     """
     registry_path = registry_path or DEFAULT_REGISTRY_PATH
     registry = _load_registry(registry_path)
-    verify_key_hex = registry["actors"].get(actor)
+    # The local registry knows the writers that signed on THIS host; every
+    # other writer's key is distributed through registry/principals.yaml.
+    verify_key_hex = registry["actors"].get(actor) or principals_verify_key(actor)
     if not verify_key_hex:
         return False
 

--- a/.datacore/lib/ledger/verify.py
+++ b/.datacore/lib/ledger/verify.py
@@ -130,10 +130,17 @@ def verify_chain(path: Path, registry_path: Path | None = None, strict: bool = F
 
         if event.sig != "":
             if not verify_sig(event.actor, canonical_bytes(body), event.sig, registry_path=registry_path):
-                errors.append(
-                    f"line {line_no}: signature verification failed for actor {event.actor!r} "
-                    "(unknown actor or invalid signature)"
-                )
+                from .keys import known_verify_key
+                if known_verify_key(event.actor, registry_path):
+                    errors.append(
+                        f"line {line_no}: signature verification failed for actor {event.actor!r} "
+                        "(invalid signature against the registered key)"
+                    )
+                elif strict:
+                    errors.append(f"line {line_no}: no verify key known for actor {event.actor!r} (strict)")
+                # else: signed by a writer whose key this host does not hold yet --
+                # the chain is intact; the signature is unverifiable here, not
+                # wrong. Keys travel through registry/principals.yaml (verify_keys).
         elif strict:
             errors.append(f"line {line_no}: unsigned event")
 

--- a/.datacore/lib/tests/test_stages_gates.py
+++ b/.datacore/lib/tests/test_stages_gates.py
@@ -120,3 +120,32 @@ def test_signing_switch_is_read_from_the_identity_file(tmp_path, monkeypatch):
     assert json.loads((sd / ".datacore" / "events" / "miles.jsonl").read_text().splitlines()[-1])["sig"]
     ident.write_text("DATACORE_ACTOR=miles\n")
     assert EventLog(sd, "miles", keys_dir=tmp_path / "k", registry_path=tmp_path / "r.yaml").sign is False
+
+
+def test_distributed_verify_key_verifies_a_signed_chain(tmp_path, monkeypatch):
+    """A host that never saw the writer's key verifies its chain through
+    principals.yaml's verify_keys; a writer with no key anywhere is
+    unverifiable (not an error) unless strict."""
+    from ledger import keys as K
+    from ledger.verify import verify_chain
+    sd = _space(tmp_path); keys_dir = tmp_path / "k"; reg = tmp_path / "r.yaml"
+    log = EventLog(sd, "miles", keys_dir=keys_dir, registry_path=reg, sign=True)
+    log.append("item.create", {"id": "s1", "title": "signed"})
+    hexkey = __import__("yaml").safe_load(reg.read_text())["actors"]["miles"]
+    # the verifying host: an EMPTY local registry, the key only in principals.yaml
+    pr = tmp_path / "principals.yaml"; pr.write_text(f"principals:\n  miles: {{kind: agent, writes_as: [miles]}}\nverify_keys:\n  miles: {hexkey}\n")
+    monkeypatch.setattr(K, "DATACORE_ROOT", tmp_path)
+    (tmp_path / ".datacore" / "registry").mkdir(parents=True); (tmp_path / ".datacore" / "registry" / "principals.yaml").write_text(pr.read_text())
+    empty = tmp_path / "empty.yaml"
+    assert verify_chain(sd / ".datacore" / "events" / "miles.jsonl", registry_path=empty) == []
+    # tamper: the signature no longer matches -> a real error, because the key is known
+    f = sd / ".datacore" / "events" / "miles.jsonl"; line = json.loads(f.read_text().splitlines()[-1]); line["sig"] = "ab" * 64
+    f.write_text(json.dumps(line, separators=(",", ":"), sort_keys=True) + "\n")
+    errs = verify_chain(f, registry_path=empty)
+    assert errs and "signature" in errs[0]
+    # unknown writer: unverifiable, not an error; strict refuses
+    (tmp_path / ".datacore" / "registry" / "principals.yaml").write_text("principals: {}\nverify_keys: {}\n")
+    sd2 = tmp_path / "5-x"; (sd2 / ".datacore" / "events").mkdir(parents=True)
+    EventLog(sd2, "ghost", keys_dir=keys_dir, registry_path=tmp_path / "r2.yaml", sign=True).append("item.create", {"id": "g", "title": "x"})
+    assert verify_chain(sd2 / ".datacore" / "events" / "ghost.jsonl", registry_path=empty) == []
+    assert verify_chain(sd2 / ".datacore" / "events" / "ghost.jsonl", registry_path=empty, strict=True)

--- a/.datacore/registry/principals.yaml
+++ b/.datacore/registry/principals.yaml
@@ -101,3 +101,15 @@ principals:
     memory_scope: agent:john
     decision: proposes; the client approves every protocol change
     permission_mode: propose
+
+# Verify keys (stage 8). Each writer signs its events with a private key that
+# never leaves its host (~/.datacore/keys/<actor>.key); the public half is
+# registered here from the host's own registry so any machine can verify the
+# writer's chain. Collected 2026-09-06 from the hosts' keys/registry.yaml;
+# re-collect with ledger_keys_collect.py after a rotation.
+verify_keys:
+  genesis: f8be73e8a3cbd8ce5eba7901c14c4a49e120fc4083ba760546a604397dd6266d
+  winston: 879693ba05bacf52625de40c75cb75555b3a8fec707ad0ff34f2440b16ad5ba4
+  miles: c44e9552d55dcbf26bb0057877fdfaa829b1736124d5d68d082530b77f05a1c9
+  data: 94ffd37dfa9d15528f8c556a90bfe623b0b7a4abb67478ee045e7663863eb755
+


### PR DESCRIPTION
Signing on exposed that no host could verify another's key (local registries, root checkout never pushes). Public keys now travel in principals.yaml verify_keys; unknown key = unverifiable not broken (strict refuses). plur-claw's dispatcher moves into Data's attest clone (the fork's cause), declares openclaw as executor; hermes gets the hourly cycle; job_verify finds its attest space by glob. Tests added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)