### PR TITLE
scoreboard: R6 counts FAIL verdicts, not the word FAIL inside an OK line

### DIFF
--- a/.datacore/lib/reliability_scoreboard.py
+++ b/.datacore/lib/reliability_scoreboard.py
@@ -226,12 +226,20 @@ def r5_reachable(state: Path, day: str, now: float | None = None) -> tuple[bool,
     return ok, f"{hits}/{expected} probe hits from {PROBER_IP} today"
 
 
+_R6_FAIL = re.compile(r"^\S+ (?:\S+ )?(?:\[[^\]]+\] )?FAIL\b")
+
+
 def r6_rebuildable(cos: Path, day: str) -> tuple[bool, str]:
     rows = _lines(cos / "verify-daily.log")
     today = [l for l in rows if l.startswith(day)]
     if not today:
         return False, "no --verify run logged today"
-    fails = [l for l in today if " FAIL " in l or l.split(" ", 1)[-1].startswith("FAIL")]
+    # A FAIL line is one whose VERDICT is FAIL — `<date> [cos-setup] FAIL <check>`
+    # or `<date> <time> FAIL <check>` — never an OK line that quotes the word.
+    # 2026-09-07: --verify printed "OK  scoreboard: 2026-09-06 FAIL streak=0 …"
+    # (yesterday's line, quoted as a check), the substring match counted it,
+    # and R6 failed today's scoreboard on a day every check had passed.
+    fails = [l for l in today if _R6_FAIL.match(l)]
     return not fails, (f"{len(fails)} FAIL line(s)" if fails else "0 FAIL")
 
 

--- a/.datacore/lib/tests/test_reliability_scoreboard.py
+++ b/.datacore/lib/tests/test_reliability_scoreboard.py
@@ -111,3 +111,18 @@ def test_r4_reads_the_units_own_result_where_there_is_one(tmp_path, monkeypatch)
     (state / "fleet-sync.log").write_text("FAIL: stale text from a run that has since succeeded\n")
     monkeypatch.setattr(M, "_unit_show", lambda unit: {"LoadState": "loaded", "Result": "success", "ExecMainExitTimestamp": stamp(2)})
     assert M.compute(day, state, cos, now=now)["checks"]["R4"]["ok"]
+
+
+def test_r6_ignores_an_ok_line_that_quotes_a_fail(tmp_path):
+    """--verify quotes yesterday's scoreboard line and '0 failed units' inside
+    OK lines; only a line whose verdict is FAIL counts (2026-09-07)."""
+    day = "2026-09-05"; state, cos = _good_box(tmp_path, day)
+    (cos / "verify-daily.log").write_text(
+        f"{day} [cos-setup] OK  0 failed systemd units\n"
+        f"{day} [cos-setup] OK  scoreboard: 2026-09-04 FAIL streak=0 level=3 R6=FAIL | R6: 4 FAIL\n"
+        f"{day} 0 (interventions.log)\n"
+        f"{day} [cos-setup] ALL CHECKS PASS\n")
+    assert M.compute(day, state, cos)["checks"]["R6"]["ok"]
+    (cos / "verify-daily.log").write_text(f"{day} [cos-setup] FAIL heartbeat cron scheduled\n")
+    assert not M.compute(day, state, cos)["checks"]["R6"]["ok"]
+


### PR DESCRIPTION
The daily --verify log quotes yesterday's scoreboard line and the failed-unit count inside OK lines; the substring match counted them, failing R6 (and the day) on 2026-09-07 with every check green. Only a line whose verdict is FAIL counts now. Test added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)