### PR TITLE
jobs: point Miles GitHub triage at the script that exists

### DIFF
--- a/.datacore/lib/jobs/manifest.yaml
+++ b/.datacore/lib/jobs/manifest.yaml
@@ -633,7 +633,13 @@ jobs:
   - name: nightshift-github-triage
     machine: nightshift
     schedule: "30 4 * * *"
-    cmd: "bash ~/Data/.datacore/modules/github/server/triage-github.sh"
+    # server/triage-github.sh HAS NEVER EXISTED. The real script is
+    # modules/github/lib/triage_github.sh (lib not server, underscore not
+    # hyphen). Both spellings look plausible, so this job failed on a
+    # missing file rather than obviously, and the box quietly took the
+    # work over. Miles owns GitHub triage -- he is the CTO and holds the
+    # access; Winston reads the result through the synced scan cache.
+    cmd: "bash ~/Data/.datacore/modules/github/lib/triage_github.sh"
     on_fail: telegram
     artifacts:
       - path: "~/Data/.datacore/modules/github/data/scan_cache.json"


### PR DESCRIPTION
`nightshift-github-triage` ran `modules/github/server/triage-github.sh`, which has never existed — the real script is `modules/github/lib/triage_github.sh` (lib not server, underscore not hyphen). It failed on a missing file rather than obviously, and the box quietly took the work over.

Miles owns GitHub triage; Winston reads the synced scan cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)