### PR TITLE
transport: never autosave another principal's writer log; registry ships with the code

### DIFF
--- a/.datacore/config/authorship-reviewed.yaml
+++ b/.datacore/config/authorship-reviewed.yaml
@@ -11,3 +11,10 @@ reviewed:
     date: 2026-09-06
     what: "A geo cadence run on hermes (clone ~/Data/2-plur) committed with `git add -A` and swept two ingest events that a process on that host had written under actor winston (hlc .winston) — a misattributed writer on the wrong host, carried under Tris's name."
     action: "Reviewed 2026-09-06 08:00. Source fix: the hermes clone must write as tris only and stage its own paths; tracked in the 2-datacore inbox."
+  - commit: c7138535
+    space: 5-plur
+    writer: winston
+    committed_as: tris                  # author email hash 6b962a4a3a0068be
+    date: 2026-09-07
+    what: "Same cause as e3c8068e, one day later: the Hermes cron job geo-research-tris (06:00 UTC) followed its skill file geo-cadence-operations/SKILL.md, which said to open EventLog(actor='winston', sign=False) for task creation; one item.create for a geo review landed in winston.jsonl, and the transport's autosave at 06:25 committed the file under Tris's name."
+    action: "Reviewed 2026-09-07. Source fixed: the skill now uses this_actor() (tris) and leaves signing to identity.env; the transport no longer autosaves a writer log that belongs to another declared principal (it unstages it, commits the rest and stops, naming the file). Tris's memory store still carries the old instruction three times; the guard makes that harmless."

--- a/.datacore/lib/ledger_transport.py
+++ b/.datacore/lib/ledger_transport.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 import fcntl
 import json
 import os
+import re
 import subprocess
 import sys
 from contextlib import contextmanager
@@ -87,9 +88,24 @@ def _repo_lock(space: Path):
             fcntl.flock(fh, fcntl.LOCK_UN)
 
 
+SHIPPED_REGISTRY = Path(__file__).resolve().parents[2] / ".datacore" / "registry" / "repositories.yaml"
+
+
 def _registry(root: Path) -> dict:
+    """The repository registry: the root's own copy, else the one that ships
+    with this code tree.
+
+    A host whose code lives outside its data root (hermes: the runner clone
+    holds the code, `~/Data` there is a plain directory of space clones) has no
+    `.datacore/registry` under `--root`. Until 2026-09-06 `sync` globbed the
+    spaces and classified each against the code tree's registry; the
+    registry-driven sync that replaced it read `root/.datacore/registry` only
+    and raised FileNotFoundError twice a day on hermes (datacore-fleet-sync,
+    from 18:10 UTC 2026-09-06) — a traceback where an outcome belonged."""
     import yaml
     p = root / ".datacore" / "registry" / "repositories.yaml"
+    if not p.exists() and SHIPPED_REGISTRY.exists():
+        p = SHIPPED_REGISTRY
     return (yaml.safe_load(p.read_text()) or {}).get("repositories", {})
 
 
@@ -156,6 +172,53 @@ def _in_progress(space: Path) -> str:
         if "leftover conflict marker" in out:
             return "conflict markers"
     return ""
