### PR TITLE
verify: stranded means knowledge repos; shipped:false is a stated outcome

### DIFF
--- a/.datacore/lib/v2_verify.py
+++ b/.datacore/lib/v2_verify.py
@@ -526,7 +526,7 @@ def check_topology(rep: Report) -> None:
     if not repos:
         rep.add("0046", "repo topology", None, "no registered repositories on this host")
         return
-    wrong, parked_knowledge, parked_code, stranded = [], [], [], []
+    wrong, parked_knowledge, parked_code, stranded, code_unpushed = [], [], [], [], []
     for name, path, category, canonical in repos:
         rc, url = _git(path, "remote", "get-url", "origin")
         base = ""
@@ -542,14 +542,22 @@ def check_topology(rep: Report) -> None:
             (parked_knowledge if category == "knowledge" else parked_code).append(f"{name}: {cur}")
         n, age = stranded_age_hours(path)
         if n and age > UNPUSHED_MAX_HOURS:
-            stranded.append(f"{name}: {n} commit(s), oldest {age:.0f}h")
+            # The transport pushes a KNOWLEDGE repo every cycle, so a day-old
+            # commit with no remote copy there is work at risk — FAIL. A CODE
+            # repo is a person's working tree (a box-side fix awaiting
+            # reconciliation, a feature branch): pushing is a deliberate act,
+            # so it is reported here for the deploy-drift review, not failed.
+            (stranded if category == "knowledge" else code_unpushed).append(
+                f"{name}: {n} commit(s), oldest {age:.0f}h")
     rep.add("0046", "remotes canonical", not wrong,
             f"{len(repos)} repos" if not wrong else "; ".join(wrong[:3]))
     rep.add("0046", "knowledge on default branch", not parked_knowledge,
             ("; ".join(parked_knowledge[:3]) if parked_knowledge
              else (f"code parked: {'; '.join(parked_code[:3])}" if parked_code else "all on default")))
     rep.add("0046", "no stranded commits", not stranded,
-            "; ".join(stranded[:3]) if stranded else f"nothing older than {UNPUSHED_MAX_HOURS:g}h off-remote")
+            ("; ".join(stranded[:3]) if stranded
+             else (f"code unpushed: {'; '.join(code_unpushed[:3])}" if code_unpushed
+                   else f"nothing older than {UNPUSHED_MAX_HOURS:g}h off-remote")))
 
 
 def _pinned_org_workspace() -> tuple[int, ...] | None:
@@ -644,7 +652,11 @@ def roadmap_trust_violations(root: Path | None = None) -> list[str]:
                 continue
             dw = item.get("done_when")
             named = isinstance(dw, dict) and bool(dw.get("evidence")) and bool(dw.get("verify"))
-            if not named or not item.get("shipped"):
+            # `shipped` must be STATED, not necessarily a date: `shipped:
+            # false` is an author saying "closed, nothing shipped" (a retired
+            # item — the schema has no retired status), which is a named
+            # outcome; a missing or null `shipped` is not.
+            if not named or item.get("shipped") is None:
                 bad.append(f"{rm.parent.name}:{item.get('id')}")
     return bad
 

--- a/.datacore/tests/test_v2_verify_rows.py
+++ b/.datacore/tests/test_v2_verify_rows.py
@@ -100,13 +100,17 @@ def test_topology_code_parked_is_reported_not_failed(fixture_root):
     assert row.ok is True and "code parked: .datacore/modules/mod: feature" in row.detail
 
 
+def _old_local_commit(repo: Path, hours: int = 30) -> None:
+    (repo / "new").write_text("y\n")
+    _git(repo, "add", "new")
+    old = str(int(time.time()) - hours * 3600)
+    _git(repo, "commit", "-q", "-m", "local only",
+         env={"GIT_COMMITTER_DATE": f"@{old} +0000", "GIT_AUTHOR_DATE": f"@{old} +0000"})
+
+
 def test_stranded_commit_older_than_a_day_fails(fixture_root):
     space = _repo_with_remote(fixture_root, "2-space", "datacore-space")
-    (space / "new").write_text("y\n")
-    _git(space, "add", "new")
-    old = str(int(time.time()) - 30 * 3600)
-    _git(space, "commit", "-q", "-m", "local only",
-         env={"GIT_COMMITTER_DATE": f"@{old} +0000", "GIT_AUTHOR_DATE": f"@{old} +0000"})
+    _old_local_commit(space)
     n, age = vv.stranded_age_hours(space)
     assert n == 1 and 29 < age < 31
     _registry(fixture_root, {"2-space": {"category": "knowledge", "repo": "datacore-space"}})
@@ -114,6 +118,19 @@ def test_stranded_commit_older_than_a_day_fails(fixture_root):
     vv.check_topology(rep)
     row = {c.name: c for c in rep.checks}["no stranded commits"]
     assert row.ok is False and row.detail.startswith("2-space: 1 commit(s), oldest 30h")
+
+
+def test_unpushed_code_commit_is_reported_not_failed(fixture_root):
+    # A box-side fix awaiting reconciliation, or a feature branch: a person's
+    # working tree. The deploy-drift review reads the detail; the row stays ok.
+    code = _repo_with_remote(fixture_root, ".datacore/modules/mod", "datacore-mod")
+    _old_local_commit(code)
+    _registry(fixture_root, {".datacore/modules/mod": {"category": "code", "repo": "datacore-mod"}})
+    rep = vv.Report()
+    vv.check_topology(rep)
+    row = {c.name: c for c in rep.checks}["no stranded commits"]
+    assert row.ok is True
+    assert row.detail.startswith("code unpushed: .datacore/modules/mod: 1 commit(s), oldest 30h")
 
 
 def test_fresh_unpushed_commit_is_not_stranded(fixture_root):
@@ -201,6 +218,9 @@ def test_done_without_verify_or_shipped_fails(fixture_root):
          "done_when": {"condition": "c", "evidence": "test"}},
         {"id": "X-004", "status": "done", "shipped": None,
          "done_when": {"condition": "c", "evidence": "test", "verify": "pytest"}},
+        # A retired item: `shipped: false` is a stated outcome, not a missing one.
+        {"id": "X-005", "status": "done", "shipped": False,
+         "done_when": {"condition": "c", "evidence": "decision", "verify": "the exposure is gone"}},
     ])
     assert vv.roadmap_trust_violations(fixture_root) == ["5-space:X-003", "5-space:X-004"]
     rep = vv.Report()


### PR DESCRIPTION
## Summary

The two rows from #135 turned the box red on their first scheduled run (18:00 UTC) and the morning `ops` check with it — three hourly alerts overnight. Both findings were real; neither is the box's to fix.

- **no stranded commits**: a day-old commit with no remote copy FAILS only in a knowledge repo (the transport should have pushed it). In a code repo it is a person's working tree — a box-side fix awaiting reconciliation, a feature branch — and is now reported in the row's detail (`code unpushed: …`) for the deploy-drift review, not failed.
- **done names its check**: `shipped: false` on a done item is an author stating "closed, nothing shipped" (a retired item; the roadmap schema has no retired status). Only a missing or null `shipped` fails.

## Test plan

- [x] `test_v2_verify_rows.py` 23 passed (new: unpushed code commit reported not failed; `shipped: false` accepted), `test_hook_commands_resolve.py` 5 passed.
- [ ] Box: pull, `systemctl start v2-verify.service` → unit green; the hourly `unit-failed` alert and the morning `ops` FAIL stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)