### PR TITLE
transport: an unreachable remote fails in seconds, not minutes

### DIFF
--- a/.datacore/lib/ledger_transport.py
+++ b/.datacore/lib/ledger_transport.py
@@ -66,10 +66,32 @@ class Result:
         return self.ok
 
 
+# AN UNREACHABLE HOST MUST FAIL IN SECONDS, NOT MINUTES. Measured against a
+# blackhole address by the chaos harness on 2026-09-08: a single converge sat
+# for 75 s before giving up, because ssh's default ConnectTimeout is the OS
+# TCP timeout. A sweep over ten spaces then costs twelve minutes of pure
+# waiting, which is how `mac-seq-gap` lost its artifact for three days --
+# the job was killed before it could write anything at all.
+#
+# Five seconds is far longer than any reachable host needs. The distinction
+# this preserves is the one that matters: a fast refusal still reads as
+# `blocked` (auth, missing repo), and only a genuine timeout reads as
+# `offline`. Failing fast makes that classification arrive sooner; it does
+# not blur it.
+SSH_FAIL_FAST = "ssh -o ConnectTimeout=5 -o BatchMode=yes"
+
+
+def _net_env() -> dict:
+    env = {**os.environ}
+    env.setdefault("GIT_SSH_COMMAND", SSH_FAIL_FAST)
+    env.setdefault("GIT_TERMINAL_PROMPT", "0")   # never block waiting for a password
+    return env
+
+
 def _git(repo: Path, *args: str, timeout: int = 120) -> tuple[int, str, str]:
     try:
         r = subprocess.run(["git", *args], cwd=repo, capture_output=True,
-                           text=True, timeout=timeout)
+                           text=True, timeout=timeout, env=_net_env())
         return r.returncode, (r.stdout or ""), (r.stderr or "")
     except (OSError, subprocess.TimeoutExpired) as exc:
         return 1, "", f"{type(exc).__name__}: {exc}"

--- a/.datacore/lib/tests/test_ledger_transport.py
+++ b/.datacore/lib/tests/test_ledger_transport.py
@@ -201,9 +201,17 @@ def test_seq_gap_reports_unverifiable_when_fetch_fails(tmp_path: Path, monkeypat
     rows = seq_gap.scan_space(space, fetch=True)
 
     assert calls["fetch"] == 1
-    assert rows and all(r["error"] for r in rows), "a failed fetch must mark rows unverifiable"
+    # datacore#150 split these: an unreachable remote is UNVERIFIABLE (a
+    # condition — a VPN, a closed lid), while a denied key or a missing repo
+    # stays an ERROR (a fault someone must fix). Counting the first as an
+    # error failed mac-seq-gap five times over a VPN toggle.
+    assert rows, "a failed fetch must still produce rows"
+    assert all(r.get("unverifiable") for r in rows), "offline rows are unverifiable"
+    assert not any(r["error"] for r in rows), "offline is a condition, not an error"
+    assert all("cannot verify" in (r.get("note") or "") for r in rows), \
+        "and the reason must still be visible"
     assert all(r["gap"] is None for r in rows), "must not claim a gap of zero"
-    assert "unreachable" in rows[0]["error"]
+    assert "unreachable" in rows[0]["note"], "the note carries the reason now, not error"
 
 
 def test_submodule_only_change_still_converges(repo_pair: Path, tmp_path: Path):


### PR DESCRIPTION
The chaos harness measured it against a blackhole address: **one converge sits 75 s** before giving up, because ssh default `ConnectTimeout` is the OS TCP timeout. A sweep over ten spaces is twelve minutes of pure waiting — the shape that killed `mac-seq-gap` for three days, where the job was killed before writing its artifact.

#156 fixed the seq-gap detector. This is the other half, and the transport is what every sync path goes through.

The classification is preserved: a fast refusal still reads as `blocked` (auth, missing repo); only a genuine timeout reads as `offline`.

Also repairs a test left stale by #150 — it still asserted that a failed fetch sets `error`, when #150 deliberately made an unreachable remote **unverifiable** with the reason in `note`. 35 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)