### PR TITLE
hermes: a Datacore plugin — one principal, enforced before the call

### DIFF
--- a/.datacore/config/tool_effects.yaml
+++ b/.datacore/config/tool_effects.yaml
@@ -24,7 +24,16 @@ version: 1
 # cannot send, pay or deploy by themselves — reading deploy.sh is not a
 # deployment — so they are never an effect; the outer file-level guards
 # (org_guard, restricted paths) own those.
-acting_tools: &acting ["Bash", "WebFetch", "mcp__*"]
+# Every tool that can reach the world, across the runtimes the fleet runs:
+# Claude Code / the SDK (Bash, WebFetch, mcp__*) and Hermes (terminal,
+# execute_code, write_file, patch, web_extract, browser_*, computer_use,
+# delegate_task, cronjob). A tool absent from this list is invisible to the
+# classifier, which is why Winston — a Hermes agent — was ungoverned until
+# 2026-09-07 while nightshift and Miles were not.
+acting_tools: &acting
+  ["Bash", "WebFetch", "mcp__*",
+   "terminal", "execute_code", "write_file", "patch", "web_extract",
+   "browser_*", "computer_use", "delegate_task", "cronjob"]
 effects:
   email.send:
     tools: *acting

--- a/.datacore/lib/hermes_plugin/__init__.py
+++ b/.datacore/lib/hermes_plugin/__init__.py
@@ -1,0 +1,307 @@
+"""Datacore principal plugin for Hermes (DIP-0044, datacore#30).
+
+WHY THIS EXISTS. A Hermes agent knew who it was only if a skill file said so,
+and nothing checked. On 2026-09-06 and again on 2026-09-07 the geo cadence on
+hermes followed a skill that said `EventLog(actor='winston', ...)`, wrote a
+task into 5-plur's winston log, and the fleet verifier reported
+"5-plur/winston by tris" the next morning — twice, after the fact. Meanwhile
+the tool-call policy that guards nightshift and Miles (datacore#30) had no
+Hermes equivalent at all: Winston, the principal whose registry entry says
+`permission_mode: propose`, was the least governed agent in the fleet.
+
+WHAT IT DOES. Three things, all from the registry the fleet already keeps:
+
+  identity   The host's actor and principal (registry/principals.yaml) are
+             written into Hermes's own always-injected memory file at session
+             start, inside a marked block that is rewritten, never appended.
+             `datacore_whoami` returns the same record as a tool.
+
+  authorship A pre_tool_call gate refuses a call that would write the ledger
+             under a DIFFERENT declared principal's name. Only a
+             declared-against-declared mismatch is refused: an undeclared
+             writer, or a host whose own identity cannot be resolved, is left
+             alone — the guard exists for the one case the registry can decide.
+
+  policy     Every acting tool call goes through tool_policy.evaluate_hook —
+             the same classifier, the same approvals_policy.yaml limits, the
+             same `metric.attest policy.refusal` in the ledger as the Claude
+             SDK hook. A refusal reaches the model as the block message.
+
+FAILS OPEN, ALWAYS. Every entry point is wrapped: a missing DATACORE_ROOT, an
+unreadable registry, an import error in the fleet lib — the agent keeps
+working and the plugin is simply not in force. A guard that can take the
+gateway down would be worse than the exposure it closes. `datacore_whoami`
+says whether it is actually in force, so "inert" is visible rather than
+assumed.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+MARK_START = "<!-- datacore:principal (generated — edits are overwritten) -->"
+MARK_END = "<!-- /datacore:principal -->"
+
+# `EventLog(space_dir=..., actor='winston')`, `EventLog(dir, "winston")`,
+# `--actor winston`, `DATACORE_ACTOR=winston` — the shapes a shell or python
+# call actually takes. Anchored on the ledger API so ordinary prose about a
+# principal ("ask winston to review") is never mistaken for a write.
+# `actor=` ANYWHERE in a ledger-context call, not just before the first ')'.
+# The first version anchored on `EventLog\([^)]*?actor=` and missed the exact
+# shape the incident took — `EventLog(space_dir=Path('~/Data/2-plur'),
+# actor='winston')` — because Path(...) closes a paren first. The
+# _LEDGER_CONTEXT gate is what keeps prose out, so this can be permissive.
+_EVENTLOG_KW = re.compile(r"\bactor\s*=\s*['\"]([A-Za-z0-9_-]+)['\"]")
+_EVENTLOG_POS = re.compile(r"EventLog\s*\(\s*[^,)]+,\s*['\"]([A-Za-z0-9_-]+)['\"]", re.S)
+_ACTOR_FLAG = re.compile(r"--actor[= ]+['\"]?([A-Za-z0-9_-]+)")
+_ACTOR_ENV = re.compile(r"DATACORE_ACTOR=['\"]?([A-Za-z0-9_-]+)")
+_LEDGER_CONTEXT = re.compile(r"EventLog|ledger|\.datacore/events|append\s*\(\s*['\"]item\.")
+
+
+def _root() -> Path:
+    return Path(os.environ.get("DATACORE_ROOT") or (Path.home() / "Data"))
+
+
+def _lib() -> bool:
+    """Put the fleet lib on the path. False when this host has no Datacore."""
+    lib = _root() / ".datacore" / "lib"
+    if not (lib / "actor_identity.py").exists():
+        return False
+    if str(lib) not in sys.path:
+        sys.path.insert(0, str(lib))
+    return True
+
+
+_IDENTITY: dict | None = None
+
+
+def identity(refresh: bool = False) -> dict:
+    """{actor, principal, display, role, permission_mode, ok, why}.
+
+    `ok` is False whenever the plugin cannot bind this host to a declared
+    principal — the guards stand down in that state and say so."""
+    global _IDENTITY
+    if _IDENTITY is not None and not refresh:
+        return _IDENTITY
+    out = {"actor": "", "principal": "", "display": "", "role": "",
+           "permission_mode": "", "ok": False, "why": ""}
+    try:
+        if not _lib():
+            out["why"] = f"no .datacore/lib under {_root()}"
+            _IDENTITY = out
+            return out
+        from actor_identity import principal_of, this_actor  # noqa: PLC0415
+        actor = (this_actor() or "").strip().lower()
+        name, rec = principal_of(actor)
+        out.update(actor=actor, principal=name or "",
+                   display=str(rec.get("display") or ""),
+                   role=str(rec.get("role") or ""),
+                   permission_mode=str(rec.get("permission_mode") or ""))
+        if not name:
+            out["why"] = f"actor {actor!r} is not a declared principal"
+        else:
+            out["ok"] = True
+    except Exception as exc:  # noqa: BLE001 — identity is advisory, never fatal
+        out["why"] = f"{type(exc).__name__}: {exc}"
+    _IDENTITY = out
+    return out
+
+
+# ---- identity in memory ----------------------------------------------------
+
+def identity_block(ident: dict | None = None) -> str:
+    """The block written into Hermes's memory file. Short by design: it is
+    injected into every turn, and its job is to make one fact unmissable."""
+    d = ident or identity()
+    if not d["ok"]:
+        return ""
+    who = d["display"] or d["principal"]
+    role = f", {d['role']}" if d["role"] else ""
+    return (
+        f"{MARK_START}\n"
+        f"## Who I am (Datacore registry, DIP-0044)\n"
+        f"I am **{who}**{role} — principal `{d['principal']}`, "
+        f"writing as actor `{d['actor']}`.\n"
+        f"- My ledger log is `<space>/.datacore/events/{d['actor']}.jsonl`. "
+        f"I write NO other principal's log, whatever an older note or skill says.\n"
+        f"- Permission mode: `{d['permission_mode'] or 'unset'}`. "
+        f"Effects the fleet policy reserves are refused before the call runs.\n"
+        f"{MARK_END}"
+    )
+
+
+def memory_file() -> Path:
+    home = Path(os.environ.get("HERMES_HOME") or (Path.home() / ".hermes"))
+    return home / "memories" / "MEMORY.md"
+
+
+def sync_memory_block(path: Path | None = None, ident: dict | None = None) -> str:
+    """Write the identity block into MEMORY.md, replacing any earlier one.
+
+    Idempotent and bounded: the block sits between markers, so a hand-written
+    memory around it survives and the file cannot grow a copy per session."""
+    block = identity_block(ident)
+    if not block:
+        return "skipped"
+    p = path or memory_file()
+    try:
+        text = p.read_text(encoding="utf-8") if p.exists() else ""
+    except OSError as exc:
+        return f"unreadable: {exc}"
+    if MARK_START in text and MARK_END in text:
+        head, _, rest = text.partition(MARK_START)
+        _, _, tail = rest.partition(MARK_END)
+        new = head + block + tail
+        outcome = "unchanged" if new == text else "updated"
+    else:
+        new = (text.rstrip("\n") + "\n\n" + block + "\n") if text.strip() else block + "\n"
+        outcome = "added"
+    if outcome == "unchanged":
+        return outcome
+    try:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        tmp = p.with_suffix(p.suffix + ".tmp")
+        tmp.write_text(new, encoding="utf-8")
+        tmp.replace(p)
+    except OSError as exc:
+        return f"unwritable: {exc}"
+    return outcome
+
+
+def on_session_start(**_kw):
+    try:
+        outcome = sync_memory_block()
+        logger.debug("datacore: identity block %s", outcome)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("datacore: identity sync skipped (%s)", exc)
+    return None
+
+
+# ---- authorship gate -------------------------------------------------------
+
+def call_text(tool_name: str, args) -> str:
+    try:
+        if not _lib():
+            return json.dumps(args, default=str) if args else ""
+        from tool_policy import call_text as _ct  # noqa: PLC0415
+        return _ct(args)
+    except Exception:  # noqa: BLE001
+        try:
+            return json.dumps(args, default=str)
+        except Exception:  # noqa: BLE001
+            return str(args)
+
+
+def foreign_actor_write(text: str, ident: dict | None = None) -> str | None:
+    """The reason to refuse, or None.
+
+    Refuses only when the named actor belongs to a DIFFERENT declared
+    principal. An unknown writer is not refused: it may be a hostname-derived
+    log from before DIP-0044, and refusing it would break more than it
+    protects."""
+    d = ident or identity()
+    if not d["ok"] or not text or not _LEDGER_CONTEXT.search(text):
+        return None
+    try:
+        from actor_identity import principal_of  # noqa: PLC0415
+    except Exception:  # noqa: BLE001
+        return None
+    for rx in (_EVENTLOG_KW, _EVENTLOG_POS, _ACTOR_FLAG, _ACTOR_ENV):
+        for named in rx.findall(text):
+            actor = str(named).strip().lower()
+            if not actor or actor == d["actor"]:
+                continue
+            try:
+                owner, _ = principal_of(actor)
+            except Exception:  # noqa: BLE001
+                continue
+            if owner and owner != d["principal"]:
+                return (
+                    f"Refused: this call writes the ledger as actor '{actor}', which belongs to "
+                    f"principal '{owner}'. You are '{d['principal']}' and write only as "
+                    f"'{d['actor']}' (DIP-0044). A principal's log is its own word; writing "
+                    f"another's is a misattribution the fleet verifier reports the next morning. "
+                    f"Re-run with actor='{d['actor']}', or ask {owner} to record it."
+                )
+    return None
+
+
+# ---- fleet tool policy -----------------------------------------------------
+
+def policy_block(tool_name: str, args) -> str | None:
+    """The fleet's tool-effect decision for this call, as a block reason."""
+    try:
+        if not _lib():
+            return None
+        from tool_policy import evaluate_hook  # noqa: PLC0415
+        out = evaluate_hook({"tool_name": tool_name, "tool_input": args or {}})
+        if not out:
+            return None
+        spec = (out.get("hookSpecificOutput") or {})
+        if spec.get("permissionDecision") not in ("deny", "ask"):
+            return None
+        return str(spec.get("permissionDecisionReason") or "refused by the Datacore tool policy")
+    except Exception as exc:  # noqa: BLE001 — policy failure must not stop the agent
+        logger.debug("datacore: policy check skipped (%s)", exc)
+        return None
+
+
+def pre_tool_call(tool_name: str = "", args=None, **_kw):
+    """Hermes pre_tool_call: {"action": "block", "message": ...} or None."""
+    try:
+        text = call_text(tool_name, args)
+        reason = foreign_actor_write(text) or policy_block(tool_name, args)
+        if reason:
+            return {"action": "block", "message": reason}
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("datacore: pre_tool_call skipped (%s)", exc)
+    return None
+
+
+# ---- tool -------------------------------------------------------------------
+
+WHOAMI_SCHEMA = {
+    "type": "function",
+    "function": {
+        "name": "datacore_whoami",
+        "description": ("This agent's Datacore principal and ledger actor, from the fleet "
+                        "registry, plus whether the identity and policy guards are in force."),
+        "parameters": {"type": "object", "properties": {}, "required": []},
+    },
+}
+
+
+def whoami_handler(**_kw) -> str:
+    d = identity(refresh=True)
+    if not d["ok"]:
+        return json.dumps({"in_force": False, "why": d["why"] or "identity unresolved",
+                           "actor": d["actor"]}, indent=2)
+    return json.dumps({"in_force": True, "principal": d["principal"], "actor": d["actor"],
+                       "display": d["display"], "role": d["role"],
+                       "permission_mode": d["permission_mode"],
+                       "ledger_log": f"<space>/.datacore/events/{d['actor']}.jsonl",
+                       "root": str(_root())}, indent=2)
+
+
+def register(ctx) -> None:
+    ctx.register_hook("pre_tool_call", pre_tool_call)
+    ctx.register_hook("on_session_start", on_session_start)
+    try:
+        ctx.register_tool(
+            name="datacore_whoami", toolset="datacore", schema=WHOAMI_SCHEMA,
+            handler=whoami_handler,
+            description="This agent's Datacore principal, actor and guard state.",
+            emoji="🪪",
+        )
+    except Exception as exc:  # noqa: BLE001 — hooks matter more than the tool
+        logger.warning("datacore: could not register datacore_whoami (%s)", exc)
+    d = identity()
+    logger.info("datacore plugin: %s",
+                f"{d['principal']} as {d['actor']} — guards in force" if d["ok"]
+                else f"inert ({d['why']})")

