### PR TITLE
verify: every hook command in global and project settings resolves to a file

### DIFF
--- a/.datacore/lib/v2_verify.py
+++ b/.datacore/lib/v2_verify.py
@@ -452,6 +452,80 @@ def check_stores(rep: Report) -> None:
         rep.add("lens", "lens store bounded", None, "no observations.db on this host", skipped=True)
 
 
+# ── Hooks: every wired command must resolve to a file that exists ───────────
+#: Where Claude Code reads hooks on this host. The user-global file is OUTSIDE
+#: every repository, which is why a repo-scoped hygiene pass (800fd31,
+#: datacore#25) could delete three hook scripts and leave their global wiring
+#: pointing at nothing — silent until the next session started.
+HOOK_SETTINGS = (
+    Path.home() / ".claude" / "settings.json",
+    ROOT / ".datacore" / "settings.json",
+    ROOT / ".claude" / "settings.json",
+    ROOT / ".claude" / "settings.local.json",
+)
+_INTERPRETERS = {"python", "python3", "bash", "sh", "node", "env"}
+
+
+def hook_script_path(command: str) -> Path | None:
+    """The file a hook command runs, or None when it runs a package/binary
+    we cannot resolve to a path (`npx …`, a bare executable on PATH).
+
+    `python3 /x/y.py args` -> /x/y.py; `bash ~/x.sh` -> ~/x.sh;
+    `/abs/script arg` -> /abs/script; `VAR=1 python3 /x.py` -> /x.py.
+    """
+    import shlex
+    try:
+        parts = shlex.split(command)
+    except ValueError:
+        parts = command.split()
+    parts = [p for p in parts if "=" not in p or p.startswith(("/", "~", "."))]
+    for tok in parts:
+        if tok in _INTERPRETERS:
+            continue
+        if tok.startswith(("/", "~", ".")):
+            return Path(os.path.expanduser(tok))
+        return None   # first real token is a PATH binary or npx: not a file path
+    return None
+
+
+def hook_commands(settings: Path) -> list[tuple[str, str]]:
+    """(event, command) for every hook wired in one settings file."""
+    try:
+        data = json.loads(settings.read_text())
+    except (OSError, ValueError):
+        return []
+    out = []
+    for event, groups in (data.get("hooks") or {}).items():
+        for g in groups or []:
+            for h in (g or {}).get("hooks") or []:
+                cmd = (h or {}).get("command")
+                if cmd:
+                    out.append((event, cmd))
+    return out
+
+
+def check_hooks(rep: Report) -> None:
+    """Every hook command in the global and project settings files runs a
+    file that exists on this host."""
+    seen_files = 0
+    missing: list[str] = []
+    for settings in HOOK_SETTINGS:
+        cmds = hook_commands(settings)
+        if not cmds:
+            continue
+        seen_files += 1
+        short = str(settings).replace(str(Path.home()), "~")
+        for event, cmd in cmds:
+            p = hook_script_path(cmd)
+            if p is not None and not p.exists():
+                missing.append(f"{short}: {event} -> {p.name}")
+    if not seen_files:
+        rep.add("0036", "hook commands resolve", None, "no settings file with hooks", skipped=True)
+        return
+    rep.add("0036", "hook commands resolve", not missing,
+            f"{seen_files} settings file(s)" if not missing else "; ".join(missing[:3]))
+
+
 def check_transport(rep: Report) -> None:
     t = LIB / "ledger_transport.py"
     if not t.exists():
@@ -817,6 +891,7 @@ def main() -> int:
     check_identity(rep)
     check_transport(rep)
     check_stores(rep)
+    check_hooks(rep)
     check_finality(rep)
     check_app(rep)
     check_declared_identity(rep)

