### PR TITLE
ledger: a drawer inside a body is never rendered or ingested

### DIFF
--- a/.datacore/lib/ledger/genesis.py
+++ b/.datacore/lib/ledger/genesis.py
@@ -39,6 +39,7 @@ from pathlib import Path
 from .events import Event  # noqa: F401  (re-exported for callers/tests)
 from .fold import fold
 from .log import EventLog, read_events
+from .projector import strip_drawers as _strip_drawers
 
 #: Human workflow states.
 HUMAN_STATES = ("TODO", "NEXT", "WAITING", "DEFERRED")
@@ -256,7 +257,10 @@ def task_payload(node, space: str, date: str, rung: str) -> dict:
         "effective_tags": sorted(t for t in (node.tags or []) if t),
         "org": {
             "priority": node.priority,
-            "body": node.body or "",
+            # A second drawer inside the body (left behind by an id rewrite)
+            # is structure, not prose; captured verbatim it made the
+            # projection print an :ID: twice (5-plur, 2026-09-05..07).
+            "body": _strip_drawers(node.body or ""),
             "properties": {
                 k: v for k, v in (node.properties or {}).items()
                 if k not in ("ID", "CREATED")

--- a/.datacore/lib/ledger/projector.py
+++ b/.datacore/lib/ledger/projector.py
@@ -317,13 +317,29 @@ def render_item(item, *, level: int | None = None) -> list[str]:
         props["CREATED"] = f"[{genesis['date']}]"
     lines.extend("  " + line for line in _drawer(props))
 
-    body = (org.get("body") or "").rstrip()
+    body = strip_drawers((org.get("body") or "").rstrip())
     # Body text is copied verbatim, so a typed weekday inside it (a DEADLINE
     # line captured as body, 4-forge 2026-09-04) came back on every projection.
     body = _STAMP_DAY.sub(_fix_day, body)
     if body:
         lines.extend(body.split("\n"))
     return lines
+
+
+_DRAWER_BLOCK = re.compile(r"^[ \t]*:PROPERTIES:[ \t]*\n(?:.*\n)*?[ \t]*:END:[ \t]*\n?", re.M)
+
+
+def strip_drawers(body: str) -> str:
+    """A properties drawer is structure, never prose: the one drawer an item
+    has is rendered from its payload above the body. Sixteen items in 5-plur
+    carried a second drawer INSIDE their body text (an earlier id-rewrite
+    left the old drawer behind, and ingest copied the body verbatim), so the
+    projection printed `:ID: org-70b200f505da` twice and id_churn failed
+    hourly for two days. Dropped at render time so the ledger's history
+    stays as written; genesis drops them at ingest too."""
+    if ":PROPERTIES:" not in body:
+        return body
+    return _DRAWER_BLOCK.sub("", body + ("\n" if not body.endswith("\n") else "")).rstrip("\n")
 
 
 def projected_items(state: LedgerState, *, space: str | None = None) -> list:

--- a/.datacore/lib/tests/test_ledger_projector_body.py
+++ b/.datacore/lib/tests/test_ledger_projector_body.py
@@ -1,0 +1,41 @@
+"""A properties drawer inside an item's body is never rendered, and never
+ingested: the one drawer an item has comes from its payload.
+
+5-plur, 2026-09-05..07: sixteen items carried a second drawer in their body
+(an earlier id rewrite left the old drawer behind; ingest copied the body
+verbatim), so the projection printed `:ID: org-70b200f505da` twice and the
+id_churn detector failed hourly for two days."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from ledger.fold import ItemState  # noqa: E402
+from ledger.projector import render_item, strip_drawers  # noqa: E402
+
+STRAY = "  :PROPERTIES:\n  :ID: org-70b200f505da\n  :END:\n"
+
+
+def test_strip_drawers_removes_every_drawer_and_keeps_prose():
+    assert strip_drawers("") == ""
+    assert strip_drawers("plain prose") == "plain prose"
+    assert strip_drawers(STRAY) == ""
+    assert strip_drawers("before\n" + STRAY + "after") == "before\nafter"
+    two = STRAY + "middle\n:PROPERTIES:\n:CREATED: [2026-07-15 Wed]\n:ID: org-old\n:END:\nend"
+    assert strip_drawers(two) == "middle\nend"
+
+
+def test_render_item_never_prints_a_drawer_from_the_body():
+    item = ItemState(id="org-1", title="Send the inventory", owner=None, status="created",
+                     payload={"state": "TODO", "org": {"body": STRAY + "notes here"}})
+    text = "\n".join(render_item(item, level=2))
+    assert text.count(":ID:") == 1
+    assert ":ID: org-1" in text and "org-70b200f505da" not in text
+    assert text.rstrip().endswith("notes here")
+
+
+def test_genesis_strips_the_body_at_ingest():
+    import ledger.genesis as g
+    assert g._strip_drawers is strip_drawers


### PR DESCRIPTION
## Summary

`mac-id-churn` failed 26 times because `5-plur/org/next_actions.org` printed four `:ID:` lines twice. Cause: sixteen items in the 5-plur ledger carry a second properties drawer inside their body text (an earlier id rewrite left the old drawer behind; ingest copied the body verbatim), and the projector rendered bodies verbatim.

- `projector.strip_drawers(body)` removes `:PROPERTIES: … :END:` blocks from body text at render time; the ledger's history stays as written.
- `genesis` applies the same strip at ingest, so no new item carries one.

Alongside (not in this PR, ledger housekeeping already applied on the mac as actor `mac`): the empty duplicate `Business` and `Engineering` section items were dismissed (kind housekeeping) and the three subsections under the second Engineering section re-parented to the surviving one.

## Test plan

- [x] `test_ledger_projector_body.py` (3 tests) + existing fold/dismiss tests pass.
- [ ] Mac after merge: `ledger_project_org.py --space 5-plur`, then `detectors/id_churn.py` prints `0 with findings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)