--- a/.datacore/lib/hermes_plugin/deploy.sh
+++ b/.datacore/lib/hermes_plugin/deploy.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Install the Datacore plugin into a Hermes host and enable it.
+#
+#   .datacore/lib/hermes_plugin/deploy.sh [host ...]      (default: winston hermes)
+#
+# The plugin is a user plugin (~/.hermes/plugins/datacore/): Hermes scans that
+# directory but leaves user plugins OFF until config.yaml lists them under
+# plugins.enabled — untrusted-code gate. This script copies the files and
+# reports the config line; it does NOT edit config.yaml, because a gateway
+# reading a half-written config is a worse failure than an unenabled plugin.
+set -euo pipefail
+SRC="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOSTS=("${@:-winston hermes}")
+[ $# -gt 0 ] && HOSTS=("$@") || HOSTS=(winston hermes)
+
+for H in "${HOSTS[@]}"; do
+  echo "── $H"
+  ssh -o ConnectTimeout=20 "$H" 'mkdir -p ~/.hermes/plugins/datacore'
+  rsync -q --checksum "$SRC/plugin.yaml" "$SRC/__init__.py" "$H:.hermes/plugins/datacore/"
+  ssh -o ConnectTimeout=20 "$H" '
+    set -e
+    PY=$(ls /usr/local/lib/hermes-agent/venv/bin/python ~/.hermes/hermes-agent/venv/bin/python 2>/dev/null | head -1)
+    cd ~/.hermes/plugins
+    "$PY" -c "
+import sys; sys.path.insert(0, \".\")
+import datacore as d
+i = d.identity(refresh=True)
+print(\"  identity:\", i[\"principal\"] or \"-\", \"as\", i[\"actor\"] or \"-\",
+      \"| in force\" if i[\"ok\"] else \"| INERT: \" + i[\"why\"])
+print(\"  memory block:\", d.sync_memory_block())
+"
+    if grep -qE "^\s+- datacore$" ~/.hermes/config.yaml 2>/dev/null; then
+      echo "  config: already under plugins.enabled"
+    else
+      echo "  config: NOT enabled — add to ~/.hermes/config.yaml:"
+      echo "            plugins:"
+      echo "              enabled:"
+      echo "                - datacore"
+      echo "          then: systemctl restart hermes-gateway (or --user)"
+    fi'
+done

--- a/.datacore/lib/hermes_plugin/plugin.yaml
+++ b/.datacore/lib/hermes_plugin/plugin.yaml
@@ -1,0 +1,19 @@
+name: datacore
+version: "1.0.0"
+description: >-
+  Datacore principal plugin for Hermes. Gives a Hermes agent the identity the
+  fleet already declares for it (DIP-0044): its actor and principal are
+  injected into memory every session, a pre_tool_call gate refuses a ledger
+  write under another principal's name, and the fleet's tool-effect policy
+  (approvals_policy.yaml) applies to Hermes tool calls exactly as it does to
+  nightshift and Miles. Inert when DATACORE_ROOT holds no .datacore/lib.
+author: Datacore
+kind: standalone
+hooks:
+  - pre_tool_call
+  - on_session_start
+provides_tools:
+  - datacore_whoami
+provides_hooks:
+  - pre_tool_call
+  - on_session_start

--- a/.datacore/lib/tests/test_hermes_plugin.py
+++ b/.datacore/lib/tests/test_hermes_plugin.py
@@ -1,0 +1,182 @@
+"""The Datacore plugin for Hermes: identity in memory, authorship gate, policy.
+
+2026-09-06/07: the geo cadence on hermes followed a skill saying
+`EventLog(actor='winston', ...)`, wrote into 5-plur's winston log, and the
+verifier reported "5-plur/winston by tris" the next morning — twice, after
+the fact. These tests pin the gate that refuses it before the call runs, and
+the two states in which the gate deliberately stands down."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+LIB = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(LIB))
+sys.path.insert(0, str(LIB / "hermes_plugin"))
+
+import hermes_plugin as hp  # noqa: E402
+
+PRINCIPALS = {"winston": "winston", "bridge": "winston", "tris": "tris",
+              "miles": "miles", "nightshift": "miles", "mac": "gregor"}
+
+TRIS = {"actor": "tris", "principal": "tris", "display": "Tris",
+        "role": "chief intelligence officer", "permission_mode": "yolo",
+        "ok": True, "why": ""}
+
+
+@pytest.fixture()
+def as_tris(monkeypatch):
+    """This host is Tris, and the registry knows the fleet's writers."""
+    monkeypatch.setattr(hp, "_IDENTITY", dict(TRIS))
+    monkeypatch.setattr(hp, "_lib", lambda: True)
+    import types
+    fake = types.ModuleType("actor_identity")
+    fake.principal_of = lambda a, path=None: (PRINCIPALS.get(str(a).lower()), {})
+    fake.this_actor = lambda strict=False: "tris"
+    monkeypatch.setitem(sys.modules, "actor_identity", fake)
+    return TRIS
+
+
+# ── authorship gate ─────────────────────────────────────────────────────────
+
+WRITE = ("python3 -c \"from ledger.log import EventLog; "
+         "EventLog(space_dir=Path('~/Data/2-plur'), actor='winston', sign=False)"
+         ".append('item.create', payload)\"")
+
+
+def test_the_incident_call_is_refused_and_the_message_says_what_to_do(as_tris):
+    reason = hp.foreign_actor_write(WRITE)
+    assert reason and "actor 'winston'" in reason and "principal 'winston'" in reason
+    assert "You are 'tris'" in reason and "actor='tris'" in reason
+    out = hp.pre_tool_call("execute_code", {"code": WRITE})
+    assert out == {"action": "block", "message": reason}
+
+
+def test_every_shape_a_wrong_actor_takes_is_caught(as_tris):
+    for text in (
+        "EventLog(space_dir=d, actor=\"winston\")",
+        "EventLog(space, 'winston')  # positional, from ledger.log",
+        "python3 ledger_ingest_org.py --actor winston --root ~/Data",
+        "DATACORE_ACTOR=winston python3 -c 'from ledger.log import EventLog'",
+    ):
+        assert hp.foreign_actor_write(text), text
+
+
+def test_our_own_actor_and_our_own_alias_pass(as_tris):
+    assert hp.foreign_actor_write("EventLog(space_dir=d, actor='tris')") is None
+    assert hp.pre_tool_call("execute_code", {"code": "EventLog(d, 'tris')"}) is None
+
+
+def test_an_undeclared_writer_is_left_alone(as_tris):
+    # A hostname-derived log from before DIP-0044. Refusing it would break
+    # more than it protects; the registry cannot decide it.
+    assert hp.foreign_actor_write("EventLog(space_dir=d, actor='transporter')") is None
+
+
+def test_prose_about_another_principal_is_not_a_write(as_tris):
+    assert hp.foreign_actor_write("ask winston to approve the invoice") is None
+    assert hp.foreign_actor_write("actor='winston' is what the old skill said") is None
+
+
+def test_an_unresolved_identity_refuses_nothing(monkeypatch):
+    monkeypatch.setattr(hp, "_IDENTITY", {"actor": "", "principal": "", "display": "",
+                                          "role": "", "permission_mode": "",
+                                          "ok": False, "why": "no registry"})
+    assert hp.foreign_actor_write(WRITE) is None
+    assert hp.pre_tool_call("execute_code", {"code": WRITE}) is None
+
+
+def test_a_broken_guard_never_blocks_the_agent(as_tris, monkeypatch):
+    monkeypatch.setattr(hp, "call_text", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")))
+    assert hp.pre_tool_call("terminal", {"command": WRITE}) is None
+
+
+# ── identity in memory ──────────────────────────────────────────────────────
+
+def test_identity_block_names_the_principal_and_the_one_log(as_tris):
+    b = hp.identity_block()
+    assert "**Tris**, chief intelligence officer" in b
+    assert "principal `tris`" in b and "actor `tris`" in b
+    assert "events/tris.jsonl" in b and "NO other principal's log" in b
+
+
+def test_memory_sync_is_idempotent_and_keeps_the_rest_of_the_file(tmp_path, as_tris):
+    m = tmp_path / "MEMORY.md"
+    m.write_text("# Memory\n\n- Gregor prefers short answers.\n")
+    assert hp.sync_memory_block(m) == "added"
+    assert hp.sync_memory_block(m) == "unchanged"
+    text = m.read_text()
+    assert text.count(hp.MARK_START) == 1
+    assert "Gregor prefers short answers." in text
+
+    stale = text.replace("actor `tris`", "actor `winston`")
+    m.write_text(stale)
+    assert hp.sync_memory_block(m) == "updated"
+    assert "actor `winston`" not in m.read_text()
+    assert m.read_text().count(hp.MARK_START) == 1
+    assert "Gregor prefers short answers." in m.read_text()
+
+
+def test_memory_sync_does_nothing_without_an_identity(tmp_path, monkeypatch):
+    monkeypatch.setattr(hp, "_IDENTITY", {"ok": False, "why": "x", "actor": "",
+                                          "principal": "", "display": "", "role": "",
+                                          "permission_mode": ""})
+    m = tmp_path / "MEMORY.md"
+    assert hp.sync_memory_block(m) == "skipped"
+    assert not m.exists()
+
+
+# ── fleet policy reaches Hermes tool names ──────────────────────────────────
+
+def test_hermes_acting_tools_are_classified_like_claude_code_ones():
+    import tool_policy as tp
+    effects = tp.load_effects()
+    pay = "curl -s https://api.stripe.com/v1/charges -d amount=500"
+    for tool in ("terminal", "execute_code", "Bash"):
+        assert "payment" in tp.classify(tool, {"command": pay}, effects), tool
+    assert tp.classify("read_file", {"path": "/etc/hosts"}, effects) == set()
+
+
+def test_a_refused_effect_becomes_a_block_message(as_tris, monkeypatch):
+    import types
+    fake = types.ModuleType("tool_policy")
+    fake.call_text = lambda i: str(i)
+    fake.evaluate_hook = lambda payload, *a, **k: {
+        "hookSpecificOutput": {"hookEventName": "PreToolUse",
+                               "permissionDecision": "deny",
+                               "permissionDecisionReason": "payment: never for tris"}}
+    monkeypatch.setitem(sys.modules, "tool_policy", fake)
+    out = hp.pre_tool_call("terminal", {"command": "stripe charges create"})
+    assert out == {"action": "block", "message": "payment: never for tris"}
+
+
+def test_whoami_reports_whether_the_guards_are_in_force(as_tris):
+    import json
+    d = json.loads(hp.whoami_handler())
+    assert d["in_force"] is True and d["principal"] == "tris" and d["actor"] == "tris"
+    assert d["ledger_log"].endswith("events/tris.jsonl")
+
+
+def test_registration_wires_both_hooks_and_the_tool(as_tris):
+    calls = {"hooks": [], "tools": []}
+
+    class Ctx:
+        def register_hook(self, name, cb): calls["hooks"].append((name, cb))
+        def register_tool(self, **kw): calls["tools"].append(kw["name"])
+
+    hp.register(Ctx())
+    assert [n for n, _ in calls["hooks"]] == ["pre_tool_call", "on_session_start"]
+    assert calls["tools"] == ["datacore_whoami"]
+
+
+def test_registration_survives_a_runtime_that_rejects_the_tool(as_tris):
+    class Ctx:
+        def __init__(self): self.hooks = []
+        def register_hook(self, name, cb): self.hooks.append(name)
+        def register_tool(self, **kw): raise RuntimeError("toolset unknown")
+
+    c = Ctx()
+    hp.register(c)                      # must not raise: the hooks are the point
+    assert c.hooks == ["pre_tool_call", "on_session_start"]


### PR DESCRIPTION
First piece of the Winston-as-Hermes direction: the agent gets the identity the fleet already declares for it, and the same policy plane as every other principal — using hooks Hermes already offers, not a fork.

**Why now.** On 2026-09-06 and 2026-09-07 the geo cadence on hermes followed a skill file saying `EventLog(actor='winston', ...)`, wrote into 5-plur's winston log, and the verifier reported `5-plur/winston by tris` the next morning. Both times, after the fact. And the tool-call guard from #30 covered nightshift and Miles but not Hermes, so Winston — `permission_mode: propose` in the registry — was the least governed agent in the fleet.

**What it does**

| Hook | Effect |
|---|---|
| `on_session_start` | Writes actor + principal from `registry/principals.yaml` into Hermes's own always-injected memory file, in a marked block (rewritten, never appended) |
| `pre_tool_call` | Refuses a ledger write under another **declared** principal's name, naming the fix. Then applies `tool_policy.evaluate_hook` — same classifier, same limits, same `metric.attest policy.refusal` |
| `datacore_whoami` | Reports whether the guards are in force, so "inert" is visible |

`tool_effects.yaml` learns Hermes's acting tools (`terminal`, `execute_code`, `write_file`, `patch`, `web_extract`, `browser_*`, `computer_use`, `delegate_task`, `cronjob`). Without them the classifier could not see a Hermes call at all.

**Deliberately narrow.** Only a declared-against-declared mismatch is refused; an undeclared writer (a pre-DIP-0044 hostname log) and a host whose identity will not resolve are both left alone. Every entry point fails open — a guard that can take the gateway down is worse than the exposure it closes.

**Tests.** 15 new, including the exact call from the incident, every shape a wrong actor takes, prose that must not trip it, and both stand-down states. The 27 existing `test_tool_policy.py` tests pass against the widened tool list.

Install is a separate step by design: `deploy.sh` copies the files and prints the `plugins.enabled` line, but does not edit `config.yaml` — a gateway reading a half-written config is worse than an unenabled plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)