### PR TITLE
hermes plugin: find the fleet lib where the host actually keeps it

### DIFF
--- a/.datacore/lib/hermes_plugin/__init__.py
+++ b/.datacore/lib/hermes_plugin/__init__.py
@@ -68,14 +68,33 @@ def _root() -> Path:
     return Path(os.environ.get("DATACORE_ROOT") or (Path.home() / "Data"))
 
 
+def lib_candidates() -> list[Path]:
+    """Where the fleet lib can be, most specific first.
+
+    A host does not always keep its code under its data root. hermes keeps
+    spaces in ~/Data and the code in the v2-runner clone, which is exactly
+    why `ledger_transport._registry` grew the same fallback on 2026-09-07
+    (datacore#139) after failing twice a day for a fortnight. The plugin
+    deployed there reported INERT for the same reason, five minutes after
+    that fix landed."""
+    out = []
+    override = os.environ.get("DATACORE_LIB")
+    if override:
+        out.append(Path(override))
+    out.append(_root() / ".datacore" / "lib")
+    out.append(Path.home() / ".datacore" / "v2-runner" / ".datacore" / "lib")
+    return out
+
+
 def _lib() -> bool:
     """Put the fleet lib on the path. False when this host has no Datacore."""
-    lib = _root() / ".datacore" / "lib"
-    if not (lib / "actor_identity.py").exists():
-        return False
-    if str(lib) not in sys.path:
-        sys.path.insert(0, str(lib))
-    return True
+    for lib in lib_candidates():
+        if not (lib / "actor_identity.py").exists():
+            continue
+        if str(lib) not in sys.path:
+            sys.path.insert(0, str(lib))
+        return True
+    return False
 
 
 _IDENTITY: dict | None = None
@@ -93,7 +112,8 @@ def identity(refresh: bool = False) -> dict:
            "permission_mode": "", "ok": False, "why": ""}
     try:
         if not _lib():
-            out["why"] = f"no .datacore/lib under {_root()}"
+            tried = ", ".join(str(p) for p in lib_candidates())
+            out["why"] = f"no .datacore/lib found (tried {tried})"
             _IDENTITY = out
             return out
         from actor_identity import principal_of, this_actor  # noqa: PLC0415

--- a/.datacore/lib/tests/test_hermes_plugin.py
+++ b/.datacore/lib/tests/test_hermes_plugin.py
@@ -180,3 +180,38 @@ def test_registration_survives_a_runtime_that_rejects_the_tool(as_tris):
     c = Ctx()
     hp.register(c)                      # must not raise: the hooks are the point
     assert c.hooks == ["pre_tool_call", "on_session_start"]
+
+
+# ── finding the fleet lib ───────────────────────────────────────────────────
+
+def test_lib_is_found_in_the_runner_clone_when_the_data_root_has_none(tmp_path, monkeypatch):
+    """hermes keeps spaces in ~/Data and code in ~/.datacore/v2-runner —
+    the layout that made the first deploy report INERT (2026-09-07)."""
+    runner = tmp_path / ".datacore" / "v2-runner" / ".datacore" / "lib"
+    runner.mkdir(parents=True)
+    (runner / "actor_identity.py").write_text("")
+    monkeypatch.setenv("DATACORE_ROOT", str(tmp_path / "Data"))
+    monkeypatch.delenv("DATACORE_LIB", raising=False)
+    monkeypatch.setattr(hp.Path, "home", staticmethod(lambda: tmp_path))
+    monkeypatch.setattr(hp.sys, "path", list(hp.sys.path))
+    assert hp._lib() is True
+    assert str(runner) in hp.sys.path
+
+
+def test_datacore_lib_env_wins_and_a_host_without_datacore_stays_inert(tmp_path, monkeypatch):
+    override = tmp_path / "custom" / "lib"
+    override.mkdir(parents=True)
+    (override / "actor_identity.py").write_text("")
+    monkeypatch.setenv("DATACORE_LIB", str(override))
+    monkeypatch.setenv("DATACORE_ROOT", str(tmp_path / "Data"))
+    monkeypatch.setattr(hp.Path, "home", staticmethod(lambda: tmp_path / "empty"))
+    monkeypatch.setattr(hp.sys, "path", list(hp.sys.path))
+    assert hp.lib_candidates()[0] == override
+    assert hp._lib() is True
+
+    monkeypatch.delenv("DATACORE_LIB")
+    monkeypatch.setattr(hp.sys, "path", list(hp.sys.path))
+    assert hp._lib() is False
+    d = hp.identity(refresh=True)
+    assert d["ok"] is False and "no .datacore/lib found (tried" in d["why"]
+


### PR DESCRIPTION
The first deploy reported INERT on hermes: the plugin looked only under `$DATACORE_ROOT/.datacore/lib`, and that host keeps spaces in `~/Data` with the code in the v2-runner clone — the same layout that failed the registry lookup twice a day until #139 gave it a fallback. Now tries `$DATACORE_LIB`, the data root, then the runner clone; an inert plugin names the paths it tried. Two tests; 17 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)