### PR TITLE
verify: repo topology, org-workspace parity, and done-names-its-check rows

### DIFF
--- a/.datacore/lib/v2_verify.py
+++ b/.datacore/lib/v2_verify.py
@@ -420,7 +420,11 @@ def _read_identity_env() -> dict:
 
 
 # ── DIP-0046: git transport ─────────────────────────────────────────────────
-LENS_MAX_GB = 1.0
+#: Measured 2026-09-06 after the first full sweep on the mac: 30 days of
+#: events + 7 days of raw rows + indexes = 1.14 GB, vacuumed. The ceiling sits
+#: above that steady state so the row fires on GROWTH, not on the retention
+#: policy working as declared.
+LENS_MAX_GB = 2.0
 
 
 def check_stores(rep: Report) -> None:
@@ -450,6 +454,217 @@ def check_stores(rep: Report) -> None:
                 f"{gb:.2f} GB (ceiling {LENS_MAX_GB:g} GB)")
     else:
         rep.add("lens", "lens store bounded", None, "no observations.db on this host", skipped=True)
+
+
+# ── datacore#34: the three rows the reliability epic still lacked ──────────
+#: A commit that exists on this host and on no remote for longer than this is
+#: STRANDED: the class of failure that parked 610 commits on a branch nobody
+#: pushed (datacore#31). A fresh feature branch is not stranded; a day-old one
+#: with nothing upstream is.
+UNPUSHED_MAX_HOURS = 24.0
+
+
+def _git(repo: Path, *args: str, timeout: int = 30) -> tuple[int, str]:
+    return run(["git", "-C", str(repo), *args], timeout)
+
+
+def _default_branch(repo: Path) -> str:
+    rc, out = _git(repo, "symbolic-ref", "--short", "refs/remotes/origin/HEAD")
+    if rc == 0 and out.strip():
+        return out.strip().split("/", 1)[-1]
+    rc, out = _git(repo, "rev-parse", "--verify", "-q", "refs/remotes/origin/main")
+    return "main" if rc == 0 else "master"
+
+
+def registered_repos(root: Path | None = None) -> list[tuple[str, Path, str, str]]:
+    """(name, path, category, canonical repo name) for every entry of
+    registry/repositories.yaml that exists as a git checkout on this host.
+    Entries that are not here (another host's spaces) are simply not rows."""
+    root = root or ROOT   # resolved at call time, so a test can point ROOT elsewhere
+    try:
+        import yaml
+        reg = (yaml.safe_load((root / ".datacore" / "registry" / "repositories.yaml")
+                              .read_text()) or {}).get("repositories", {})
+    except Exception:  # noqa: BLE001 — no registry, no rows; the transport row says so
+        return []
+    out = []
+    for key, entry in sorted(reg.items()):
+        path = root if key == "<root>" else root / key
+        if not (path / ".git").exists():
+            continue
+        entry = entry or {}
+        out.append((key, path, str(entry.get("category") or ""), str(entry.get("repo") or "")))
+    return out
+
+
+def stranded_age_hours(repo: Path, now: float | None = None) -> tuple[int, float]:
+    """(count, age of the oldest) for commits reachable from HEAD that no
+    branch of `origin` has. Zero rows when everything is upstream."""
+    import time as _time
+    rc, out = _git(repo, "log", "--format=%ct", "HEAD", "--not", "--remotes=origin")
+    if rc != 0:
+        return 0, 0.0
+    stamps = [int(s) for s in out.split() if s.strip().isdigit()]
+    if not stamps:
+        return 0, 0.0
+    now = now if now is not None else _time.time()
+    return len(stamps), max(0.0, (now - min(stamps)) / 3600.0)
+
+
+def check_topology(rep: Report) -> None:
+    """Every registered repo on this host: origin names the canonical repo,
+    knowledge repos sit on their default branch, and no commit is older than
+    a day with no copy on any remote.
+
+    The reconciler that datacore#36 specified never existed; these are the
+    three invariants from its list that nothing else measured. A knowledge
+    repo on a work branch is one the transport will not converge (it only
+    moves the default branch); a code repo on a work branch is a person's
+    working tree and is reported, not failed.
+    """
+    repos = registered_repos()
+    if not repos:
+        rep.add("0046", "repo topology", None, "no registered repositories on this host")
+        return
+    wrong, parked_knowledge, parked_code, stranded = [], [], [], []
+    for name, path, category, canonical in repos:
+        rc, url = _git(path, "remote", "get-url", "origin")
+        base = ""
+        if rc == 0 and url.strip():
+            import re as _re
+            base = _re.sub(r"\.git$", "", url.strip().rstrip("/").split("/")[-1].split(":")[-1])
+        if not canonical or base != canonical:
+            wrong.append(f"{name}: origin={base or 'none'} registry={canonical or '?'}")
+        db = _default_branch(path)
+        _, cur = _git(path, "branch", "--show-current")
+        cur = cur.strip() or "detached"
+        if cur != db:
+            (parked_knowledge if category == "knowledge" else parked_code).append(f"{name}: {cur}")
+        n, age = stranded_age_hours(path)
+        if n and age > UNPUSHED_MAX_HOURS:
+            stranded.append(f"{name}: {n} commit(s), oldest {age:.0f}h")
+    rep.add("0046", "remotes canonical", not wrong,
+            f"{len(repos)} repos" if not wrong else "; ".join(wrong[:3]))
+    rep.add("0046", "knowledge on default branch", not parked_knowledge,
+            ("; ".join(parked_knowledge[:3]) if parked_knowledge
+             else (f"code parked: {'; '.join(parked_code[:3])}" if parked_code else "all on default")))
+    rep.add("0046", "no stranded commits", not stranded,
+            "; ".join(stranded[:3]) if stranded else f"nothing older than {UNPUSHED_MAX_HOURS:g}h off-remote")
+
+
+def _pinned_org_workspace() -> tuple[int, ...] | None:
+    try:
+        for line in (LIB / "requirements.txt").read_text().splitlines():
+            m = __import__("re").match(r"\s*org-workspace\s*>=\s*([0-9][0-9.]*)", line)
+            if m:
+                return tuple(int(x) for x in m.group(1).strip(".").split("."))
+    except OSError:
+        pass
+    return None
+
+
+def interpreters() -> list[str]:
+    """The Pythons this host actually runs jobs with: the one running this
+    checklist first, then everything named python3 on PATH, the system one,
+    and the daemon's venv when it exists."""
+    import shutil
+    cands = [sys.executable, shutil.which("python3"), "/usr/bin/python3",
+             "/opt/homebrew/bin/python3", "/usr/local/bin/python3",
+             str(ROOT / "2-datacore" / "2-projects" / "datacore-app" / "daemon" / ".venv" / "bin" / "python")]
+    out: list[str] = []
+    for c in cands:
+        if not c:
+            continue
+        try:
+            real = os.path.realpath(c)
+        except OSError:
+            continue
+        if os.path.exists(real) and real not in out:
+            out.append(real)
+    return out
+
+
+def org_workspace_version(py: str) -> str:
+    """'0.5.1', or 'missing' when that interpreter cannot import it."""
+    rc, out = run([py, "-c",
+                   "import importlib.metadata as m; print(m.version('org-workspace'))"], 30)
+    v = out.strip().splitlines()[-1].strip() if out.strip() else ""
+    return v if rc == 0 and v and v[0].isdigit() else "missing"
+
+
+def check_versions(rep: Report) -> None:
+    """org-workspace: one version under every interpreter this host runs
+    jobs with, and at least the pinned one.
+
+    2026-07-26 (datacore#34): two Pythons on the mac carried two versions of
+    org-workspace, so a script's behaviour depended on which shim launched
+    it. Every host compares against the same pin in requirements.txt, which
+    is what makes the row cross-host: parity here means parity everywhere.
+    """
+    pin = _pinned_org_workspace()
+    found = {py: org_workspace_version(py) for py in interpreters()}
+    present = {v for v in found.values() if v != "missing"}
+    mine = found.get(os.path.realpath(sys.executable), "missing")
+    if not present:
+        rep.add("0035", "org-workspace parity", False, "not installed for any interpreter")
+        return
+    def _tup(v: str) -> tuple[int, ...]:
+        return tuple(int(x) for x in v.split(".") if x.isdigit())
+    below = [v for v in present if pin and _tup(v) < pin]
+    ok = len(present) == 1 and mine != "missing" and not below
+    missing = [os.path.basename(os.path.dirname(os.path.dirname(p))) or p
+               for p, v in found.items() if v == "missing"]
+    if ok:
+        detail = f"{next(iter(present))} under {len(found) - len(missing)} interpreter(s)"
+        if missing:
+            detail += f"; absent under {len(missing)}"
+    elif mine == "missing":
+        detail = f"absent under the checklist's own interpreter {sys.executable}"
+    elif len(present) > 1:
+        detail = "; ".join(f"{v} ({p})" for p, v in found.items() if v != "missing")[:100]
+    else:
+        detail = f"{next(iter(present))} below the pin {'.'.join(map(str, pin))}"
+    rep.add("0035", "org-workspace parity", ok, detail)
+
+
+def roadmap_trust_violations(root: Path | None = None) -> list[str]:
+    """Roadmap items marked done that carry no named check: no `shipped`
+    date, or a `done_when` without both `evidence` and `verify`."""
+    import yaml
+    root = root or ROOT
+    bad = []
+    for rm in sorted(root.glob("[0-9]-*/roadmap.yaml")):
+        try:
+            data = yaml.safe_load(rm.read_text()) or {}
+        except Exception as exc:  # noqa: BLE001 — an unreadable roadmap is itself a violation
+            bad.append(f"{rm.parent.name}: unreadable ({type(exc).__name__})")
+            continue
+        for item in data.get("items") or []:
+            if not isinstance(item, dict) or item.get("status") != "done":
+                continue
+            dw = item.get("done_when")
+            named = isinstance(dw, dict) and bool(dw.get("evidence")) and bool(dw.get("verify"))
+            if not named or not item.get("shipped"):
+                bad.append(f"{rm.parent.name}:{item.get('id')}")
+    return bad
+
+
+def check_trust_labels(rep: Report) -> None:
+    """No "done" without a named check (datacore#34's trust-label rule).
+
+    A status is a label; what makes it trustworthy is the check it names.
+    Today the rule is enforceable on roadmap items — `done` must carry a
+    `shipped` date and a `done_when` with `evidence` and `verify` — which is
+    where "done" is most often written by hand.
+    """
+    bad = roadmap_trust_violations()
+    roadmaps = list(ROOT.glob("[0-9]-*/roadmap.yaml"))
+    if not roadmaps:
+        rep.add("0035", "done names its check", None, "no roadmap.yaml on this host", skipped=True)
+        return
+    rep.add("0035", "done names its check", not bad,
+            f"{len(roadmaps)} roadmap(s), every done item has evidence+verify+shipped"
+            if not bad else "; ".join(bad[:4]))
 
 
 def check_transport(rep: Report) -> None:
