### PR TITLE
roadmap tools: one roadmap per space, selected by --space

### DIFF
--- a/.datacore/lib/roadmap_drift.py
+++ b/.datacore/lib/roadmap_drift.py
@@ -25,7 +25,7 @@ Checks, and what each one catches:
   stray-roadmap  a file that reads as a roadmap and declares no canonical
                  pointer — a sixth document is how the first five happened
 """
-import argparse, json, re, subprocess, sys
+import argparse, json, os, re, subprocess, sys
 from collections import defaultdict
 from datetime import date, datetime
 from pathlib import Path
@@ -33,10 +33,28 @@ from pathlib import Path
 import yaml
 
 REPO = Path(__file__).resolve().parents[2]
-ROADMAP = REPO / "5-plur" / "roadmap.yaml"
 ADAPTER = REPO / ".datacore/lib/org_workspace_adapter.py"
-ORG = ["5-plur/org/next_actions.org", "5-plur/org/someday.org",
-       "5-plur/org/inbox.org"]
+
+# One roadmap per space (see roadmap_validate.configure). --space or ROADMAP_SPACE.
+SPACE = os.environ.get("ROADMAP_SPACE", "5-plur")
+
+
+def space_root(space: str) -> Path:
+    """A space is a directory name under the Data root, or an absolute path."""
+    p = Path(space).expanduser()
+    return p if p.is_absolute() else REPO / space
+
+
+def configure(space: str) -> None:
+    global SPACE, SPACE_ROOT, ROADMAP, ORG
+    SPACE = space
+    SPACE_ROOT = space_root(space)
+    ROADMAP = SPACE_ROOT / "roadmap.yaml"
+    ORG = [str(SPACE_ROOT / "org" / f)
+           for f in ("next_actions.org", "someday.org", "inbox.org")]
+
+
+configure(SPACE)
 STALE_DAYS = 45
 
 
@@ -84,7 +102,11 @@ def main():
                     help="exit 1 when drift is found (for CI)")
     ap.add_argument("--no-github", action="store_true",
                     help="skip the GitHub checks (offline)")
+    ap.add_argument("--space", default=SPACE,
+                    help="space holding roadmap.yaml (directory under the Data "
+                         "root, or an absolute path)")
     args = ap.parse_args()
+    configure(args.space)
 
     r = yaml.safe_load(ROADMAP.read_text())
     items = r["items"]
@@ -137,10 +159,10 @@ def main():
     # looks like a roadmap and does not declare itself a view is a place an
     # idea can land unseen by every check in this directory.
     import glob as _glob
-    for path in _glob.glob(str(REPO / "5-plur/**/*oadmap*.md"), recursive=True) + \
-            _glob.glob(str(REPO / "5-plur/**/ROADMAP.md"), recursive=True):
+    for path in _glob.glob(str(SPACE_ROOT / "**" / "*oadmap*.md"), recursive=True) + \
+            _glob.glob(str(SPACE_ROOT / "**" / "ROADMAP.md"), recursive=True):
         pp = Path(path)
-        rel = pp.relative_to(REPO)
+        rel = pp.relative_to(REPO) if pp.is_relative_to(REPO) else pp
         if any(x in str(rel) for x in (".git", "node_modules", "worktrees",
                                        "-wt", "4-archive", "3-knowledge",
                                        "presentations")):

--- a/.datacore/lib/roadmap_render.py
+++ b/.datacore/lib/roadmap_render.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Render 5-plur/roadmap.yaml to a human view.
+"""Render a space's roadmap.yaml to a human view (default space: 5-plur).
 
 The other half of the 2026-08-21 spec: roadmap.yaml is the source, every
 readable roadmap is generated. A stale generated view is then a visible diff
@@ -17,6 +17,7 @@ Usage:
 import argparse
 import html
 import json
+import os
 import re
 import sys
 from pathlib import Path
@@ -27,7 +28,31 @@ except ImportError:
     sys.exit("pyyaml required: pip install pyyaml")
 
 REPO = Path(__file__).resolve().parents[2]
