### PR TITLE
policy: an in-flight tool-call guard for executors, keyed by principal

### DIFF
--- a/.datacore/config/tool_effects.yaml
+++ b/.datacore/config/tool_effects.yaml
@@ -1,0 +1,70 @@
+# Tool-call effects — how an executor's in-flight tool call maps onto the
+# effect vocabulary of approvals_policy.yaml (datacore#30, roadmap D-005).
+#
+# approvals_policy.yaml decides WHO may cause an effect (never_effects per
+# principal, cosign_effects that need a human grant). This file decides WHICH
+# tool calls count as that effect, so the same policy that gates an item at
+# claim time also binds a running task: tool_policy.py classifies every
+# PreToolUse call with these patterns, and a hit on a principal's never-effect
+# is refused while a hit on a cosign effect without a grant is paused.
+#
+# Matching:
+#   tools          fnmatch globs on the tool name; absent = every tool
+#   tool_patterns  regexes on the tool name (MCP tools carry the verb there)
+#   patterns       regexes (case-insensitive) on the call's text: a Bash
+#                  command, a URL, a file path, or the JSON of an MCP input
+#
+# Public file — generic providers and verbs only, never a customer host.
+# Missing an effect here fails OPEN for that call: the outer controls (egress
+# enforcement, the pre-push guard, claim-time cosign) still apply. A pattern
+# that is too broad fails CLOSED on a legitimate call, which the refusal on
+# the ledger makes visible the next morning; loosen it here, not in code.
+version: 1
+# Only tools that can ACT are classified. Read, Grep, Glob, Edit and Write
+# cannot send, pay or deploy by themselves — reading deploy.sh is not a
+# deployment — so they are never an effect; the outer file-level guards
+# (org_guard, restricted paths) own those.
+acting_tools: &acting ["Bash", "WebFetch", "mcp__*"]
+effects:
+  email.send:
+    tools: *acting
+    tool_patterns:
+      - 'send_?(e?mail|message)'
+    patterns:
+      - '\bwinston_send\.py\b'
+      - '\bsendmail\b'
+      - '\bmail\s+-s\b'
+      - '\bmutt\s'
+      - '\bsmtplib\b'
+      - 'gmail/v1/users/[^/\s]+/(messages|drafts)/send'
+      - 'api\.(sendgrid|mailgun|resend|postmarkapp|sparkpost)\.'
+      - '\bgmail_send\b'
+  payment:
+    tools: *acting
+    tool_patterns:
+      - '(create_)?(charge|payment|payout|transfer)'
+      - 'place_?order'
+    patterns:
+      - 'api\.stripe\.com'
+      - '\bstripe\b.*\b(charges?|payment_intents?|transfers?|payouts?)\b'
+      - 'api(-m)?\.paypal\.com'
+      - '\bwise\.com/'
+      - 'revolut\.com/'
+      - '/(spot|futures|delivery|options)/[^\s]*orders\b'
+      - 'hyperliquid[^\s]*/exchange\b'
+      - '\b(eth|usdc|usdt|btc|bzz|icp)\b[^\n]{0,40}\b(send|transfer)\b'
+      - '\bdfx\s+(ledger\s+transfer|canister\s+call\s+\S+\s+(transfer|icrc1_transfer))'
+  prod.deploy:
+    tools: *acting
+    patterns:
+      - '\bgh\s+release\s+(create|upload)\b'
+      - '\bnpm\s+publish\b'
+      - '\btwine\s+upload\b'
+      - '\bdocker\s+push\b'
+      - '\bkubectl\s+(apply|rollout|delete|scale)\b'
+      - '\bterraform\s+(apply|destroy)\b'
+      - '\bsystemctl\s+(--user\s+)?(restart|stop|start|reload)\s'
+      - '\blaunchctl\s+(unload|bootout|kickstart)\b'
+      - '\bdeploy\.sh\b'
+      - '\bagent_update\.py\b[^\n]*--apply'
+      - '\bdistribute\.sh\b'

