### PR TITLE
seq-gap: an unreachable host fails in seconds, not minutes

### DIFF
--- a/.datacore/lib/detectors/seq_gap.py
+++ b/.datacore/lib/detectors/seq_gap.py
@@ -44,11 +44,27 @@ import sys
 from pathlib import Path
 
 
-def git(repo: Path, *args: str) -> tuple[int, str]:
+# AN UNREACHABLE HOST MUST FAIL IN SECONDS, NOT MINUTES. Measured on the mac
+# with a work VPN capturing the route to Gitea on 2026-09-08: a single fetch
+# took 75 s to give up. Eleven spaces, several of them Gitea-backed, and the
+# detector blew its own runtime budget and was killed — so the job failed on
+# a TIMEOUT while the artifact it should have written never appeared, and
+# `mac-seq-gap` alerted for a third day running.
+#
+# ssh's default ConnectTimeout is the OS TCP timeout, which is the 75 s. Five
+# seconds is far longer than any reachable host needs and turns a hung sweep
+# into a fast, honest "unverifiable".
+SSH_FAIL_FAST = "ssh -o ConnectTimeout=5 -o BatchMode=yes"
+
+
+def git(repo: Path, *args: str, timeout: int = 30) -> tuple[int, str]:
     """(returncode, stdout). Never raises — a git failure is data here."""
+    env = {**os.environ}
+    env.setdefault("GIT_SSH_COMMAND", SSH_FAIL_FAST)
+    env.setdefault("GIT_TERMINAL_PROMPT", "0")      # never block on credentials
     try:
         r = subprocess.run(["git", *args], cwd=repo, capture_output=True,
-                           text=True, timeout=60)
+                           text=True, timeout=timeout, env=env)
         return r.returncode, (r.stdout or "")
     except (OSError, subprocess.TimeoutExpired) as exc:
         return 1, f"{type(exc).__name__}: {exc}"

--- a/.datacore/tests/test_seq_gap_offline.py
+++ b/.datacore/tests/test_seq_gap_offline.py
@@ -44,3 +44,41 @@ def test_the_contract_line_still_says_zero_errors_when_only_unreachable():
             f"{len(errors)} error(s), {len(unver)} unverifiable (remote unreachable)")
     assert "0 with unpublished events, 0 error" in line
     assert "1 unverifiable" in line
+
+
+def test_git_calls_fail_fast_on_an_unreachable_host(monkeypatch, tmp_path):
+    """A VPN capturing the route made ONE fetch take 75 s; eleven spaces then
+    blew the job's runtime budget and mac-seq-gap failed on a timeout while
+    writing no artifact at all (2026-09-08)."""
+    seen = {}
+
+    class R:
+        returncode = 0
+        stdout = ""
+
+    def fake_run(argv, **kw):
+        seen.update(env=kw.get("env") or {}, timeout=kw.get("timeout"))
+        return R()
+
+    monkeypatch.setattr(sg.subprocess, "run", fake_run)
+    sg.git(tmp_path, "fetch", "-q", "origin")
+    assert "ConnectTimeout=5" in seen["env"]["GIT_SSH_COMMAND"]
+    assert "BatchMode=yes" in seen["env"]["GIT_SSH_COMMAND"]
+    assert seen["env"]["GIT_TERMINAL_PROMPT"] == "0", "must never block on credentials"
+    assert seen["timeout"] and seen["timeout"] <= 30
+
+
+def test_an_explicit_ssh_command_is_respected(monkeypatch, tmp_path):
+    """setdefault, not overwrite: a host with its own GIT_SSH_COMMAND (a
+    jump host, an identity file) must keep it."""
+    class R:
+        returncode = 0
+        stdout = ""
+
+    seen = {}
+    monkeypatch.setenv("GIT_SSH_COMMAND", "ssh -i /custom/key")
+    monkeypatch.setattr(sg.subprocess, "run",
+                        lambda argv, **kw: (seen.update(env=kw.get("env") or {}), R())[1])
+    sg.git(tmp_path, "status")
+    assert seen["env"]["GIT_SSH_COMMAND"] == "ssh -i /custom/key"
+


### PR DESCRIPTION
`mac-seq-gap` alerted for a third day, and the check was never the problem. With a VPN capturing the route to Gitea, **one fetch takes 75 s** to give up. Eleven spaces, several Gitea-backed, and the detector blew its runtime budget and was killed — so the job failed on a **timeout** and never wrote the artifact. "Regex did not match" was true in the least useful way: there was nothing to match.

`ConnectTimeout=5` + `BatchMode=yes` + `GIT_TERMINAL_PROMPT=0`, per-call timeout 60 -> 30. Both env vars use `setdefault` so a host with its own `GIT_SSH_COMMAND` keeps it.

Measured with the VPN still on: full sweep in **36 s**, reporting 51 logs, 0 unpublished, 0 errors, 20 unverifiable. 2 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)