### PR TITLE
verify: migration leftovers as rows, not incidents

### DIFF
--- a/.datacore/lib/v2_verify.py
+++ b/.datacore/lib/v2_verify.py
@@ -1098,6 +1098,93 @@ def check_finality(rep: Report) -> None:
             + (f"; MISMATCH: {', '.join(bad)}" if bad else ""))
 
 
+
+def foreign_home_links(bindirs=("/usr/local/bin",)) -> list[str]:
+    """PATH symlinks whose target lives in a home directory this user cannot
+    read — a command that resolves for root and dies for the service user."""
+    import pwd
+    me = pwd.getpwuid(os.getuid()).pw_name
+    out = []
+    for d in bindirs:
+        try:
+            entries = list(Path(d).iterdir())
+        except OSError:
+            continue
+        for link in entries:
+            try:
+                if not link.is_symlink():
+                    continue
+                target = os.readlink(link)
+            except OSError:
+                continue
+            if not target.startswith(("/root/", "/home/", "/Users/")):
+                continue
+            owner = target.split("/")[2] if target.startswith(("/home/", "/Users/")) else "root"
+            if owner == me:
+                continue
+            if not os.access(target, os.X_OK):
+                out.append(f"{link.name} -> {target} (owner {owner}, not executable by {me})")
+    return out
+
+
+def cgroup_is_managed(cgroup: str, uid: int) -> bool:
+    """True when this cgroup is a systemd unit belonging to THIS user (or the
+    system manager). `user-0.slice` for a non-root user is the orphan case."""
+    if ".service" not in cgroup:
+        return False
+    return f"user-{uid}.slice" in cgroup or "/system.slice/" in cgroup
+
+
+def unmanaged_service_processes(names=("hermes_cli.main gateway", "datacored"),
+                                procfs: Path | None = None, uid: int | None = None) -> list[str]:
+    """Long-lived service processes running outside any systemd unit.
+
+    A service-user migration leaves the OLD user's process running: it has no
+    unit, logs nowhere, and keeps doing its job — a second Telegram consumer,
+    a second writer. On 2026-09-07 a gateway orphaned by the 2026-08-13
+    root->gregor move had been running 25 days in `user-0.slice`, and was
+    found only because someone went looking for a third poller."""
+    procfs = procfs or Path("/proc")
+    uid = os.getuid() if uid is None else uid
+    if sys.platform != "linux" and procfs == Path("/proc"):
+        return []
+    out = []
+    for proc in sorted(procfs.iterdir()):
+        if not proc.name.isdigit():
+            continue
+        try:
+            cmd = (proc / "cmdline").read_bytes().replace(b"\0", b" ").decode(errors="ignore")
+            if not any(n in cmd for n in names):
+                continue
+            cgroup = (proc / "cgroup").read_text().strip().splitlines()[-1]
+        except (OSError, IndexError):
+            continue
+        if cgroup_is_managed(cgroup, uid):
+            continue
+        short = cmd.strip()[:60]
+        out.append(f"pid {proc.name}: {short} [{cgroup.split(':')[-1]}]")
+    return out
+
+
+def check_migration_leftovers(rep: Report) -> None:
+    """The residue of a service-user move, as rows instead of incidents.
+
+    The 2026-08-13 root->gregor move left three things behind, each found
+    separately and weeks apart: an orphaned gateway process, a `plur` symlink
+    into root's home that the service user could not execute, and a deploy
+    key. Three incidents, one cause. These two rows catch that cause."""
+    links = foreign_home_links()
+    rep.add("0044", "no PATH link into another user's home", not links,
+            "; ".join(links[:3]) if links else "every PATH symlink resolves for this user")
+    if sys.platform != "linux":
+        rep.add("0044", "service processes are managed", None, "linux only")
+        return
+    orphans = unmanaged_service_processes()
+    rep.add("0044", "service processes are managed", not orphans,
+            "; ".join(orphans[:3]) if orphans
+            else "no service process outside a systemd unit")
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description="v2 verification checklist")
     ap.add_argument("--json", action="store_true")
@@ -1120,6 +1207,7 @@ def main() -> int:
     check_versions(rep)
     check_trust_labels(rep)
     check_hooks(rep)
+    check_migration_leftovers(rep)
     check_finality(rep)
     check_app(rep)
     check_declared_identity(rep)