@@ -817,6 +1032,9 @@ def main() -> int:
     check_identity(rep)
     check_transport(rep)
     check_stores(rep)
+    check_topology(rep)
+    check_versions(rep)
+    check_trust_labels(rep)
     check_finality(rep)
     check_app(rep)
     check_declared_identity(rep)

--- a/.datacore/tests/test_v2_verify_rows.py
+++ b/.datacore/tests/test_v2_verify_rows.py
@@ -1,0 +1,218 @@
+"""datacore#34: repo topology, version parity, and the trust-label rule as
+verifier rows. Each row is exercised against a fixture root, never the real
+installation, so the tests pass on a machine with any number of repos."""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+LIB = Path(__file__).resolve().parents[1] / "lib"
+sys.path.insert(0, str(LIB))
+import v2_verify as vv  # noqa: E402
+
+
+def _git(repo: Path, *args: str, env: dict | None = None) -> str:
+    e = {**os.environ, "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@x",
+         "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@x", **(env or {})}
+    return subprocess.run(["git", "-C", str(repo), *args], capture_output=True,
+                          text=True, env=e, check=True).stdout
+
+
+def _repo_with_remote(root: Path, name: str, remote_name: str, *, branch: str = "main") -> Path:
+    bare = root / "remotes" / f"{remote_name}.git"
+    bare.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q", "--bare", "-b", branch, str(bare)], check=True)
+    repo = root / name
+    repo.mkdir(parents=True)
+    subprocess.run(["git", "init", "-q", "-b", branch, str(repo)], check=True)
+    (repo / "README").write_text("x\n")
+    _git(repo, "add", "README")
+    _git(repo, "commit", "-q", "-m", "init")
+    _git(repo, "remote", "add", "origin", str(bare))
+    _git(repo, "push", "-q", "-u", "origin", branch)
+    _git(repo, "remote", "set-head", "origin", branch)
+    return repo
+
+
+def _registry(root: Path, entries: dict) -> None:
+    import yaml
+    reg = root / ".datacore" / "registry"
+    reg.mkdir(parents=True, exist_ok=True)
+    (reg / "repositories.yaml").write_text(yaml.safe_dump({"repositories": entries}))
+
+
+@pytest.fixture
+def fixture_root(tmp_path, monkeypatch):
+    monkeypatch.setattr(vv, "ROOT", tmp_path)
+    return tmp_path
+
+
+# ── topology ────────────────────────────────────────────────────────────────
+
+def test_topology_all_green(fixture_root):
+    _repo_with_remote(fixture_root, "2-space", "datacore-space")
+    _repo_with_remote(fixture_root, ".datacore/modules/mod", "datacore-mod")
+    _registry(fixture_root, {
+        "2-space": {"category": "knowledge", "repo": "datacore-space"},
+        ".datacore/modules/mod": {"category": "code", "repo": "datacore-mod"},
+        "not-here": {"category": "knowledge", "repo": "elsewhere"},
+    })
+    rep = vv.Report()
+    vv.check_topology(rep)
+    rows = {c.name: c for c in rep.checks}
+    assert rows["remotes canonical"].ok is True and "2 repos" in rows["remotes canonical"].detail
+    assert rows["knowledge on default branch"].ok is True
+    assert rows["no stranded commits"].ok is True
+
+
+def test_topology_wrong_remote_and_parked_knowledge(fixture_root):
+    space = _repo_with_remote(fixture_root, "2-space", "someone-elses-fork")
+    _git(space, "checkout", "-q", "-b", "wip")
+    code = _repo_with_remote(fixture_root, ".datacore/modules/mod", "datacore-mod")
+    _git(code, "checkout", "-q", "-b", "feature")
+    _registry(fixture_root, {
+        "2-space": {"category": "knowledge", "repo": "datacore-space"},
+        ".datacore/modules/mod": {"category": "code", "repo": "datacore-mod"},
+    })
+    rep = vv.Report()
+    vv.check_topology(rep)
+    rows = {c.name: c for c in rep.checks}
+    assert rows["remotes canonical"].ok is False
+    assert "2-space: origin=someone-elses-fork registry=datacore-space" in rows["remotes canonical"].detail
+    # A knowledge repo off its default branch fails; a code repo merely reports.
+    assert rows["knowledge on default branch"].ok is False
+    assert "2-space: wip" in rows["knowledge on default branch"].detail
+    assert "mod" not in rows["knowledge on default branch"].detail.split("2-space: wip")[0]
+
+
+def test_topology_code_parked_is_reported_not_failed(fixture_root):
+    code = _repo_with_remote(fixture_root, ".datacore/modules/mod", "datacore-mod")
+    _git(code, "checkout", "-q", "-b", "feature")
+    _registry(fixture_root, {".datacore/modules/mod": {"category": "code", "repo": "datacore-mod"}})
+    rep = vv.Report()
+    vv.check_topology(rep)
+    row = {c.name: c for c in rep.checks}["knowledge on default branch"]
+    assert row.ok is True and "code parked: .datacore/modules/mod: feature" in row.detail
+
+
+def test_stranded_commit_older_than_a_day_fails(fixture_root):
+    space = _repo_with_remote(fixture_root, "2-space", "datacore-space")
+    (space / "new").write_text("y\n")
+    _git(space, "add", "new")
+    old = str(int(time.time()) - 30 * 3600)
+    _git(space, "commit", "-q", "-m", "local only",
+         env={"GIT_COMMITTER_DATE": f"@{old} +0000", "GIT_AUTHOR_DATE": f"@{old} +0000"})
+    n, age = vv.stranded_age_hours(space)
+    assert n == 1 and 29 < age < 31
+    _registry(fixture_root, {"2-space": {"category": "knowledge", "repo": "datacore-space"}})
+    rep = vv.Report()
+    vv.check_topology(rep)
+    row = {c.name: c for c in rep.checks}["no stranded commits"]
+    assert row.ok is False and row.detail.startswith("2-space: 1 commit(s), oldest 30h")
+
+
+def test_fresh_unpushed_commit_is_not_stranded(fixture_root):
+    space = _repo_with_remote(fixture_root, "2-space", "datacore-space")
+    (space / "new").write_text("y\n")
+    _git(space, "add", "new")
+    _git(space, "commit", "-q", "-m", "just now")
+    _registry(fixture_root, {"2-space": {"category": "knowledge", "repo": "datacore-space"}})
+    rep = vv.Report()
+    vv.check_topology(rep)
+    assert {c.name: c for c in rep.checks}["no stranded commits"].ok is True
+
+
+def test_topology_without_registry_is_not_applicable(fixture_root):
+    rep = vv.Report()
+    vv.check_topology(rep)
+    assert rep.checks[0].name == "repo topology" and rep.checks[0].ok is None
+
+
+# ── version parity ──────────────────────────────────────────────────────────
+
+def _parity(monkeypatch, found: dict, pin=(0, 5, 1), mine="/py/a"):
+    monkeypatch.setattr(vv, "interpreters", lambda: list(found))
+    monkeypatch.setattr(vv, "org_workspace_version", lambda py: found[py])
+    monkeypatch.setattr(vv, "_pinned_org_workspace", lambda: pin)
+    monkeypatch.setattr(vv.sys, "executable", mine)
+    monkeypatch.setattr(vv.os.path, "realpath", lambda p: p)
+    rep = vv.Report()
+    vv.check_versions(rep)
+    return rep.checks[0]
+
+
+def test_parity_one_version_everywhere(monkeypatch):
+    row = _parity(monkeypatch, {"/py/a": "0.5.1", "/py/b": "0.5.1"})
+    assert row.ok is True and row.detail == "0.5.1 under 2 interpreter(s)"
+
+
+def test_parity_two_versions_fail(monkeypatch):
+    row = _parity(monkeypatch, {"/py/a": "0.5.1", "/py/b": "0.4.4"})
+    assert row.ok is False and "0.4.4 (/py/b)" in row.detail
+
+
+def test_parity_below_pin_fails(monkeypatch):
+    row = _parity(monkeypatch, {"/py/a": "0.4.4"}, pin=(0, 5, 1))
+    assert row.ok is False and "below the pin 0.5.1" in row.detail
+
+
+def test_parity_absent_under_own_interpreter_fails(monkeypatch):
+    row = _parity(monkeypatch, {"/py/a": "missing", "/py/b": "0.5.1"}, mine="/py/a")
+    assert row.ok is False and "absent under the checklist's own interpreter" in row.detail
+
+
+def test_parity_absent_elsewhere_is_only_reported(monkeypatch):
+    row = _parity(monkeypatch, {"/py/a": "0.5.1", "/py/b": "missing"})
+    assert row.ok is True and "absent under 1" in row.detail
+
+
+def test_parity_not_installed_anywhere_fails(monkeypatch):
+    row = _parity(monkeypatch, {"/py/a": "missing"})
+    assert row.ok is False and row.detail == "not installed for any interpreter"
+
+
+# ── trust labels ────────────────────────────────────────────────────────────
+
+def _roadmap(root: Path, space: str, items: list[dict]) -> None:
+    import yaml
+    (root / space).mkdir(parents=True, exist_ok=True)
+    (root / space / "roadmap.yaml").write_text(yaml.safe_dump({"items": items}))
+
+
+DONE_OK = {"id": "X-001", "status": "done", "shipped": "2026-09-01",
+           "done_when": {"condition": "c", "evidence": "merged-pr", "verify": "gh pr view 1"}}
+
+
+def test_done_with_evidence_and_verify_passes(fixture_root):
+    _roadmap(fixture_root, "5-space", [DONE_OK, {"id": "X-002", "status": "ready"}])
+    rep = vv.Report()
+    vv.check_trust_labels(rep)
+    assert rep.checks[0].ok is True and "1 roadmap(s)" in rep.checks[0].detail
+
+
+def test_done_without_verify_or_shipped_fails(fixture_root):
+    _roadmap(fixture_root, "5-space", [
+        {"id": "X-003", "status": "done", "shipped": "2026-09-01",
+         "done_when": {"condition": "c", "evidence": "test"}},
+        {"id": "X-004", "status": "done", "shipped": None,
+         "done_when": {"condition": "c", "evidence": "test", "verify": "pytest"}},
+    ])
+    assert vv.roadmap_trust_violations(fixture_root) == ["5-space:X-003", "5-space:X-004"]
+    rep = vv.Report()
+    vv.check_trust_labels(rep)
+    assert rep.checks[0].ok is False and "5-space:X-003" in rep.checks[0].detail
+
+
+def test_no_roadmap_is_not_applicable(fixture_root):
+    rep = vv.Report()
+    vv.check_trust_labels(rep)
+    assert rep.checks[0].ok is None and rep.checks[0].skipped is True
+
+
+def test_lens_ceiling_sits_above_the_measured_steady_state():
+    assert vv.LENS_MAX_GB == 2.0