--- a/.datacore/lib/hooks/tool_policy_guard.py
+++ b/.datacore/lib/hooks/tool_policy_guard.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: the in-flight tool-call policy for executors (datacore#30).
+
+Thin wrapper so the hook can be named by path in `claude -p --settings`;
+every decision lives in ../tool_policy.py. Reads the hook payload on stdin,
+prints a deny when the call would cause an effect the principal may never
+cause or one that needs a grant this task does not carry, and records the
+refusal on the ledger. Exit 0 either way: the JSON is the decision.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+try:
+    from tool_policy import hook_main
+except Exception as e:  # noqa: BLE001 — a missing library must not block every call
+    print(f"[tool-policy] guard unavailable ({type(e).__name__}: {e}); call allowed", file=sys.stderr)
+    sys.exit(0)
+
+if __name__ == "__main__":
+    sys.exit(hook_main())

--- a/.datacore/lib/tool_policy.py
+++ b/.datacore/lib/tool_policy.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""In-flight tool-call policy for executors (datacore#30, roadmap D-005).
+
+The policy layer bound an item at CLAIM time — approvals_policy.yaml names,
+per principal, the effects it may never cause and the effects that need a
+human's co-signed grant; claim_gate.py enforces both before work starts. But
+a running task was bounded only by the outer controls: nightshift passed no
+hooks or settings to `claude -p`, and Miles ran with bypassPermissions and no
+hooks. Once a task was executing, "never payment" was a sentence in a YAML
+file, not a wall.
+
+This module is the wall. One classifier — config/tool_effects.yaml maps tool
+calls onto the same effect vocabulary — and one decision, keyed by principal:
+
+    never-effect hit      -> refused  (no grant can allow it)
+    cosign effect, no     -> paused   (the model is told to leave a proposal;
+      grant on this task               a human grants, the next run acts)
+    anything else         -> allowed
+
+Every refusal is recorded on the ledger as `metric.attest` with
+metric=policy.refusal — the same "this machine observed this about itself"
+vocabulary cos_ledger_event.sh uses — so a task that tried to pay someone
+shows up in the morning instead of in a log nobody reads.
+
+Two callers, one decision:
+  * hooks/tool_policy_guard.py — the PreToolUse command hook nightshift passes
+    to `claude -p --settings` (see `settings_json`)
+  * the Miles bot — an SDK PreToolUse hook that calls `evaluate_hook` in-process
+
+Context reaches the hook through the environment the executor sets:
+  DATACORE_POLICY_PRINCIPAL  whose limits apply (default: this host's actor's
+                             principal from registry/principals.yaml)
+  DATACORE_POLICY_SPACE      the task's space; the refusal is recorded there
+                             (default: <root>/2-datacore)
+  DATACORE_POLICY_TASK       the task id, carried on the record
+  DATACORE_POLICY_GRANTED    comma-separated effects a human already granted
+                             for this task (the task's :GRANTED_EFFECTS:)
+
+Fails OPEN when the policy or effects file cannot be read — a broken hook
+that blocks every call is an outage of its own, and a run with no policy is
+what every run was before this file existed — and says so on stderr. A
+classification hit is decided even when the ledger cannot be written: the
+record is evidence, not the gate.
+"""
+from __future__ import annotations
+
+import fnmatch
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+LIB = Path(__file__).resolve().parent
+ROOT = Path(os.environ.get("DATACORE_ROOT", str(Path.home() / "Data")))
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+DEFAULT_EFFECTS_FILE = LIB.parent / "config" / "tool_effects.yaml"
+DEFAULT_POLICY_FILE = LIB.parent / "config" / "approvals_policy.yaml"
+GUARD = LIB / "hooks" / "tool_policy_guard.py"
+REFUSAL_METRIC = "policy.refusal"
+
+#: Which keys of a tool's input carry the text worth matching. Anything
+#: else (an MCP tool's structured input) is matched as its JSON.
+_TEXT_KEYS = ("command", "url", "file_path", "path", "query", "prompt", "content", "new_string")
+
+
+@dataclass
+class Decision:
+    allow: bool
+    effects: set[str] = field(default_factory=set)
+    reason: str = ""
+    kind: str = "allow"          # allow | never | cosign | granted
+
+    @property
+    def blocked(self) -> bool:
+        return not self.allow
+
+
+# ── effects ─────────────────────────────────────────────────────────────────
+def load_effects(path: Path | None = None) -> dict[str, dict]:
+    """{effect: {tools, tool_patterns, patterns}} from tool_effects.yaml.
+    An unreadable file is an empty vocabulary: every call allowed, which is
+    the pre-policy behaviour, reported on stderr by the caller."""
+    import yaml
+    p = Path(path or DEFAULT_EFFECTS_FILE)
+    data = yaml.safe_load(p.read_text(encoding="utf-8")) or {}
+    out: dict[str, dict] = {}
+    for name, spec in (data.get("effects") or {}).items():
+        spec = spec or {}
+        out[str(name)] = {
+            "tools": [str(t) for t in (spec.get("tools") or [])],
+            "tool_patterns": [re.compile(str(r), re.I) for r in (spec.get("tool_patterns") or [])],
+            "patterns": [re.compile(str(r), re.I) for r in (spec.get("patterns") or [])],
+        }
+    return out
+
+
+def call_text(tool_input) -> str:
+    """The matchable text of a call: its command/url/path fields, else its JSON."""
+    if isinstance(tool_input, str):
+        return tool_input
+    if not isinstance(tool_input, dict):
+        return ""
+    parts = [str(tool_input[k]) for k in _TEXT_KEYS if isinstance(tool_input.get(k), str)]
+    if not parts:
+        try:
+            return json.dumps(tool_input, ensure_ascii=False, sort_keys=True)
+        except (TypeError, ValueError):
+            return str(tool_input)
+    return "\n".join(parts)
+
+
+def classify(tool_name: str, tool_input, effects: dict[str, dict] | None = None) -> set[str]:
+    """The effects a call would cause, by the vocabulary in tool_effects.yaml."""
+    effects = effects if effects is not None else load_effects()
+    text = call_text(tool_input)
+    hit: set[str] = set()
+    for name, spec in effects.items():
+        tools = spec.get("tools") or []
+        if tools and not any(fnmatch.fnmatch(tool_name, t) for t in tools):
+            continue
+        if any(r.search(tool_name) for r in spec.get("tool_patterns") or []):
+            hit.add(name)
+            continue
+        if text and any(r.search(text) for r in spec.get("patterns") or []):
+            hit.add(name)
+    return hit
+
+
+# ── principals ──────────────────────────────────────────────────────────────
+def limits_for(principal: str, policy_path: Path | None = None) -> tuple[set[str], set[str]]:
+    """(never_effects, cosign_effects) for a principal from approvals_policy.yaml.
+    An unlisted principal gets the global cosign set and no never-effects."""
+    from ledger.policy import load_policy
+    policy = load_policy(Path(policy_path or DEFAULT_POLICY_FILE))
+    entry = (policy.principals or {}).get(principal) or {}
+    never = {str(e) for e in (entry.get("never_effects") or [])}
+    cosign = set(policy.cosign_effects) | {str(e) for e in (entry.get("cosign_effects") or [])}
+    return never, cosign
+
+
+def principal_for(actor: str | None = None) -> str:
+    """The principal whose limits bind this executor: the writer's own entry,
+    or the principal that lists it under writes_as (nightshift -> miles)."""
+    from actor_identity import principal_of, this_actor
+    actor = (actor or this_actor()).strip().lower()
+    name, _ = principal_of(actor)
+    return name or actor
+
+
+def decide(principal: str, tool_name: str, tool_input, granted=(),
+           effects: dict[str, dict] | None = None,
+           policy_path: Path | None = None) -> Decision:
+    hit = classify(tool_name, tool_input, effects)
+    if not hit:
+        return Decision(True, hit, "no policy effect", "allow")
+    never, cosign = limits_for(principal, policy_path)
+    forbidden = hit & never
+    if forbidden:
+        what = ", ".join(sorted(forbidden))
+        return Decision(False, hit, f"{principal} may never cause {what} "
+                                    f"(approvals_policy.yaml never_effects); the call is refused "
+                                    f"and recorded — do not retry it another way", "never")
+    needs = (hit & cosign) - {str(g).strip() for g in granted if str(g).strip()}
+    if needs:
+        what = ", ".join(sorted(needs))
+        return Decision(False, hit, f"{what} needs a co-signed grant before it runs and this task "
+                                    f"carries none; the call is paused and recorded — leave the "
+                                    f"step as a proposal for a human to grant", "cosign")
+    return Decision(True, hit, f"{', '.join(sorted(hit))} granted on this task", "granted")
+
+
+# ── the record ──────────────────────────────────────────────────────────────
+def record_refusal(decision: Decision, *, principal: str, tool_name: str,
+                   space_dir: Path | None = None, task_id: str = "",
+                   actor: str | None = None, detail: str = "") -> bool:
+    """Append the refusal to the ledger of the task's space. Best-effort:
+    returns False and says why on stderr when it cannot; never raises."""
+    try:
+        from actor_identity import this_actor
+        from ledger.log import EventLog
+        space = Path(space_dir) if space_dir else ROOT / "2-datacore"
+        if not (space / ".datacore" / "events").is_dir():
+            print(f"[tool-policy] no ledger at {space}; refusal not recorded", file=sys.stderr)
+            return False
+        log = EventLog(space, (actor or this_actor()).strip().lower())
+        log.append("metric.attest", {
+            "metric": REFUSAL_METRIC,
+            "principal": principal,
+            "task": task_id or "",
+            "tool": tool_name,
+            "effects": sorted(decision.effects),
+            "kind": decision.kind,
+            "reason": decision.reason[:300],
+            "detail": detail[:200],
+        })
+        return True
+    except Exception as e:  # noqa: BLE001 — the record is evidence, not the gate
+        print(f"[tool-policy] refusal not recorded ({type(e).__name__}: {e})", file=sys.stderr)
+        return False
+
+
+# ── the hook ────────────────────────────────────────────────────────────────
+def context_from_env(env=None) -> dict:
+    env = os.environ if env is None else env
+    principal = (env.get("DATACORE_POLICY_PRINCIPAL") or "").strip().lower()
+    if not principal:
+        try:
+            principal = principal_for()
+        except Exception:  # noqa: BLE001
+            principal = "unknown"
+    granted = [g.strip() for g in (env.get("DATACORE_POLICY_GRANTED") or "").split(",") if g.strip()]
+    space = env.get("DATACORE_POLICY_SPACE") or ""
+    return {"principal": principal, "granted": granted,
+            "space": Path(space) if space else None,
+            "task": (env.get("DATACORE_POLICY_TASK") or "").strip()}
+
+
+def deny_output(reason: str) -> dict:
+    return {"hookSpecificOutput": {"hookEventName": "PreToolUse",
+                                   "permissionDecision": "deny",
+                                   "permissionDecisionReason": reason}}
+
+
+def evaluate_hook(payload: dict, env=None, *, record: bool = True,
+                  effects: dict[str, dict] | None = None,
+                  policy_path: Path | None = None) -> dict | None:
+    """The PreToolUse decision for one call. Returns the hook's JSON output
+    when the call is refused or paused, None when it may proceed."""
+    tool_name = str((payload or {}).get("tool_name") or "")
+    tool_input = (payload or {}).get("tool_input") or {}
+    ctx = context_from_env(env)
+    try:
+        effects = effects if effects is not None else load_effects()
+        decision = decide(ctx["principal"], tool_name, tool_input, ctx["granted"], effects, policy_path)
+    except Exception as e:  # noqa: BLE001 — fail open, loudly
+        print(f"[tool-policy] policy unavailable ({type(e).__name__}: {e}); call allowed", file=sys.stderr)
+        return None
+    if decision.allow:
+        return None
+    if record:
+        record_refusal(decision, principal=ctx["principal"], tool_name=tool_name,
+                       space_dir=ctx["space"], task_id=ctx["task"],
+                       detail=call_text(tool_input)[:200])
+    return deny_output(decision.reason)
+
+
+def hook_main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError, ValueError):
+        return 0
+    out = evaluate_hook(payload)
+    if out is not None:
+        print(json.dumps(out))
+    return 0
+
+
+def settings_json(guard: Path | None = None, timeout: int = 8) -> str:
+    """The `--settings` JSON that wires the guard as a PreToolUse hook on
+    every tool, for `claude -p` runs that load no other settings."""
+    cmd = f"python3 {guard or GUARD}"
+    return json.dumps({"hooks": {"PreToolUse": [
+        {"matcher": "*", "hooks": [{"type": "command", "command": cmd, "timeout": timeout}]}]}})
+
+
+if __name__ == "__main__":
+    sys.exit(hook_main())

--- a/.datacore/tests/test_tool_policy.py
+++ b/.datacore/tests/test_tool_policy.py
@@ -1,0 +1,201 @@
+"""The in-flight tool-call policy (datacore#30): classification by
+tool_effects.yaml, the decision per principal, the refusal on the ledger,
+and the hook protocol. Fixture policy and ledger; never the real ones."""
+from __future__ import annotations
+
+import io
+import json
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+LIB = Path(__file__).resolve().parents[1] / "lib"
+sys.path.insert(0, str(LIB))
+import tool_policy as tp  # noqa: E402
+
+EFFECTS = tp.load_effects()   # the shipped vocabulary, config/tool_effects.yaml
+
+
+@pytest.fixture
+def policy_file(tmp_path):
+    p = tmp_path / "approvals_policy.yaml"
+    p.write_text(yaml.safe_dump({
+        "version": 1, "approver": "human",
+        "cosign_effects": ["email.send", "payment", "prod.deploy"],
+        "known_effects": ["email.send", "payment", "prod.deploy"],
+        "principals": {
+            "gregor": {},
+            "miles": {"never_effects": ["payment"], "may_delegate_to": ["tris", "data"]},
+            "tris": {"never_effects": ["payment", "prod.deploy"]},
+        },
+    }))
+    return p
+
+
+# ── classification ──────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("tool,inp,expected", [
+    ("Bash", {"command": "curl -X POST https://api.stripe.com/v1/charges -d amount=100"}, {"payment"}),
+    ("Bash", {"command": "python3 ~/Data/.datacore/lib/winston_send.py 'hello'"}, {"email.send"}),
+    ("Bash", {"command": "gh release create v1.2.0 --notes x"}, {"prod.deploy"}),
+    ("Bash", {"command": "sudo systemctl restart datacored"}, {"prod.deploy"}),
+    ("Bash", {"command": "ls -la && git status"}, set()),
+    ("Bash", {"command": "grep -rn 'stripe' docs/ | head"}, set()),
+    ("WebFetch", {"url": "https://api.paypal.com/v2/checkout/orders"}, {"payment"}),
+    ("mcp__gmail__send_email", {"to": "x@example.org", "body": "hi"}, {"email.send"}),
+    ("mcp__gateio__place_order", {"pair": "BTC_USDT"}, {"payment"}),
+    # Reading, editing or writing cannot act: no effect, whatever the text says.
+    ("Read", {"file_path": "/x/deploy.sh"}, set()),
+    ("Edit", {"file_path": "/x/pay.py", "new_string": "requests.post('https://api.stripe.com/v1/charges')"}, set()),
+])
+def test_classify_by_the_shipped_vocabulary(tool, inp, expected):
+    assert tp.classify(tool, inp, EFFECTS) == expected
+
+
+def test_call_text_prefers_command_fields_then_json():
+    assert tp.call_text({"command": "ls", "description": "list"}) == "ls"
+    assert json.loads(tp.call_text({"a": 1, "b": [2]})) == {"a": 1, "b": [2]}
+    assert tp.call_text("raw") == "raw"
+    assert tp.call_text(None) == ""
+
+
+# ── decision ────────────────────────────────────────────────────────────────
+
+def test_never_effect_is_refused_whatever_the_grants(policy_file):
+    d = tp.decide("miles", "Bash", {"command": "curl https://api.stripe.com/v1/charges"},
+                  granted=["payment"], effects=EFFECTS, policy_path=policy_file)
+    assert d.blocked and d.kind == "never" and "may never cause payment" in d.reason
+
+
+def test_cosign_effect_without_grant_is_paused(policy_file):
+    d = tp.decide("miles", "Bash", {"command": "python3 winston_send.py 'x'"},
+                  effects=EFFECTS, policy_path=policy_file)
+    assert d.blocked and d.kind == "cosign"
+    assert "email.send needs a co-signed grant" in d.reason and "proposal" in d.reason
+
+
+def test_cosign_effect_with_grant_is_allowed(policy_file):
+    d = tp.decide("miles", "Bash", {"command": "python3 winston_send.py 'x'"},
+                  granted=["email.send"], effects=EFFECTS, policy_path=policy_file)
+    assert d.allow and d.kind == "granted"
+
+
+def test_plain_calls_are_allowed(policy_file):
+    d = tp.decide("tris", "Bash", {"command": "pytest -q"}, effects=EFFECTS, policy_path=policy_file)
+    assert d.allow and d.kind == "allow" and d.effects == set()
+
+
+def test_tris_may_never_deploy(policy_file):
+    d = tp.decide("tris", "Bash", {"command": "npm publish"}, effects=EFFECTS, policy_path=policy_file)
+    assert d.blocked and d.kind == "never" and "prod.deploy" in d.reason
+
+
+def test_unlisted_principal_gets_global_cosign_and_no_nevers(policy_file):
+    never, cosign = tp.limits_for("someone-new", policy_file)
+    assert never == set() and cosign == {"email.send", "payment", "prod.deploy"}
+
+
+# ── the record ──────────────────────────────────────────────────────────────
+
+def _space(tmp_path):
+    (tmp_path / "space" / ".datacore" / "events").mkdir(parents=True)
+    return tmp_path / "space"
+
+
+def test_refusal_is_recorded_on_the_task_space_ledger(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATACORE_LEDGER_SIGN", "0")
+    space = _space(tmp_path)
+    d = tp.Decision(False, {"payment"}, "miles may never cause payment", "never")
+    assert tp.record_refusal(d, principal="miles", tool_name="Bash", space_dir=space,
+                             task_id="org-1", actor="nightshift", detail="curl api.stripe.com")
+    from ledger.log import read_events
+    ev = read_events(space)
+    assert len(ev) == 1 and ev[0].type == "metric.attest" and ev[0].actor == "nightshift"
+    p = ev[0].payload
+    assert p["metric"] == "policy.refusal" and p["principal"] == "miles"
+    assert p["task"] == "org-1" and p["effects"] == ["payment"] and p["kind"] == "never"
+
+
+def test_record_is_best_effort_without_a_ledger(tmp_path, capsys):
+    d = tp.Decision(False, {"payment"}, "x", "never")
+    assert tp.record_refusal(d, principal="miles", tool_name="Bash", space_dir=tmp_path / "nowhere",
+                             actor="nightshift") is False
+    assert "not recorded" in capsys.readouterr().err
+
+
+# ── the hook ────────────────────────────────────────────────────────────────
+
+def test_hook_denies_never_effect_and_records(tmp_path, monkeypatch, policy_file):
+    monkeypatch.setenv("DATACORE_LEDGER_SIGN", "0")
+    monkeypatch.setenv("DATACORE_ACTOR", "nightshift")
+    space = _space(tmp_path)
+    env = {"DATACORE_POLICY_PRINCIPAL": "miles", "DATACORE_POLICY_SPACE": str(space),
+           "DATACORE_POLICY_TASK": "org-42"}
+    out = tp.evaluate_hook({"tool_name": "Bash", "tool_input": {"command": "curl https://api.stripe.com/v1/charges"}},
+                           env=env, effects=EFFECTS, policy_path=policy_file)
+    assert out["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert "may never cause payment" in out["hookSpecificOutput"]["permissionDecisionReason"]
+    from ledger.log import read_events
+    ev = read_events(space)
+    assert ev[-1].payload["task"] == "org-42" and ev[-1].payload["tool"] == "Bash"
+
+
+def test_hook_allows_plain_calls_and_granted_effects(tmp_path, policy_file):
+    env = {"DATACORE_POLICY_PRINCIPAL": "miles", "DATACORE_POLICY_GRANTED": "email.send"}
+    assert tp.evaluate_hook({"tool_name": "Bash", "tool_input": {"command": "ls"}},
+                            env=env, effects=EFFECTS, policy_path=policy_file) is None
+    assert tp.evaluate_hook({"tool_name": "Bash", "tool_input": {"command": "python3 winston_send.py x"}},
+                            env=env, effects=EFFECTS, policy_path=policy_file) is None
+
+
+def test_absent_policy_file_means_the_shipped_defaults(tmp_path):
+    # ledger.policy falls back to its built-in defaults (the three cosign
+    # effects, no principals) when the file is absent — so a deploy without
+    # a grant is still paused, not waved through.
+    env = {"DATACORE_POLICY_PRINCIPAL": "miles"}
+    out = tp.evaluate_hook({"tool_name": "Bash", "tool_input": {"command": "npm publish"}},
+                           env=env, effects=EFFECTS, policy_path=tmp_path / "missing.yaml", record=False)
+    assert out["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+def test_hook_fails_open_when_policy_is_unreadable(tmp_path, capsys):
+    bad = tmp_path / "broken.yaml"
+    bad.write_text("approver: [unclosed\ncosign_effects: {")
+    env = {"DATACORE_POLICY_PRINCIPAL": "miles"}
+    out = tp.evaluate_hook({"tool_name": "Bash", "tool_input": {"command": "npm publish"}},
+                           env=env, effects=EFFECTS, policy_path=bad)
+    assert out is None and "call allowed" in capsys.readouterr().err
+
+
+def test_hook_main_protocol(monkeypatch, capsys, tmp_path, policy_file):
+    monkeypatch.setattr(tp, "DEFAULT_POLICY_FILE", policy_file)
+    monkeypatch.setenv("DATACORE_POLICY_PRINCIPAL", "tris")
+    monkeypatch.setenv("DATACORE_POLICY_SPACE", str(tmp_path / "nowhere"))
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(
+        {"tool_name": "Bash", "tool_input": {"command": "twine upload dist/*"}})))
+    assert tp.hook_main() == 0
+    out = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert out["hookSpecificOutput"]["permissionDecision"] == "deny"
+    monkeypatch.setattr(sys, "stdin", io.StringIO("not json"))
+    assert tp.hook_main() == 0
+
+
+def test_settings_json_wires_the_guard_on_every_tool():
+    s = json.loads(tp.settings_json(Path("/opt/x/guard.py")))
+    hook = s["hooks"]["PreToolUse"][0]
+    assert hook["matcher"] == "*"
+    assert hook["hooks"][0]["command"] == "python3 /opt/x/guard.py"
+    assert tp.GUARD.name == "tool_policy_guard.py" and tp.GUARD.exists()
+
+
+def test_principal_for_maps_a_writer_to_its_principal(tmp_path, monkeypatch):
+    import actor_identity as ai
+    reg = tmp_path / "principals.yaml"
+    reg.write_text(yaml.safe_dump({"principals": {
+        "miles": {"kind": "agent", "writes_as": ["miles", "nightshift"]}}}))
+    monkeypatch.setattr(ai, "PRINCIPALS", reg)
+    assert tp.principal_for("nightshift") == "miles"
+    assert tp.principal_for("miles") == "miles"
+    assert tp.principal_for("stranger") == "stranger"


### PR DESCRIPTION
## Summary

`approvals_policy.yaml` bound an item at claim time; nothing bound a running task. nightshift passed no hooks or settings to `claude -p`, Miles ran with `bypassPermissions` and no hooks, so "miles may never cause payment" was a sentence, not a wall (datacore#30, roadmap D-005).

- **`config/tool_effects.yaml`** maps acting tool calls (Bash, WebFetch, `mcp__*`) onto the effect vocabulary — `email.send`, `payment`, `prod.deploy` — with tool-name and text patterns. Read/Edit/Write never classify (reading deploy.sh is not a deployment).
- **`lib/tool_policy.py`**: `classify` → `decide(principal, …)` → never-effect **refused**, cosign effect without a grant **paused** (the model is told to leave a proposal), else allowed. Every refusal is recorded as `metric.attest` (`metric: policy.refusal`) on the task's space ledger with principal, task, tool, effects and reason. Context arrives as `DATACORE_POLICY_PRINCIPAL / _SPACE / _TASK / _GRANTED`; the principal defaults to this host's actor's principal (`nightshift` → `miles` via `writes_as`). Fails open, loudly, when the policy file is unreadable; an absent file means ledger.policy's shipped defaults.
- **`lib/hooks/tool_policy_guard.py`**: the PreToolUse command hook for `claude -p --settings` (`settings_json()` builds the JSON). The Miles bot calls `evaluate_hook` in process.

Companion PRs: datacore-nightshift (executor wiring + `:GRANTED_EFFECTS:`), datacore-telegram (Miles SDK hook).

## Test plan

- [x] `.datacore/tests/test_tool_policy.py` (27 tests): classification by the shipped vocabulary, never/cosign/granted decisions per principal, refusal recorded on a fixture ledger, hook protocol on stdin, fail-open on a broken policy, defaults on an absent one, writer→principal mapping.
- [ ] On the nightshift host after the three PRs merge: pipe a synthetic Bash payload (`curl https://api.stripe.com/...`) into the guard with `DATACORE_POLICY_PRINCIPAL=miles` and confirm a deny plus a `policy.refusal` event in 2-datacore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)