-ROADMAP = REPO / "5-plur" / "roadmap.yaml"
+
+# One roadmap per space (see roadmap_validate.configure). --space or ROADMAP_SPACE.
+SPACE = os.environ.get("ROADMAP_SPACE", "5-plur")
+NAMES = {"plur": "PLUR"}  # display names that are not the capitalised slug
+
+
+def space_root(space: str) -> Path:
+    """A space is a directory name under the Data root, or an absolute path."""
+    p = Path(space).expanduser()
+    return p if p.is_absolute() else REPO / space
+
+
+def configure(space: str) -> None:
+    global SPACE, SPACE_ROOT, ROADMAP, INTENTS_ORG, NAME, SRC
+    SPACE = space
+    SPACE_ROOT = space_root(space)
+    ROADMAP = SPACE_ROOT / "roadmap.yaml"
+    INTENTS_ORG = SPACE_ROOT / "org" / "intents.org"
+    name = SPACE_ROOT.name
+    slug = name.split("-", 1)[1] if "-" in name and name[0].isdigit() else name
+    NAME = NAMES.get(slug, slug.capitalize())
+    SRC = f"{name}/roadmap.yaml"
+
+
+configure(SPACE)
 
 REDACTED = "Withheld from generated views — embargoed. Read it in roadmap.yaml."
 
@@ -35,8 +60,6 @@ REDACTED = "Withheld from generated views — embargoed. Read it in roadmap.yaml
 def load():
     return yaml.safe_load(ROADMAP.read_text())
 
-
-INTENTS_ORG = REPO / "5-plur" / "org" / "intents.org"
 
 
 def load_intents():
@@ -78,7 +101,7 @@ def public_items(r):
 
 
 def render_md(r):
-    lines = [f"# PLUR Roadmap\n", f"_Generated from `5-plur/roadmap.yaml` — updated {r['updated']}._\n"]
+    lines = [f"# {NAME} Roadmap\n", f"_Generated from `{SRC}` — updated {r['updated']}._\n"]
     ns = r["north_star"]
     lines.append(f"**North star:** {ns['metric']} — {ns['target']} by {ns['by']}"
                  + (f"  ⚠️ **{ns['status']}**" if ns.get("status") else "") + "\n")
@@ -1256,12 +1279,12 @@ def render_html(r):
   <div class="head-top">
     <div style="display:flex;flex-direction:column;gap:10px">
       <span class="eyebrow">Source of truth · consolidated {e(r["updated"])}</span>
-      <h1>PLUR Roadmap</h1>
+      <h1>{e(NAME)} Roadmap</h1>
     </div>
     <span class="valid">{len(items)} items · 0 errors</span>
   </div>
   <div class="srcline">
-    <span>generated from <b>5-plur/roadmap.yaml</b></span>
+    <span>generated from <b>{e(SRC)}</b></span>
     <span>·</span><span>{len(tracks)} tracks</span>
     <span>·</span><span>north star: {e(ns["metric"])} {e(ns["target"])} by {e(ns["by"])}</span>
   </div>
@@ -1401,7 +1424,7 @@ def execution_html(r: dict) -> str:
     for f in ("next_actions.org", "someday.org", "inbox.org"):
         x = subprocess.run(
             ["python3", str(REPO / ".datacore/lib/org_workspace_adapter.py"),
-             "list", "--file", f"5-plur/org/{f}",
+             "list", "--file", str(SPACE_ROOT / "org" / f),
              "--states", "NEXT,TODO,WAITING,REVIEW"],
             capture_output=True, text=True, cwd=REPO)
         if x.returncode:
@@ -1488,7 +1511,11 @@ def main():
     ap.add_argument("--html", metavar="OUT", help="write the HTML view to OUT")
     ap.add_argument("--md", action="store_true", help="print the markdown view")
     ap.add_argument("--json", action="store_true", help="print public items as JSON")
+    ap.add_argument("--space", default=SPACE,
+                    help="space holding roadmap.yaml (directory under the Data "
+                         "root, or an absolute path)")
     args = ap.parse_args()