### PR DESCRIPTION
## Summary

datacore#34's reconciler never existed; three invariants from its list had no row anywhere. This adds them to `v2_verify.py`:

- **repo topology** (three rows): every registered repo on the host has `origin` naming the canonical repo; knowledge repos sit on their default branch (code repos on a work branch are reported, not failed); no commit is older than 24h with no copy on any `origin` branch (the class that stranded 610 commits, datacore#31).
- **org-workspace parity**: one version under every interpreter the host runs jobs with (the checklist's own, PATH `python3`, system, homebrew, the daemon venv), at least the pin in `requirements.txt`. Every host compares against the same pin, which is what makes it cross-host.
- **done names its check**: every roadmap item with `status: done` carries `shipped` and a `done_when` with `evidence` and `verify`.
- Lens ceiling 1 → 2 GB: 30 days of events measured 1.14 GB after the first full sweep, so 1 GB fired on the retention policy, not on growth.

First run on the mac found four real things: the trading module's `origin` basename is `li2`, not `datacore-trading`; a health-module commit has sat unpushed for 147h (`bed382a9`); homebrew's Python 3.14 carries org-workspace 0.4.0 next to pyenv's 0.5.1; 5-plur `R-092` is `done` with `shipped: false`. Those are the owner's to settle (roadmap item D-004).

## Test plan

- [x] `.datacore/tests/test_v2_verify_rows.py` (16 tests) against fixture roots: canonical remote, parked knowledge vs code, stranded vs fresh commits, parity outcomes, trust-label outcomes, no-registry and no-roadmap n/a.
- [x] `v2_verify.py --quick` on the mac runs the new rows (they fail on the real findings above, as intended).
- [ ] Verify on the box after merge; the row set there should be green except the findings that apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)