--- a/.datacore/tests/test_hook_commands_resolve.py
+++ b/.datacore/tests/test_hook_commands_resolve.py
@@ -1,0 +1,93 @@
+"""Every hook command wired in Claude Code settings runs a file that exists.
+
+800fd31 (datacore#25) deleted three hook scripts from the repo while the
+user-global ~/.claude/settings.json — outside every repository — still ran
+them: every session then threw a PostToolUse error and a SessionStart error
+at files that were gone. This checks the same thing the v2 checklist row
+checks, against fixture settings files and against this repo's own project
+settings, so the class of breakage fails a test before it fails a session.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+LIB = Path(__file__).resolve().parents[1] / "lib"
+sys.path.insert(0, str(LIB))
+import v2_verify as vv  # noqa: E402
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_hook_script_path_resolves_the_file_a_command_runs():
+    assert vv.hook_script_path("python3 /x/y.py") == Path("/x/y.py")
+    assert vv.hook_script_path("python3 /x/y.py --flag a") == Path("/x/y.py")
+    assert vv.hook_script_path("bash ~/Data/.datacore/hooks/org-date-fix.sh") == \
+        Path.home() / "Data" / ".datacore" / "hooks" / "org-date-fix.sh"
+    assert vv.hook_script_path("/Users/x/.plur/bin/plur-hook hook-session-guard") == \
+        Path("/Users/x/.plur/bin/plur-hook")
+    assert vv.hook_script_path("CLAUDE_HOOK_EVENT_NAME=PostToolUseFailure python3 /x/h.py") == \
+        Path("/x/h.py")
+    # Package runners and PATH binaries are not files we can check.
+    assert vv.hook_script_path("npx @plur-ai/cli hook-observe >/dev/null") is None
+    assert vv.hook_script_path("some-binary --arg") is None
+
+
+def _settings(path: Path, hooks: dict) -> Path:
+    path.write_text(json.dumps({"hooks": hooks}))
+    return path
+
+
+def test_missing_hook_file_fails_the_row(tmp_path, monkeypatch):
+    present = tmp_path / "present.py"
+    present.write_text("")
+    s = _settings(tmp_path / "settings.json", {
+        "PreToolUse": [{"matcher": "*", "hooks": [
+            {"type": "command", "command": f"python3 {present}"},
+            {"type": "command", "command": f"python3 {tmp_path}/gone_guard.py"},
+        ]},
+        {"matcher": "Bash", "hooks": [{"type": "command", "command": "npx something"}]}],
+        "SessionStart": [{"hooks": [{"type": "command", "command": f"python3 {tmp_path}/gone_reminder.py"}]}],
+    })
+    monkeypatch.setattr(vv, "HOOK_SETTINGS", (s,))
+    rep = vv.Report()
+    vv.check_hooks(rep)
+    row = rep.checks[0]
+    assert row.name == "hook commands resolve" and row.ok is False
+    assert "PreToolUse -> gone_guard.py" in row.detail
+    assert "SessionStart -> gone_reminder.py" in row.detail
+
+
+def test_all_present_passes_and_counts_files(tmp_path, monkeypatch):
+    present = tmp_path / "present.py"
+    present.write_text("")
+    a = _settings(tmp_path / "a.json", {"Stop": [{"hooks": [{"command": f"python3 {present}"}]}]})
+    b = _settings(tmp_path / "b.json", {"Stop": [{"hooks": [{"command": "npx x"}]}]})
+    monkeypatch.setattr(vv, "HOOK_SETTINGS", (a, b, tmp_path / "absent.json"))
+    rep = vv.Report()
+    vv.check_hooks(rep)
+    assert rep.checks[0].ok is True and rep.checks[0].detail == "2 settings file(s)"
+
+
+def test_no_settings_at_all_is_not_applicable(tmp_path, monkeypatch):
+    monkeypatch.setattr(vv, "HOOK_SETTINGS", (tmp_path / "none.json",))
+    rep = vv.Report()
+    vv.check_hooks(rep)
+    assert rep.checks[0].ok is None and rep.checks[0].skipped is True
+
+
+def test_this_repos_project_settings_resolve():
+    """The repo's own wiring: every path it names under ~/Data exists here."""
+    missing = []
+    for settings in (ROOT / ".datacore" / "settings.json", ROOT / ".claude" / "settings.json"):
+        for event, cmd in vv.hook_commands(settings):
+            p = vv.hook_script_path(cmd)
+            if p is None:
+                continue
+            # Project settings say ~/Data/...; map that onto this checkout so
+            # the test is about the repo, not about where it is cloned.
+            rel = str(p).replace(str(Path.home() / "Data"), str(ROOT), 1)
+            if not Path(rel).exists():
+                missing.append(f"{settings.name}: {event} -> {p}")
+    assert not missing, missing

--- a/.datacore/tests/test_hook_commands_resolve.py
+++ b/.datacore/tests/test_hook_commands_resolve.py
@@ -25,8 +25,8 @@ def test_hook_script_path_resolves_the_file_a_command_runs():
     assert vv.hook_script_path("python3 /x/y.py --flag a") == Path("/x/y.py")
     assert vv.hook_script_path("bash ~/Data/.datacore/hooks/org-date-fix.sh") == \
         Path.home() / "Data" / ".datacore" / "hooks" / "org-date-fix.sh"
-    assert vv.hook_script_path("/Users/x/.plur/bin/plur-hook hook-session-guard") == \
-        Path("/Users/x/.plur/bin/plur-hook")
+    assert vv.hook_script_path("/opt/plur/bin/plur-hook hook-session-guard") == \
+        Path("/opt/plur/bin/plur-hook")
     assert vv.hook_script_path("CLAUDE_HOOK_EVENT_NAME=PostToolUseFailure python3 /x/h.py") == \
         Path("/x/h.py")
     # Package runners and PATH binaries are not files we can check.


### PR DESCRIPTION
## Summary

- **What broke.** 800fd31 (PR #133, datacore#25) deleted the datacore copy of the PLUR session hooks (guard, mark, reminder) and their project wiring. `~/.claude/settings.json` is outside every repository and still ran all three, so every session start errored at two deleted files, and the guard was a hand-made stub. Reproduced by a parallel session on 2026-09-06 21:48.
- **Decision: retired, not restored.** The global file wires the plur-cli set (`~/.plur/bin/plur-hook hook-session-guard|mark|remind|end`) next to the datacore copy; the plur-cli set is canonical and is the nudge-once design. The owner removed the three datacore entries from the global file (backup `~/.claude/settings.json.bak-2026-09-06`); the stub and the `.bak` are deleted.
- **The check.** New checklist row `hook commands resolve` reads `~/.claude/settings.json`, `.datacore/settings.json`, `.claude/settings.json` and `.claude/settings.local.json`, resolves each hook command to the file it runs (`python3 /x.py`, `bash ~/x.sh`, `/abs/bin arg`, `VAR=1 python3 /x.py`), and fails naming `<file>: <event> -> <script>` when the file is missing. `npx …` and PATH binaries are not files and are skipped.

## Test plan

- [x] `.datacore/tests/test_hook_commands_resolve.py` (5 tests): resolver cases, missing file fails, all present passes, no settings is n/a, and this repo's own project wiring resolves.
- [x] `v2_verify.py --quick` on the mac: `ok hook commands resolve 3 settings file(s)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)