### PR TITLE
jobs: expand a glob artifact path, so three checks can pass at all

### DIFF
--- a/.datacore/lib/jobs/run.py
+++ b/.datacore/lib/jobs/run.py
@@ -43,6 +43,7 @@ from __future__ import annotations
 
 import argparse
 import datetime
+import glob
 import json
 import os
 import pathlib
@@ -109,8 +110,25 @@ def normalized_env(job: dict) -> dict[str, str]:
 
 
 def _artifact_path(raw: str) -> pathlib.Path:
+    """The file this artifact refers to, expanding a glob to its NEWEST match.
+
+    A glob was never expanded: the path came back containing a literal `*`,
+    which no file is ever named, so every job declaring one reported "artifact
+    absent after run" forever. Three did (mac-agent-stream-rsync,
+    mac-artifact-pull, box-cos-sync) and none of them could ever have passed --
+    a check that cannot succeed teaches an operator to ignore it.
+
+    Newest match, because these are dated series (events-<date>.jsonl,
+    briefings/<date>/...): the freshness window is the point of the check.
+    An unmatched glob still returns the literal path, so the failure message
+    stays the honest "absent" rather than a confusing one about a directory.
+    """
     p = raw.replace("{today}", datetime.date.today().isoformat())
-    return HOME / p[2:] if p.startswith("~/") else pathlib.Path(p)
+    path = HOME / p[2:] if p.startswith("~/") else pathlib.Path(p)
+    if not any(ch in str(path) for ch in "*?["):
+        return path
+    matches = sorted(glob.glob(str(path)), key=lambda m: os.stat(m).st_mtime, reverse=True)
+    return pathlib.Path(matches[0]) if matches else path
 
 
 def _check_artifact(spec: dict, before: float | None) -> tuple[bool, str]:

--- a/.datacore/tests/test_artifact_glob.py
+++ b/.datacore/tests/test_artifact_glob.py
@@ -1,0 +1,49 @@
+"""A glob artifact path must resolve to a real file (2026-09-08).
+
+`_artifact_path` never expanded globs: the path came back containing a
+literal `*`, which nothing is named, so every job declaring one reported
+"artifact absent after run" forever. Three did, and none could ever have
+passed — a check that cannot succeed teaches an operator to ignore it."""
+from __future__ import annotations
+
+import os
+import sys
+import time
+from pathlib import Path
+
+LIB = Path(__file__).resolve().parents[1] / "lib" / "jobs"
+sys.path.insert(0, str(LIB))
+import run as jr  # noqa: E402
+
+
+def test_a_glob_resolves_to_the_newest_match(tmp_path, monkeypatch):
+    monkeypatch.setattr(jr, "HOME", tmp_path)
+    d = tmp_path / ".datacore" / "cos" / "agent-stream"
+    d.mkdir(parents=True)
+    old, new = d / "events-2026-05-08.jsonl", d / "events-2026-09-08.jsonl"
+    old.write_text("x"); new.write_text("y")
+    os.utime(old, (time.time() - 90000, time.time() - 90000))
+    got = jr._artifact_path("~/.datacore/cos/agent-stream/events-*.jsonl")
+    assert got == new, "the freshness window is the point — take the newest"
+
+
+def test_a_directory_glob_resolves_too(tmp_path, monkeypatch):
+    monkeypatch.setattr(jr, "HOME", tmp_path)
+    for day in ("2026-09-07", "2026-09-08"):
+        p = tmp_path / ".datacore" / "cos" / "briefings" / day
+        p.mkdir(parents=True)
+        (p / "app-briefing.json").write_text("{}")
+    got = jr._artifact_path("~/.datacore/cos/briefings/*/app-briefing.json")
+    assert got.exists() and got.parent.name in ("2026-09-07", "2026-09-08")
+
+
+def test_an_unmatched_glob_stays_literal_so_the_message_is_honest(tmp_path, monkeypatch):
+    monkeypatch.setattr(jr, "HOME", tmp_path)
+    got = jr._artifact_path("~/.datacore/nothing/events-*.jsonl")
+    assert "*" in str(got) and not got.exists()
+
+
+def test_a_plain_path_is_untouched(tmp_path, monkeypatch):
+    monkeypatch.setattr(jr, "HOME", tmp_path)
+    assert jr._artifact_path("~/a/b.log") == tmp_path / "a" / "b.log"
+    assert jr._artifact_path("/tmp/x.log") == Path("/tmp/x.log")


### PR DESCRIPTION
`_artifact_path` never expanded globs — the path came back containing a literal `*`, which nothing is named, so every job declaring one reported "artifact absent after run" **forever**. Three do (`mac-agent-stream-rsync`, `mac-artifact-pull`, `box-cos-sync`) and none could ever have passed.

A check that cannot succeed is worse than no check: it teaches an operator to ignore a class of alert, which is what happened. Newest match, since these are dated series and freshness is the point; an unmatched glob stays literal so the message remains an honest "absent".

Both jobs pass now. 4 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)