### PR TITLE
principals: bind writers by email hash, not by address

### DIFF
--- a/.datacore/config/authorship-reviewed.yaml
+++ b/.datacore/config/authorship-reviewed.yaml
@@ -7,7 +7,7 @@ reviewed:
   - commit: e3c8068e
     space: 5-plur
     writer: winston
-    committed_by: tris@datacore.one
+    committed_as: tris                  # author email hash 6b962a4a3a0068be (see principals.yaml email_sha256)
     date: 2026-09-06
     what: "A geo cadence run on hermes (clone ~/Data/2-plur) committed with `git add -A` and swept two ingest events that a process on that host had written under actor winston (hlc .winston) — a misattributed writer on the wrong host, carried under Tris's name."
     action: "Reviewed 2026-09-06 08:00. Source fix: the hermes clone must write as tris only and stage its own paths; tracked in the 2-datacore inbox."

--- a/.datacore/lib/actor_identity.py
+++ b/.datacore/lib/actor_identity.py
@@ -145,13 +145,38 @@ def principal_of(actor: str, path: Path | None = None) -> tuple[str | None, dict
     return None, {}
 
 
+def email_hash(email: str) -> str:
+    """The form an author email takes in the public registry.
+
+    datacore-one/datacore is public, and its boundary check refuses personal
+    email addresses in tracked files (validate-boundaries.yml, PII scan) —
+    the check went red on 2026-09-06 when principals.yaml listed them plainly.
+    A writer is therefore bound to the first 16 hex of sha256(lowercased
+    email): enough to match a commit author, not enough to publish who the
+    operator is. `python3 actor_identity.py hash you@example.com` prints one.
+    """
+    import hashlib
+    return hashlib.sha256(str(email).strip().lower().encode()).hexdigest()[:16]
+
+
 def allowed_emails(actor: str, path: Path | None = None) -> set[str]:
-    """Git author emails that may append to this writer's log. Empty = unbound."""
+    """Hashes of the git author emails that may append to this writer's log.
+
+    Reads `email_sha256` (the committed form) and, for a private overlay that
+    still lists addresses plainly, `emails` — hashed here so every caller
+    compares one way. Empty = unbound.
+    """
     _, p = principal_of(actor, path)
-    return {str(e).lower() for e in (p.get("emails") or [])}
+    hashes = {str(h).strip().lower() for h in (p.get("email_sha256") or [])}
+    hashes |= {email_hash(e) for e in (p.get("emails") or [])}
+    return hashes
 
 
 if __name__ == "__main__":
+    import sys
+    if len(sys.argv) > 2 and sys.argv[1] == "hash":
+        print(email_hash(sys.argv[2]))
+        raise SystemExit(0)
     a, src = resolve()
     print(f"{a or short_hostname()} ({src})")
     raise SystemExit(0 if a else 1)

--- a/.datacore/lib/agent_host_setup.sh
+++ b/.datacore/lib/agent_host_setup.sh
@@ -87,7 +87,7 @@ case "$HOST" in
     ;;
 esac
 # ── known hosts the dispatch space needs (plur-claw fetches plur-space over ssh) ──
-# The runner user's known_hosts was empty after the /root -> /home/gregor move
+# The runner user's known_hosts was empty after the move from root's home to its own
 # (DIP-0044 §3), so every fetch since 2026-08-13 failed "host key verification"
 # and the dispatcher's pull error was swallowed. The key is added only when its
 # fingerprint matches the one GitHub publishes; never blindly.

--- a/.datacore/lib/jobs/manifest.yaml
+++ b/.datacore/lib/jobs/manifest.yaml
@@ -742,13 +742,13 @@ jobs:
   - name: hermes-tris-heartbeat
     machine: hermes
     schedule: "tris-heartbeat.timer (every 30 min)"
-    cmd: "/home/gregor/tris-heartbeat.sh"
+    cmd: "~/tris-heartbeat.sh"
     on_fail: telegram
     artifacts:
       # tris-heartbeat.sh writes the last report it managed to send to
       # STATE_FILE (line 81); a report it could not send is logged but not
       # stamped, so age here means "Tris has not been heard from".
-      - path: "/home/gregor/.hermes/state/heartbeat-last-report"
+      - path: "~/.hermes/state/heartbeat-last-report"
         check: nonempty
         max_age_hours: 2
 

--- a/.datacore/lib/principals_check.py
+++ b/.datacore/lib/principals_check.py
@@ -5,7 +5,7 @@ The product description says a principal missing any of its ten things is
 not yet a principal and the system says so. This is where the system says
 so: for each entry in registry/principals.yaml it reports what is declared
 and what is not — charter on disk, contracts in the manifest, budget,
-memory scope, emails, host — and prints one line per principal. Exit 0 with
+memory scope, email hashes, host — and prints one line per principal. Exit 0 with
 the table; the checklist carries it as informational (n-a is never a pass,
 but an undeclared budget is the owner's decision, not an outage).
 
@@ -48,8 +48,8 @@ def check(root: Path = ROOT) -> list[dict]:
         pat = p.get("contracts")
         contracts = [j for j in jobs if pat and fnmatch.fnmatch(j, str(pat))]
         missing = []
-        if not (p.get("emails") or kind == "migration"):
-            missing.append("identity: no emails")
+        if not (p.get("email_sha256") or p.get("emails") or kind == "migration"):
+            missing.append("identity: no email hashes")
         if kind == "agent" and not charter_ok:
             missing.append("purpose: charter missing" if charter else "purpose: no charter")
         if kind == "agent" and not p.get("memory_scope"):

--- a/.datacore/lib/v2_verify.py
+++ b/.datacore/lib/v2_verify.py
@@ -298,7 +298,7 @@ def check_writer_authorship(rep: Report) -> None:
     """
     sys.path.insert(0, str(LIB))
     try:
-        from actor_identity import allowed_emails, principals
+        from actor_identity import allowed_emails, email_hash, principals
     except Exception as exc:  # noqa: BLE001
         rep.add("0044", "writer logs authored by their principal", None, f"actor_identity unusable: {exc}")
         return
@@ -324,7 +324,7 @@ def check_writer_authorship(rep: Report) -> None:
             if len(parts) < 2:
                 continue
             sha, email = parts[0], parts[1].lower()
-            if email in allowed or any(sha.startswith(r) for r in reviewed):
+            if email_hash(email) in allowed or any(sha.startswith(r) for r in reviewed):
                 continue  # a reviewed incident stays on the record in authorship-reviewed.yaml
             bad.add(email)
         if bad:

--- a/.datacore/registry/principals.yaml
+++ b/.datacore/registry/principals.yaml
@@ -9,11 +9,15 @@
 # month to date); null means "no ceiling declared", and principals_check.py
 # reports it as such every day.
 version: 1
+# Authorship is bound by hash, not by address: `email_sha256` holds the first
+# 16 hex of sha256(lowercased git author email). This repository is public and
+# its boundary check refuses personal addresses in tracked files. To bind a
+# new address: python3 .datacore/lib/actor_identity.py hash you@example.com
 principals:
   gregor:
     kind: human
     display: Gregor
-    emails: [gregor@plur.si, gregor@ethswarm.org, dev@datacore.one]
+    email_sha256: [49d69f113aaa313b, 4e49325caaa8e99d, 36447ff8a6d37b84]
     github: plur9
     hosts: [mac]
     writes_as: [mac]
@@ -24,7 +28,7 @@ principals:
     kind: agent
     display: Winston
     role: chief of staff
-    emails: [winston@datacore.one]
+    email_sha256: [0ca46dadf114ca4d]
     github: null                        # deliberately under the owner's account (DIP-0044 §4)
     hosts: [winston]
     writes_as: [winston, bridge]        # bridge: the hostname-derived log from before DIP-0044
@@ -41,7 +45,7 @@ principals:
     kind: agent
     display: Miles
     role: chief of operations
-    emails: [miles@datacore.one, gregor+miles@datafund.io]
+    email_sha256: [b3c41e5e12e8cdb7, 7b84804c8b3d143e]
     github: miles-on-nightshift
     hosts: [nightshift]
     writes_as: [miles, nightshift]      # nightshift: the executor's log; it commits as Miles
@@ -57,7 +61,7 @@ principals:
     kind: agent
     display: Tris
     role: chief intelligence officer
-    emails: [tris@datacore.one]
+    email_sha256: [6b962a4a3a0068be]
     github: tris-on-hermes
     hosts: [hermes]
     writes_as: [tris]
@@ -72,7 +76,7 @@ principals:
     kind: agent
     display: Mr Data
     role: communications
-    emails: [mrdata@datacore.one, data@plur.ai]
+    email_sha256: [ebb64c306f9de106, 965c4f44b8c259e1]
     github: data-on-claw
     hosts: [plur-claw]
     writes_as: [data]
@@ -86,14 +90,14 @@ principals:
   genesis:
     kind: migration
     display: genesis import (2026-08-10, one shot)
-    emails: [gregor@plur.si, winston@datacore.one, miles@datacore.one]
+    email_sha256: [49d69f113aaa313b, 0ca46dadf114ca4d, b3c41e5e12e8cdb7]
     hosts: [mac, winston, nightshift]
     writes_as: [genesis]
   practice:
     kind: agent
     display: The Practice (John, Mick)
     role: health and longevity practice
-    emails: []
+    email_sha256: []
     github: null
     hosts: [mac]
     writes_as: []                       # keeps its own intervention ledger; not yet an event-ledger writer

--- a/.datacore/tests/test_principal_email_hashes.py
+++ b/.datacore/tests/test_principal_email_hashes.py
@@ -1,0 +1,62 @@
+"""Writers are bound to author-email HASHES, never to addresses.
+
+datacore-one/datacore is public. On 2026-09-06 principals.yaml listed the
+principals' email addresses plainly and the repository's own PII scan
+(validate-boundaries.yml) went red on main for every PR. The registry now
+carries sha256 prefixes; these tests keep an address from coming back and
+keep the authorship check matching a commit author through the hash.
+"""
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / ".datacore" / "lib"))
+from actor_identity import allowed_emails, email_hash  # noqa: E402
+
+EMAIL = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+
+
+def test_hash_is_stable_case_insensitive_and_short():
+    h = email_hash("Someone@Example.com ")
+    assert h == email_hash("someone@example.com")
+    assert re.fullmatch(r"[0-9a-f]{16}", h)
+    assert h != email_hash("someone.else@example.com")
+
+
+def test_registry_binds_by_hash_and_accepts_a_plain_overlay():
+    with tempfile.TemporaryDirectory() as tmp:
+        p = Path(tmp) / "principals.yaml"
+        p.write_text(
+            "principals:\n"
+            "  alpha:\n"
+            "    kind: agent\n"
+            "    writes_as: [alpha, alpha-host]\n"
+            f"    email_sha256: [{email_hash('alpha@example.com')}]\n"
+            "  beta:\n"
+            "    kind: human\n"
+            "    writes_as: [beta]\n"
+            "    emails: [Beta@Example.com]\n"
+            "  gamma:\n"
+            "    kind: agent\n"
+            "    writes_as: [gamma]\n"
+        )
+        assert allowed_emails("alpha-host", p) == {email_hash("alpha@example.com")}
+        assert allowed_emails("beta", p) == {email_hash("beta@example.com")}
+        assert allowed_emails("gamma", p) == set()          # unbound, not wrong
+
+
+def test_committed_registry_contains_no_address():
+    text = (ROOT / ".datacore" / "registry" / "principals.yaml").read_text()
+    live = "\n".join(l for l in text.splitlines() if not l.lstrip().startswith("#"))
+    assert not EMAIL.search(live), "an email address is back in the public registry"
+    assert "email_sha256:" in live
+
+
+def test_every_writer_in_the_registry_is_bound_or_declared_unbound():
+    import yaml
+    ps = yaml.safe_load((ROOT / ".datacore" / "registry" / "principals.yaml").read_text())["principals"]
+    for name, p in ps.items():
+        if p.get("writes_as"):
+            assert allowed_emails(name) or name == "practice", f"{name}: writers with no author bound"


### PR DESCRIPTION
`principals.yaml` (#106) listed the principals' git author emails for the authorship check. This repo is public and `validate-boundaries.yml`'s PII scan refuses personal addresses in tracked files — main has been red since 08:09 today, failing every PR.

**Change:** `emails:` → `email_sha256:` (first 16 hex of sha256 of the lowercased address). `allowed_emails()` returns hashes and still accepts a plain `emails` list from a private overlay; `v2_verify` hashes the commit author before matching; `principals_check` accepts either key. `python3 .datacore/lib/actor_identity.py hash <email>` prints the committed form.

**Tests:** `test_principal_email_hashes.py` — stability, hash-or-overlay binding, no address in the committed registry, every writer bound or declared unbound.

**Residue:** the addresses remain in this repository's history (five of them were already there as commit authors; `gregor@plur.si`, `gregor@ethswarm.org`, `data@plur.ai`, `tris@`, `mrdata@` are new since #106). A history rewrite is the owner's call.
**Also in this PR** (same boundary check, same public tree): the committer address in `authorship-reviewed.yaml` becomes the principal name plus its hash; two absolute personal paths in the hermes heartbeat contract and one installer comment become `~` and prose. All three were merged 2026-09-05/06 and are what has kept `System Repo Boundaries` red on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)