+    configure(args.space)
     r = load()
 
     if args.json:

--- a/.datacore/lib/roadmap_validate.py
+++ b/.datacore/lib/roadmap_validate.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate 5-plur/roadmap.yaml against its spec.
+"""Validate a space's roadmap.yaml against its spec (default space: 5-plur).
 
 The roadmap's forcing function is that every item serves an intent. This makes
 it mechanical: a `serves` entry that does not resolve to an INTENT_ID in
@@ -10,13 +10,14 @@ Companion to roadmap_align.py, which maps org tasks and GitHub issues onto the
 same graph. This one checks the roadmap file itself.
 
 Usage:
-    python3 .datacore/lib/roadmap_validate.py [--file 5-plur/roadmap.yaml]
+    python3 .datacore/lib/roadmap_validate.py [--space 2-datacore] [--file roadmap.yaml]
     python3 .datacore/lib/roadmap_validate.py --query blocked_on=human
     python3 .datacore/lib/roadmap_validate.py --query horizon=now
     python3 .datacore/lib/roadmap_validate.py --coverage
 """
 
 import argparse
+import os
 import re
 import sys
 from pathlib import Path
@@ -27,8 +28,39 @@ except ImportError:
     sys.exit("pyyaml required: pip install pyyaml")
 
 REPO = Path(__file__).resolve().parents[2]