+
+
+_WRITER_LOG = re.compile(r"(?:^|/)\.datacore/events/([A-Za-z0-9_-]+)\.jsonl$")
+
+
+def _own_principal() -> tuple[str | None, str]:
+    """This host's principal and the actor it writes as (DIP-0044); (None, "")
+    when identity cannot be resolved — the guard then stands down rather than
+    refusing every autosave on a host with a half-configured identity."""
+    try:
+        from actor_identity import principal_of, this_actor
+        actor = this_actor()
+        return principal_of(actor)[0], actor
+    except Exception:  # noqa: BLE001 — identity is advisory here, never a crash
+        return None, ""
+
+
+def _principal_of(writer: str) -> str | None:
+    try:
+        from actor_identity import principal_of
+        return principal_of(writer)[0]
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def foreign_writer_logs(space: Path) -> list[tuple[str, str, str]]:
+    """Staged writer logs that belong to a DIFFERENT declared principal than
+    this host's: (path, writer, principal).
+
+    Only a declared-against-declared mismatch counts. A writer nobody has
+    declared (a hostname-derived log from before DIP-0044) is still autosaved
+    as before, and a host whose own principal is unknown refuses nothing:
+    the guard exists for the one case the registry can actually decide."""
+    own, _ = _own_principal()
+    if not own:
+        return []
+    _, staged, _ = _git(space, "diff", "--cached", "--name-only")
+    out = []
+    for line in (staged or "").splitlines():
+        m = _WRITER_LOG.search(line.strip())
+        if not m:
+            continue
+        writer = m.group(1)
+        principal = _principal_of(writer)
+        if principal and principal != own:
+            out.append((line.strip(), writer, principal))
+    return out
 
 
 def converge(space: Path) -> Result:
@@ -265,6 +328,20 @@ def _converge_locked(space: Path, *, publish: bool = True) -> Result:
         # whose only change is a submodule pointer could never sync again.
         # Observed on nightshift: 2 commits ahead, 7 behind, dirty only in
         # `.datacore/dips`, unable to converge at all.
+        # NEVER AUTOSAVE ANOTHER PRINCIPAL'S WRITER LOG. Per-writer logs are
+        # the ledger's authorship (DIP-0044): `<space>/.datacore/events/tris.jsonl`
+        # is Tris's word and nobody else's. On 2026-09-06 and again on
+        # 2026-09-07 a cadence on hermes appended to `winston.jsonl`, and this
+        # autosave committed the file under Tris's name — an approval-capable
+        # log carrying events its principal never made, signed into main by
+        # a host that is not its principal's. The verifier caught it after the
+        # fact; the transport must not carry it in the first place. Unstage
+        # it, commit the rest, and stop: the file stays in the working tree,
+        # visible, for whoever owns the process that wrote it.
+        foreign = foreign_writer_logs(space)
+        for path, _writer, _principal in foreign:
+            _git(space, "restore", "--staged", "--", path)
+
         rc_staged, _, _ = _git(space, "diff", "--cached", "--quiet")
         if rc_staged == 0:                      # 0 = no staged changes remain
             autosaved = False
@@ -286,6 +363,15 @@ def _converge_locked(space: Path, *, publish: bool = True) -> Result:
             detail = (cout + cerr).strip()
             return Result(False, "autosave refused by pre-commit hook",
                           {"detail": detail[:400]})
+        if foreign:
+            own_principal, own_actor = _own_principal()
+            named = "; ".join(f"{path} belongs to {principal} (writer {writer})"
+                              for path, writer, principal in foreign)
+            return Result(False,
+                          f"foreign writer log left uncommitted: {named} — this host writes "
+                          f"as {own_actor or '?'} for {own_principal or 'an undeclared principal'}; "
+                          f"find the process writing under that name and stop it (DIP-0044)",
+                          {"branch": db, "foreign": [p for p, _, _ in foreign]})
 
     rc, mout, err = _git(space, "merge", "--no-edit", f"origin/{db}")
     if rc != 0:
@@ -517,6 +603,10 @@ def sync_all(root: Path, only: str | None = None, quiet: bool = False,
              include_code: bool = True) -> int:
     outcomes = sync_outcomes(root, only=only, include_code=include_code)
     bad = [(n, o) for n, _, o in outcomes if o in HUMAN_NEEDED]
+    if not outcomes and not quiet:
+        print(f"sync: no registered repository is checked out under {root} "
+              f"({len(_registry(root))} registered) — the hourly phase-1 cycle "
+              f"converges what is here by path")
     if not quiet:
         for name, cat, o in outcomes:
             print(f"{name}: {o}" + (f"  [{cat}]" if cat == "code" else ""))

