### PR TITLE
jobs: verify a daemon by its output, and fix two jobs that never worked

### DIFF
--- a/.datacore/lib/agent_stream_rsync.sh
+++ b/.datacore/lib/agent_stream_rsync.sh
@@ -22,8 +22,18 @@
 set -euo pipefail
 
 REMOTE_HOST="${AGENT_STREAM_REMOTE_HOST:-nightshift}"
-REMOTE_USER="${AGENT_STREAM_REMOTE_USER:-deploy}"
-REMOTE_PATH="${AGENT_STREAM_REMOTE_PATH:-<HOME>/.datacore/cos/agent-stream/}"
+# The service user moved from deploy to gregor (DIP-0044, 2026-08-13) and
+# this default did not follow. With the <HOME> bug above fixed, rsync
+# reached /home/deploy/... , found nothing, and exited 0 -- the job would
+# have gone GREEN while syncing an empty file list. A silent no-op is
+# worse than the crash it replaced.
+REMOTE_USER="${AGENT_STREAM_REMOTE_USER:-gregor}"
+# A LITERAL PLACEHOLDER, NEVER SUBSTITUTED. `<HOME>` reached production and
+# bash read it as input redirection: every run since died with
+# "HOME: No such file or directory" and mac-agent-stream-rsync failed
+# with it. An rsync path without a leading / is already relative to the
+# remote user's home, so the prefix was never needed.
+REMOTE_PATH="${AGENT_STREAM_REMOTE_PATH:-.datacore/cos/agent-stream/}"
 LOCAL_PATH="${AGENT_STREAM_LOCAL_PATH:-$HOME/.datacore/cos/agent-stream/}"
 
 mkdir -p "$LOCAL_PATH"

--- a/.datacore/lib/jobs/run.py
+++ b/.datacore/lib/jobs/run.py
@@ -177,14 +177,26 @@ def run(job: dict, dry: bool = False) -> int:
 
     # pipefail matters: `cmd | tail` otherwise reports tail's status. That is
     # engram ENG-2026-08-19-018 and it recurs because nothing enforces it.
-    started = time.time()
-    proc = subprocess.run(["/bin/bash", "-o", "pipefail", "-c", job["cmd"]],
-                          env=env, capture_output=True, text=True)
-    took = time.time() - started
+    # A CONTINUOUS SERVICE IS VERIFIED BY ITS ARTIFACT, NOT BY RE-RUNNING IT.
+    # For a daemon, `cmd` documents what the unit starts; running it here
+    # either blocks until something kills it (mac-lens-sync: exit 124, a
+    # timeout reported as a failed job) or starts a SECOND copy of a service
+    # already running. Both were live on 2026-09-08. "Is it still producing?"
+    # is the real question, and the artifact checks below are what answer it.
+    continuous = str(job.get("schedule", "")).strip().lower().startswith("continuous")
+    took = 0.0
+    if continuous:
+        print("continuous service — not re-run; its artifact is the verification")
+        proc = None
+    else:
+        started = time.time()
+        proc = subprocess.run(["/bin/bash", "-o", "pipefail", "-c", job["cmd"]],
+                              env=env, capture_output=True, text=True)
+        took = time.time() - started
 
-    if proc.stdout:
+    if proc is not None and proc.stdout:
         sys.stdout.write(proc.stdout)
-    if proc.stderr:
+    if proc is not None and proc.stderr:
         sys.stderr.write(proc.stderr)
 
     # Detectors exit 1 for "ran, found problems" and 2 for "could not run";
@@ -193,11 +205,11 @@ def run(job: dict, dry: bool = False) -> int:
     # Found by the mac-seq-gap pilot: its honest "1 unpublished" read as a
     # command failure.
     ok_codes = set(job.get("exit_ok") or [0])