-DEFAULT_ROADMAP = REPO / "5-plur" / "roadmap.yaml"
-INTENTS_ORG = REPO / "5-plur" / "org" / "intents.org"
+
+# One roadmap per space, one set of tools. Every path below derives from the
+# selected space, so a second roadmap can never validate against the first
+# one's intent graph by accident. Select with --space or ROADMAP_SPACE.
+SPACE = os.environ.get("ROADMAP_SPACE", "5-plur")
+
+
+def space_root(space: str) -> Path:
+    """A space is a directory name under the Data root, or an absolute path."""
+    p = Path(space).expanduser()
+    return p if p.is_absolute() else REPO / space
+
+
+def configure(space: str) -> None:
+    """Point every path at `space`. Runs at import and again for --space."""
+    global SPACE, SPACE_ROOT, SPACE_TAG, DEFAULT_ROADMAP, INTENTS_ORG, SPACE_ORG, ORG_FILES
+    SPACE = space
+    SPACE_ROOT = space_root(space)
+    name = SPACE_ROOT.name
+    # `5-plur` -> `plur`: the tag a task in the personal space carries when
+    # it belongs to this space.
+    SPACE_TAG = name.split("-", 1)[1] if "-" in name and name[0].isdigit() else name
+    DEFAULT_ROADMAP = SPACE_ROOT / "roadmap.yaml"
+    INTENTS_ORG = SPACE_ROOT / "org" / "intents.org"
+    SPACE_ORG = [str(SPACE_ROOT / "org" / f)
+                 for f in ("next_actions.org", "someday.org", "inbox.org")]
+    # The space's own org files, plus the personal space where a task for
+    # this space is tagged with its short name.
+    ORG_FILES = SPACE_ORG + ["0-personal/org/next_actions.org",
+                             "0-personal/org/someday.org"]
+
+
+configure(SPACE)
 
 ITEM_KEYS = {
     "id", "track", "title", "outcome", "serves", "drive", "horizon", "status",
@@ -195,9 +227,7 @@ def validate(roadmap: dict, intent_ids: set) -> list:
     return errors
 
 
-ORG_FILES = ["5-plur/org/next_actions.org", "5-plur/org/someday.org",
-             "5-plur/org/inbox.org", "0-personal/org/next_actions.org",
-             "0-personal/org/someday.org"]
+# ORG_FILES is set by configure(): the space's org files plus 0-personal.
 
 THEMES = {
     "packs / hub": r"\bpack|hub\b|marketplace|listing|seller",
@@ -243,8 +273,8 @@ def report_orphans(roadmap):
             continue
         for task in json.loads(r.stdout)["tasks"]:
             tags = set(task.get("tags") or [])
-            if not ("plur" in tags or f.startswith("5-plur")
-                    or "plur" in task["heading"].lower()):
+            if not (SPACE_TAG in tags or f in SPACE_ORG
+                    or SPACE_TAG in task["heading"].lower()):
                 continue
             total += 1
             if (task.get("properties") or {}).get("ID") in refs:
@@ -255,7 +285,7 @@ def report_orphans(roadmap):
             for k in hits:
                 buckets[k].append(task["heading"])
 
-    print(f"{total} PLUR-scoped open tasks · {covered} referenced by a roadmap item "
+    print(f"{total} {SPACE_TAG.upper()}-scoped open tasks · {covered} referenced by a roadmap item "
           f"· {total - covered} orphaned\n")
     print("Most orphans are correct — the roadmap is not a backlog. Look for a\n"
           "cluster big enough to be outcome-level with no theme in the file.\n")
@@ -268,14 +298,19 @@ def report_orphans(roadmap):
 
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument("--file", default=str(DEFAULT_ROADMAP))
+    ap.add_argument("--space", default=SPACE,
+                    help="space holding roadmap.yaml and org/intents.org: a "
+                         "directory under the Data root, or an absolute path")
+    ap.add_argument("--file", default=None,
+                    help="roadmap file (default: <space>/roadmap.yaml)")
     ap.add_argument("--query", help="field=value, e.g. blocked_on=human")
     ap.add_argument("--coverage", action="store_true", help="intent coverage + orphan intents")
     ap.add_argument("--orphans", action="store_true",
                     help="PLUR org tasks with no roadmap item, clustered by theme")
     args = ap.parse_args()
 
-    roadmap = yaml.safe_load(Path(args.file).read_text())
+    configure(args.space)
+    roadmap = yaml.safe_load(Path(args.file or DEFAULT_ROADMAP).read_text())
     intent_ids = load_intent_ids(INTENTS_ORG)
     items = roadmap.get("items") or []
 

--- a/.datacore/tests/test_roadmap_tools_space.py
+++ b/.datacore/tests/test_roadmap_tools_space.py
@@ -1,0 +1,120 @@
+"""The roadmap tools serve one space at a time, selected by --space.
+
+They were born hardcoded to 5-plur. A second roadmap (2-datacore, 2026-09-06)
+validated against PLUR's intent graph would pass or fail for the wrong
+reasons, so every path now derives from the selected space — and a bad item
+must still be refused there, or the parameter has only moved the blindness.
+"""
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+LIB = Path(__file__).resolve().parents[1] / "lib"
+sys.path.insert(0, str(LIB))
+import roadmap_drift  # noqa: E402
+import roadmap_render  # noqa: E402
+import roadmap_validate  # noqa: E402
+
+INTENTS = """* Example wins  :vision:
+  :PROPERTIES:
+  :INTENT_ID: example-wins
+  :END:
+** Users stay  :intent:
+   :PROPERTIES:
+   :INTENT_ID: users-stay
+   :END:
+"""
+
+
+def _space(tmp: str) -> Path:
+    root = Path(tmp) / "7-example"
+    (root / "org").mkdir(parents=True)
+    (root / "org" / "intents.org").write_text(INTENTS)
+    return root
+
+
+def _roadmap(serves="users-stay") -> str:
+    return json.dumps({
+        "version": 1, "updated": "2026-09-06",
+        "north_star": {"metric": "retained users", "target": "100", "by": "M2"},
+        "tracks": {"core": "the product"},
+        "items": [{
+            "id": "X-001", "track": "core", "title": "Users stay",
+            "outcome": "Nobody who installs leaves in the first week",
+            "serves": [serves], "horizon": "now", "status": "ready",
+            "shipped": False,
+            "done_when": {"condition": "week-one retention above 90%",
+                          "evidence": "metric", "verify": "select ... from installs"},
+        }],
+    })
+
+
+def _run(tool, *args):
+    return subprocess.run([sys.executable, str(LIB / tool), *args],
+                          capture_output=True, text=True)
+
+
+def test_configure_derives_every_path_from_the_space():
+    try:
+        roadmap_validate.configure("2-datacore")
+        assert roadmap_validate.DEFAULT_ROADMAP.parts[-2:] == ("2-datacore", "roadmap.yaml")
+        assert roadmap_validate.INTENTS_ORG.parts[-3:] == ("2-datacore", "org", "intents.org")
+        assert roadmap_validate.SPACE_TAG == "datacore"
+        assert roadmap_validate.ORG_FILES[0].endswith("2-datacore/org/next_actions.org")
+        assert "0-personal/org/next_actions.org" in roadmap_validate.ORG_FILES
+
+        roadmap_render.configure("2-datacore")
+        assert roadmap_render.ROADMAP.parts[-2:] == ("2-datacore", "roadmap.yaml")
+        assert (roadmap_render.NAME, roadmap_render.SRC) == ("Datacore", "2-datacore/roadmap.yaml")
+        roadmap_render.configure("5-plur")
+        assert roadmap_render.NAME == "PLUR"
+
+        roadmap_drift.configure("2-datacore")
+        assert roadmap_drift.ROADMAP.parts[-2:] == ("2-datacore", "roadmap.yaml")
+        assert roadmap_drift.ORG[2].endswith("2-datacore/org/inbox.org")
+    finally:
+        for mod in (roadmap_validate, roadmap_render, roadmap_drift):
+            mod.configure("5-plur")
+
+
+def test_absolute_space_path_is_accepted():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = _space(tmp)
+        roadmap_validate.configure(str(root))
+        try:
+            assert roadmap_validate.INTENTS_ORG == root / "org" / "intents.org"
+            assert roadmap_validate.SPACE_TAG == "example"
+        finally:
+            roadmap_validate.configure("5-plur")
+
+
+def test_cli_validates_in_another_space_and_still_refuses_bad_items():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = _space(tmp)
+        (root / "roadmap.yaml").write_text(_roadmap())
+        ok = _run("roadmap_validate.py", "--space", str(root))
+        assert ok.returncode == 0, ok.stdout + ok.stderr
+        assert "1 items, 0 error(s)" in ok.stdout
+
+        (root / "roadmap.yaml").write_text(_roadmap(serves="no-such-intent"))
+        bad = _run("roadmap_validate.py", "--space", str(root))
+        assert bad.returncode == 1
+        assert "no such INTENT_ID" in bad.stdout
+
+
+def test_render_and_drift_follow_the_space():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = _space(tmp)
+        (root / "roadmap.yaml").write_text(_roadmap())
+        js = _run("roadmap_render.py", "--space", str(root), "--json")
+        assert js.returncode == 0, js.stderr
+        assert [i["id"] for i in json.loads(js.stdout)] == ["X-001"]
+        md = _run("roadmap_render.py", "--space", str(root), "--md")
+        assert md.returncode == 0, md.stderr
+        assert md.stdout.startswith("# Example Roadmap")
+        assert "7-example/roadmap.yaml" in md.stdout
+        drift = _run("roadmap_drift.py", "--space", str(root), "--no-github")
+        assert drift.returncode == 0, drift.stdout + drift.stderr
+        assert "1 epics checked" in drift.stdout


### PR DESCRIPTION
The three roadmap tools were hardcoded to `5-plur` (roadmap file, intent graph, org files scanned for `ROADMAP:` links, the stray-roadmap glob). A second roadmap (`2-datacore`) would have validated against PLUR's `intents.org`.

Every path now derives from `configure(space)` — `ROADMAP_SPACE` at import (default `5-plur`), or `--space`, taking a directory under the Data root or an absolute path.

**Regression:** validate, `--md`, `--html`, and `--no-github` drift are byte-identical for `5-plur` before and after.
**Tests:** `test_roadmap_tools_space.py` — path derivation for all three tools, absolute-path spaces, and a bad item still refused in another space (4 pass).

Not claimed: the HTML body remains the PLUR design; a second space gets a correct `--md`/`--json` view and a PLUR-shaped HTML page until its `roadmap.yaml` carries the ladder keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)