--- a/.datacore/lib/tests/test_transport_foreign_writer.py
+++ b/.datacore/lib/tests/test_transport_foreign_writer.py
@@ -1,0 +1,144 @@
+"""A host never commits another principal's writer log (DIP-0044).
+
+2026-09-06/07: a cadence on hermes appended geo tasks to 5-plur's
+`winston.jsonl`; the transport's autosave committed the file under Tris's
+name and the verifier flagged "5-plur/winston by tris" the next morning.
+The autosave now unstages a log that a different declared principal owns,
+commits the rest, and stops with the file named."""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+LIB = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(LIB))
+import ledger_transport as lt  # noqa: E402
+
+
+def git(repo: Path, *args: str) -> str:
+    return subprocess.run(["git", "-C", str(repo), *args], capture_output=True,
+                          text=True, check=True).stdout
+
+
+@pytest.fixture()
+def repo_pair(tmp_path: Path, monkeypatch):
+    """A clone with a real origin, registered so the transport will act on it
+    (the same shape test_ledger_transport.py uses)."""
+    origin = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "-q", "--bare", str(origin)], check=True)
+    work = tmp_path / "work"
+    subprocess.run(["git", "clone", "-q", str(origin), str(work)], check=True)
+    git(work, "config", "user.email", "t@t")
+    git(work, "config", "user.name", "t")
+    git(work, "config", "core.hooksPath", str(work / ".git" / "hooks"))
+    (work / "seed.txt").write_text("seed\n")
+    git(work, "add", "-A")
+    git(work, "commit", "-qm", "seed")
+    git(work, "push", "-q", "origin", "HEAD:refs/heads/main")
+    git(work, "branch", "-M", "main")
+    git(work, "branch", "--set-upstream-to=origin/main", "main")
+    monkeypatch.setattr(lt, "classify",
+                        lambda space, root=None: lt.Result(True, "knowledge", {"entry": {}}))
+    return work
+
+PRINCIPALS = {"winston": "winston", "bridge": "winston", "tris": "tris", "mac": "gregor"}
+
+
+def _hermes(monkeypatch):
+    """This host writes as tris; the registry knows winston, bridge, tris, mac."""
+    monkeypatch.setattr(lt, "_own_principal", lambda: ("tris", "tris"))
+    monkeypatch.setattr(lt, "_principal_of", lambda w: PRINCIPALS.get(w))
+
+
+def _dirty_log(space: Path, writer: str) -> Path:
+    p = space / ".datacore" / "events" / f"{writer}.jsonl"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with p.open("a") as fh:
+        fh.write('{"actor":"%s","type":"item.create"}\n' % writer)
+    return p
+
+
+def _committed(space: Path, rel: str) -> bool:
+    return subprocess.run(["git", "-C", str(space), "ls-files", "--error-unmatch", rel],
+                          capture_output=True).returncode == 0
+
+
+def test_foreign_writer_log_is_unstaged_named_and_stops_the_converge(repo_pair, monkeypatch):
+    _hermes(monkeypatch)
+    _dirty_log(repo_pair, "tris")
+    foreign = _dirty_log(repo_pair, "winston")
+    res = lt.converge(repo_pair)
+    assert not res.ok
+    assert res.reason.startswith("foreign writer log left uncommitted: .datacore/events/winston.jsonl belongs to winston")
+    assert "this host writes as tris for tris" in res.reason
+    assert res.context["foreign"] == [".datacore/events/winston.jsonl"]
+    # Tris's own log was autosaved; winston's stayed in the working tree, uncommitted.
+    assert _committed(repo_pair, ".datacore/events/tris.jsonl")
+    assert not _committed(repo_pair, ".datacore/events/winston.jsonl")
+    assert foreign.exists()
+    status = git(repo_pair, "status", "--porcelain")
+    assert "?? .datacore/events/winston.jsonl" in status
+
+
+def test_own_and_undeclared_writer_logs_still_autosave(repo_pair, monkeypatch):
+    _hermes(monkeypatch)
+    _dirty_log(repo_pair, "tris")
+    _dirty_log(repo_pair, "transporter")      # hostname-derived, declared by nobody
+    res = lt.converge(repo_pair)
+    assert res.ok, res.reason
+    assert _committed(repo_pair, ".datacore/events/tris.jsonl")
+    assert _committed(repo_pair, ".datacore/events/transporter.jsonl")
+
+
+def test_a_writes_as_alias_is_not_foreign_to_its_principal(repo_pair, monkeypatch):
+    monkeypatch.setattr(lt, "_own_principal", lambda: ("winston", "winston"))
+    monkeypatch.setattr(lt, "_principal_of", lambda w: PRINCIPALS.get(w))
+    _dirty_log(repo_pair, "bridge")           # winston's pre-DIP-0044 log
+    res = lt.converge(repo_pair)
+    assert res.ok, res.reason
+    assert _committed(repo_pair, ".datacore/events/bridge.jsonl")
+
+
+def test_unresolved_identity_refuses_nothing(repo_pair, monkeypatch):
+    monkeypatch.setattr(lt, "_own_principal", lambda: (None, ""))
+    monkeypatch.setattr(lt, "_principal_of", lambda w: PRINCIPALS.get(w))
+    _dirty_log(repo_pair, "winston")
+    assert lt.foreign_writer_logs(repo_pair) == []
+
+
+def test_writer_log_pattern_matches_only_event_logs():
+    m = lt._WRITER_LOG.search
+    assert m(".datacore/events/winston.jsonl").group(1) == "winston"
+    assert m("5-plur/.datacore/events/tris.jsonl").group(1) == "tris"
+    assert m("org/next_actions.org") is None
+    assert m(".datacore/events/winston.jsonl.bak") is None
+    assert m("notes/.datacore/events.jsonl") is None
+
+
+# ── registry fallback ───────────────────────────────────────────────────────
+
+def test_registry_falls_back_to_the_shipped_copy(tmp_path):
+    """hermes: `--root ~/Data` is a directory of space clones with no
+    `.datacore/registry`; the registry that ships with the code tree applies."""
+    assert not (tmp_path / ".datacore" / "registry" / "repositories.yaml").exists()
+    reg = lt._registry(tmp_path)
+    assert isinstance(reg, dict) and reg, "the shipped registry is non-empty"
+    assert "<root>" in reg or any(k[0].isdigit() for k in reg)
+
+
+def test_root_copy_wins_over_the_shipped_one(tmp_path):
+    reg = tmp_path / ".datacore" / "registry"
+    reg.mkdir(parents=True)
+    (reg / "repositories.yaml").write_text("repositories:\n  9-only:\n    category: knowledge\n")
+    assert lt._registry(tmp_path) == {"9-only": {"category": "knowledge"}}
+
+
+def test_sync_all_says_when_nothing_registered_is_present(tmp_path, capsys, monkeypatch):
+    monkeypatch.setattr(lt, "_registry", lambda root: {"5-plur": {"category": "knowledge"}})
+    assert lt.sync_all(tmp_path) == 0
+    out = capsys.readouterr().out
+    assert "no registered repository is checked out under" in out
+    assert "1 registered" in out


### PR DESCRIPTION
Root cause of this morning's `writer logs authored by their principal: 1 foreign: 5-plur/winston by tris` row, and of hermes's `datacore-fleet-sync` unit failing since 18:10 UTC 2026-09-06.

- The autosave in `converge` unstages a writer log owned by a different declared principal, commits the rest, and stops naming the file. Undeclared logs and unresolved identities are untouched.
- `_registry(root)` falls back to the code tree's registry when `--root` has none (hermes layout); `sync_all` prints when nothing registered is present instead of a traceback.
- `authorship-reviewed.yaml`: c7138535 recorded with its source fix (the hermes skill now uses `this_actor()`).

Tests: `test_transport_foreign_writer.py` (8) + `test_ledger_transport.py` (27) pass. The full lib suite has the same 23 pre-existing failures as main; the 11 extra in a bare worktree are grounded tests needing installed modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)