--- a/.datacore/tests/test_migration_leftovers.py
+++ b/.datacore/tests/test_migration_leftovers.py
@@ -1,0 +1,75 @@
+"""The residue of a service-user move, as rows instead of incidents.
+
+The 2026-08-13 root->gregor move on the CoS box left three things behind,
+each found separately and weeks apart: a gateway process running 25 days in
+`user-0.slice` with no unit (a third Telegram consumer), a `plur` symlink
+into root's home that the service user could not execute, and a deploy key.
+Three incidents, one cause."""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+LIB = Path(__file__).resolve().parents[1] / "lib"
+sys.path.insert(0, str(LIB))
+import v2_verify as vv  # noqa: E402
+
+
+def _proc(root: Path, pid: str, cmd: str, cgroup: str) -> None:
+    d = root / pid
+    d.mkdir(parents=True)
+    (d / "cmdline").write_bytes(cmd.encode().replace(b" ", b"\0") + b"\0")
+    (d / "cgroup").write_text(f"0::{cgroup}\n")
+
+
+def test_the_orphaned_gateway_is_found_and_the_managed_one_is_not(tmp_path):
+    procfs = tmp_path / "proc"
+    _proc(procfs, "527467", "python -m hermes_cli.main gateway run",
+          "/user.slice/user-1000.slice/user@1000.service/app.slice/hermes-gateway.service")
+    _proc(procfs, "3960788", "python -m hermes_cli.main gateway run",
+          "/user.slice/user-0.slice/user@0.service/app.slice/hermes-gateway.service")
+    _proc(procfs, "999", "python -m datacored",
+          "/system.slice/datacored.service")
+    _proc(procfs, "1234", "bash -l", "/user.slice/user-1000.slice/session.scope")
+
+    found = vv.unmanaged_service_processes(procfs=procfs, uid=1000)
+    assert len(found) == 1
+    assert found[0].startswith("pid 3960788: python -m hermes_cli.main gateway run")
+    assert "user-0.slice" in found[0]
+
+
+def test_cgroup_classification():
+    assert vv.cgroup_is_managed("/user.slice/user-1000.slice/user@1000.service/app.slice/x.service", 1000)
+    assert vv.cgroup_is_managed("/system.slice/datacored.service", 1000)
+    assert not vv.cgroup_is_managed("/user.slice/user-0.slice/user@0.service/app.slice/x.service", 1000)
+    assert not vv.cgroup_is_managed("/user.slice/user-1000.slice/session.scope", 1000)
+
+
+def test_a_path_link_into_another_users_home_is_reported(tmp_path, monkeypatch):
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    good_target = tmp_path / "mine" / "tool"
+    good_target.parent.mkdir()
+    good_target.write_text("#!/bin/sh\n")
+    good_target.chmod(0o755)
+    (bindir / "mine").symlink_to(good_target)
+    (bindir / "plur").symlink_to("/root/.hermes/node/bin/plur")   # the real one
+    (bindir / "elsewhere").symlink_to("/usr/lib/whatever")         # not a home
+
+    import pwd
+    monkeypatch.setattr(vv.os, "getuid", lambda: 1000)
+    monkeypatch.setattr(pwd, "getpwuid", lambda _uid: type("P", (), {"pw_name": "gregor"})())
+    found = vv.foreign_home_links(bindirs=(str(bindir),))
+    assert len(found) == 1
+    assert found[0].startswith("plur -> /root/.hermes/node/bin/plur")
+    assert "not executable by gregor" in found[0]
+
+
+def test_both_rows_are_added(tmp_path, monkeypatch):
+    monkeypatch.setattr(vv, "foreign_home_links", lambda *a, **k: [])
+    monkeypatch.setattr(vv, "unmanaged_service_processes", lambda *a, **k: [])
+    rep = vv.Report()
+    vv.check_migration_leftovers(rep)
+    names = [c.name for c in rep.checks]
+    assert names == ["no PATH link into another user's home", "service processes are managed"]


### PR DESCRIPTION
The 2026-08-13 service-user move left three things behind, each found separately over three weeks: a gateway orphaned in `user-0.slice` with no unit (a third Telegram consumer), a `plur` symlink into root home the service user could not execute, and a deploy key. One cause, nothing watching for it.

Two rows: a PATH symlink into another user home that is not executable here, and a known service process outside any systemd unit for this user. 4 tests, including the exact orphan (pid in `user-0.slice`) and the exact symlink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)