### PR TITLE
cadence liveness: define root and today in main; contract reads the new last line

### DIFF
--- a/.datacore/lib/cadence_liveness.py
+++ b/.datacore/lib/cadence_liveness.py
@@ -147,9 +147,11 @@ def main() -> int:
     ap.add_argument("--grace-days", type=int, default=DEFAULT_GRACE)
     a = ap.parse_args()
 
-    rows = collect(Path(a.root).expanduser(), a.grace_days)
+    root = Path(a.root).expanduser()
+    today = date.today()
+    rows = collect(root, a.grace_days)
     OUT.parent.mkdir(parents=True, exist_ok=True)
-    lines = [f"=== {date.today().isoformat()} cadence liveness "
+    lines = [f"=== {today.isoformat()} cadence liveness "
              f"(grace {a.grace_days}d) ==="]
     for days, space, role, freq, name in rows:
         lines.append(f"  {days:5}d  {space:<12} {role}.{freq}.{name}")

--- a/.datacore/lib/jobs/manifest.yaml
+++ b/.datacore/lib/jobs/manifest.yaml
@@ -310,7 +310,10 @@ jobs:
     artifacts:
       - path: "~/.datacore/state/cadence-liveness.log"
         check: regex
-        arg: "^0 cadence\\(s\\) overdue$"
+        # The last line grew a sunset-review clause on 2026-09-06 (1523c72) and
+        # the script crashed on an undefined name until 2026-09-07; both left
+        # this contract red for reasons that were not overdue cadences.
+        arg: "^0 cadence\\(s\\) overdue; sunset review: 0 past due, [0-9]+ without a review date$"
         max_age_hours: 26
 
   - name: box-deploy-drift


### PR DESCRIPTION
The script has crashed with NameError since 1523c72 (2026-09-06), and the job contract still expected the pre-clause last line. Both fixed; run against the real root: `0 cadence(s) overdue; sunset review: 0 past due, 77 without a review date`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)