### PR TITLE
verify: the leftover check judges what is executing, not what is mentioned

### DIFF
--- a/.datacore/lib/v2_verify.py
+++ b/.datacore/lib/v2_verify.py
@@ -1127,6 +1127,15 @@ def foreign_home_links(bindirs=("/usr/local/bin",)) -> list[str]:
     return out
 
 
+# Shells, search and transport tools: a process whose argv[0] is one of these
+# is talking ABOUT a service, not being one.
+_NOT_A_SERVICE = frozenset({
+    "bash", "sh", "zsh", "dash", "fish", "grep", "egrep", "fgrep", "rg", "ps",
+    "awk", "sed", "ssh", "sshd", "sudo", "su", "env", "xargs", "tee", "watch",
+    "timeout", "pgrep", "pkill", "systemctl", "journalctl",
+})
+
+
 def cgroup_is_managed(cgroup: str, uid: int) -> bool:
     """True when this cgroup is a systemd unit belonging to THIS user (or the
     system manager). `user-0.slice` for a non-root user is the orphan case."""
@@ -1153,8 +1162,19 @@ def unmanaged_service_processes(names=("hermes_cli.main gateway", "datacored"),
         if not proc.name.isdigit():
             continue
         try:
-            cmd = (proc / "cmdline").read_bytes().replace(b"\0", b" ").decode(errors="ignore")
+            raw = (proc / "cmdline").read_bytes()
+            argv = [a for a in raw.split(b"\0") if a]
+            if not argv:
+                continue
+            cmd = b" ".join(argv).decode(errors="ignore")
             if not any(n in cmd for n in names):
+                continue
+            # A SHELL THAT MENTIONS THE NAME IS NOT THE SERVICE. The first
+            # version matched its own operator: `ps | grep "hermes_cli.main
+            # gateway"` carries the search string in its own cmdline, so the
+            # row failed on the very command used to investigate it. Judge by
+            # what is EXECUTING, not by what the text mentions.
+            if Path(argv[0].decode(errors="ignore")).name in _NOT_A_SERVICE:
                 continue
             cgroup = (proc / "cgroup").read_text().strip().splitlines()[-1]
         except (OSError, IndexError):

--- a/.datacore/tests/test_migration_leftovers.py
+++ b/.datacore/tests/test_migration_leftovers.py
@@ -73,3 +73,21 @@ def test_both_rows_are_added(tmp_path, monkeypatch):
     vv.check_migration_leftovers(rep)
     names = [c.name for c in rep.checks]
     assert names == ["no PATH link into another user's home", "service processes are managed"]
+
+
+def test_a_shell_that_merely_mentions_the_service_is_not_flagged(tmp_path):
+    """The first version matched its own operator: `ps | grep 'hermes_cli.main
+    gateway'` carries the search string in its own cmdline, so the row failed
+    on the command used to investigate it (2026-09-08)."""
+    procfs = tmp_path / "proc"
+    _proc(procfs, "111409",
+          "bash -c ps -eo pid,cmd | grep hermes_cli.main gateway",
+          "/user.slice/user-1000.slice/session-31472.scope")
+    _proc(procfs, "222", "sudo -n systemctl --user stop hermes-gateway.service",
+          "/user.slice/user-1000.slice/session-9.scope")
+    _proc(procfs, "3960788", "python -m hermes_cli.main gateway run",
+          "/user.slice/user-0.slice/user@0.service/app.slice/hermes-gateway.service")
+
+    found = vv.unmanaged_service_processes(procfs=procfs, uid=1000)
+    assert len(found) == 1 and found[0].startswith("pid 3960788:")
+


### PR DESCRIPTION
The new row failed on the command used to investigate it — `ps | grep \"hermes_cli.main gateway\"` carries the search string in its own cmdline. A process whose `argv[0]` is a shell, search tool or transport is talking about a service, not being one. Test reconstructs the false positive alongside the real orphan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)