-    if proc.returncode not in ok_codes:
+    if proc is not None and proc.returncode not in ok_codes:
         print(f"COMMAND FAILED — exit {proc.returncode} after {took:.1f}s "
               f"(exit_ok={sorted(ok_codes)})")
         return 2
-    if proc.returncode != 0:
+    if proc is not None and proc.returncode != 0:
         print(f"ran with findings — exit {proc.returncode} after {took:.1f}s; the artifact check decides")
 
     failures = []

--- a/.datacore/lib/undelegate_unexecutable.py
+++ b/.datacore/lib/undelegate_unexecutable.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""One-time repair: un-delegate :AI: tasks that state no SURFACE/DONE_WHEN.
+
+Applies the rule the delegation gate now enforces (chief-of-staff 3d89ce3) to
+tasks tagged before it existed. On 2026-09-07 the gate tagged 27 follow-ups
+with neither field; the org pre-commit hook then refused every commit in
+0-personal, so the space stopped syncing and the morning briefing could not
+reach the Mac.
+
+The task is NOT deleted or deferred -- approval stands. It loses the :AI: tag
+(nightshift cannot execute it) and gains :DELEGATION_BLOCKED: naming what is
+missing, so it reads as the human task it actually is.
+
+    undelegate_unexecutable.py <space> [--apply]
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("space")
+    ap.add_argument("--apply", action="store_true")
+    a = ap.parse_args()
+
+    root = Path.home() / "Data"
+    sys.path.insert(0, str(root / ".datacore" / "lib"))
+    from org_workspace import OrgWorkspace  # noqa: PLC0415
+    # ONE definition of "executable", imported rather than restated. Writing
+    # the rule again here first flagged 93 tasks against the gate's 27: it
+    # missed that ACCEPTANCE_CRITERIA is DONE_WHEN's older spelling, and that
+    # only TODO/NEXT are queued at all.
+    from ai_task_gate import DONE_KEYS, QUEUED  # noqa: PLC0415
+
+    space = Path(a.space) if Path(a.space).is_absolute() else root / a.space
+    changed = []
+    for name in ("inbox.org", "next_actions.org"):
+        f = space / "org" / name
+        if not f.exists():
+            continue
+        ws = OrgWorkspace()
+        ws.load(str(f))
+        for node in ws.all_nodes():
+            tags = [t for t in (node.tags or [])]
+            if "AI" not in [t.upper() for t in tags]:
+                continue
+            if (node.todo or "").upper() not in QUEUED:
+                continue
+            missing = []
+            if not (node.get_property("SURFACE") or "").strip():
+                missing.append("SURFACE")
+            if not any((node.get_property(k) or "").strip() for k in DONE_KEYS):
+                missing.append("DONE_WHEN")
+            if not missing:
+                continue
+            changed.append((name, node.id(), node.heading[:58], ", ".join(missing)))
+            if a.apply:
+                ws.set_tags(node, [t for t in tags if t.upper() != "AI"])
+                ws.set_property(node, "DELEGATION_BLOCKED", ", ".join(missing))
+        if a.apply and changed:
+            ws.save_all()
+    for n, i, h, m in changed:
+        print(f"  {n:<17} {h:<60} missing {m}")
+    print(f"\n{len(changed)} task(s) {'un-delegated' if a.apply else 'would be un-delegated'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
From an audit of all 44 verify jobs.

**Continuous services**: `cmd` documents what a unit starts; the envelope ran it anyway. `mac-lens-sync` blocked until killed (exit 124 — a timeout reported as a failed job); others risked starting a second copy of a running service. The artifact check now decides alone.

**agent_stream_rsync.sh** carried a literal `<HOME>` placeholder. Bash read it as input redirection, so every run died with `HOME: No such file or directory`. With that fixed it still synced nothing: `REMOTE_USER` defaulted to `deploy`, retired by the DIP-0044 service-user move. rsync found an empty dir and **exited 0** — green while transferring nothing, worse than the crash. Now transfers.

Also ships `undelegate_unexecutable.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)