### PR TITLE
Shared language + guardrails earned by measurement

### DIFF
--- a/.datacore/CONTEXT.md
+++ b/.datacore/CONTEXT.md
@@ -1,0 +1,237 @@
+# Datacore — shared language
+
+The words this installation uses, and the ones it deliberately does not. When a
+term here has an _Avoid_ line, the listed synonyms are drift: they read as new
+concepts and cost a reader the work of discovering they are not.
+
+Scope: the root repo `datacore-one/datacore` and every space under it. Module-
+specific vocabulary belongs in that module's own `CLAUDE.base.md`.
+
+---
+
+## Structure
+
+**Space**
+A top-level `[N]-[name]/` directory that is its own git repo, with its own
+`CLAUDE.md`, org files, knowledge base and journal. The unit of convergence —
+transport operates on a space, never on a file.
+_Avoid_: workspace, vault, folder (a space is not merely a directory)
+
+**Root repo**
+`~/Data` itself, published as `datacore-one/datacore`. Holds `.datacore/`,
+the modules, the libs and the DIPs. Changes to it go through a branch and a PR;
+spaces commit on `main`.
+_Avoid_: main repo, the Datacore folder, the parent repo
+
+**Module**
+A self-contained package under `.datacore/modules/<name>/` with a `module.yaml`
+manifest, adding agents, commands, tools and context to one domain. A module
+ships **code, never the user's data**.
+_Avoid_: plugin (reserved for Claude Code plugins), extension, package
+
+**DIP**
+Datacore Improvement Proposal — a numbered spec in `.datacore/dips/` defining a
+system pattern. `Implemented`/`Accepted` requires owner ratification;
+auto-generated DIPs stay `Draft`.
+_Avoid_: RFC, ADR, proposal doc
+
+**Layered context**
+The `.base.md` → `.space.md` → `.local.md` composition (DIP-0002) that produces
+a gitignored `.md`. `.base.md` is public, `.local.md` is private.
+_Avoid_: context inheritance, config layering, overlay
+
+**Track**
+A `[space]/1-tracks/<name>/` directory organising work by department (dev,
+product, comms, growth). Where durable working documents live.
+_Avoid_: department folder, workstream directory
+
+**Focus mode**
+The state when a session starts inside `[space]/2-projects/[project]/`: a
+lightweight shim replaces the full context. Detected by
+`focus_mode.py detect`, which reports `focus`, `full` or `none`.
+_Avoid_: project mode, scoped session
+
+## Memory
+
+**Engram**
+One durable unit of memory in PLUR: a statement, its domain, a confidence and a
+commitment level. The thing that survives the quarter.
+_Avoid_: memory (too broad), note, fact record
+
+**PLUR**
+The memory engine and its MCP server. Global — one store, many projects; multi-
+project separation is by **scope**, not by separate installs.
+_Avoid_: the memory server, the engram database
+
+**Scope**
+Which store an engram is written to, chosen **per engram by its content** —
+a team store for shared engineering knowledge, the local/default store for
+personal or project-specific ones.
+_Avoid_: namespace, bucket, store selection
+
+**Auto-memory**
+The Claude Code memory directory and its `MEMORY.md` index. A *different*
+system from PLUR: loaded into the system prompt every session, so its index
+lines are a disclosure surface. Holds state with an expiry date; anything true
+in six months belongs in PLUR.
+_Avoid_: local memory, Claude memory, the memory folder
+
+**Learning sweep**
+The nightly batch (05:20) that reads the day's archived session transcripts and
+writes engrams. Replaced per-session learning agents, which cost ~112k output
+tokens per engram and never terminated.
+_Avoid_: learning pass, the classifier, nightly learning agent
+
+## Ledger and transport
+
+**Ledger**
+The append-only event log per space under `.datacore/events/<actor>.jsonl`
+(DIP-0034). Hash-chained: each event carries `seq`, `prev` and `hash`.
+_Avoid_: event store, audit log, the journal (the journal is prose, and separate)
+
+**Actor**
+The identity an event is attributed to (DIP-0044) — `mac`, `nightshift`,
+`winston`. One `.jsonl` file per actor, which is what lets independent machines
+append without conflicting.
+_Avoid_: agent (an agent is a role; an actor is an identity), host, writer
+
+**Converge**
+Receive other machines' facts and publish yours:
+`ledger_transport.py converge --space <space>`. The **only** sanctioned way to
+sync a space.
+_Avoid_: sync, pull, push, `git pull --rebase --autostash` (which loses work)
+
+**Autosave**
+The commit a converge makes of a dirty tree before integrating, so nothing is
+carried through a merge uncommitted. Visible as `ledger: autosave before converge`.
+_Avoid_: stash, WIP commit
+
+**Run branch**
+The branch a nightshift run works on. Since datacore#148 a run writes events to
+`<actor>-run-<date>.jsonl` so that one append-only chain is never extended on
+two branches at once — the failure that stranded 7 branches on 2026-09-08.
+_Avoid_: nightshift branch, job branch
+
+**Projection**
+Generating an org file from ledger state. A projected file is read-only
+(`chmod 444`); `inbox.org` is exempt in every phase and stays the capture surface.
+_Avoid_: rendering, materialising, export
+
+**Phase 1**
+A space whose `next_actions.org` is projected from the ledger rather than
+hand-edited. Write to `inbox.org` instead; the projector refuses direct writes.
+_Avoid_: ledger mode, migrated space
+
+## GTD
+
+**Inbox**
+`[space]/org/inbox.org` — the single capture point, and the only org file every
+command may write to. Returned to clean, not accumulated.
+_Avoid_: capture file, todo list
+
+**Continuation task**
+A `:continuation:`-tagged task carrying a `BOOTSTRAP` property, created by
+`/continue --save` or `/wrap-up`, scheduled on the next working day. What
+`/continue` looks for when resuming.
+_Avoid_: follow-up task, resume task, carry-over
+
+**BOOTSTRAP**
+The property holding a self-contained prompt for the next session: what was
+done, what remains, what blocks it. The thing that removes "where was I?".
+_Avoid_: context blob, handoff note
+
+**Rich Task Standard**
+The property set defined in DIP-0009 Part 3.5 — `CONTEXT`, `KEY_FILES`,
+`CURRENT_STATUS`, `ACCEPTANCE_CRITERIA`, `TOOLS`, plus `BOOTSTRAP` — that makes
+a task executable by an agent without the original conversation.
+_Avoid_: full task format, enriched task
+
+**DONE_WHEN**
+The property stating the observable condition that closes a task. Not a
+description of the work — a test a reader can run.
+_Avoid_: acceptance criteria (that is a separate, plural property), definition of done
+
+**`:AI:` tag**
+Marks a task for autonomous execution by nightshift, optionally qualified
+(`:AI:research:`, `:AI:content:`). **`sprint_sync` is the only writer of this
+tag** — never add or remove it by hand.
+_Avoid_: delegation tag, agent tag
+
+**Nightshift**
+The overnight autonomous execution system, and the box it runs on. Executes
+`:AI:`-tagged tasks on a schedule; its run logs carry the per-task token cost.
+_Avoid_: the overnight agent, the server, batch mode
+
+**Cadence**
+A recurring obligation a venture owes on a schedule (DIP: ventures module).
+Overdue cadences are a health signal, not a task backlog.
+_Avoid_: recurring task, ritual, ceremony
+
+## Knowledge
+
+**Zettel**
+An atomic concept note in `[space]/3-knowledge/zettel/`. Distinct from
+`literature/` (a summary of a source) and `reference/` (an entry about a person
+or company).
+_Avoid_: note, atomic note, permanent note
+
+**Datacortex**
+The knowledge graph and semantic search over local knowledge and journals.
+`datacore.search` reaches it. Does **not** search engrams — that is
+`plur_recall`.
+_Avoid_: the index, the vector store, RAG
+
+**Artifact index**
+`0-personal/notes/artifact-index-YYYY-MM.md` — the append-only monthly table
+answering "when did I work on X and where is it?".
+_Avoid_: file index, output log
+
+## Operations
+
+**Broker**
+`creds.py` — the one way to obtain a credential:
+`creds.py get <id> --consumer <who>`. Resolves the single declared location and
+verifies it before returning. **Searching for credentials is the failure mode
+the broker exists to prevent.**
+_Avoid_: secret store, vault, env lookup
+
+**Verdict**
+The one label every entry in `feature-ideas.md` leaves review with: **ADOPT**,
+**TRIAL**, **WATCH** or **DROP**. No idea leaves without one, and DROP is a
+success.
+_Avoid_: status, decision, disposition
+
+**Pulse**
+The single non-blocking 1-10 question `/wrap-up` asks at the start. An
+unanswered pulse is a normal outcome and nothing may block on it.
+_Avoid_: check-in, mood score
+
+## Relationships
+
+- A **Space** contains one **Ledger**, which holds **Events** written by **Actors**
+- **Converge** is the only operation that moves a **Space** between machines
+- A **Phase 1** space **projects** `next_actions.org` from its **Ledger**; its **Inbox** is never projected
+- An **Engram** lives in PLUR under a **Scope**; **Auto-memory** is a separate system with different rules
+- A **Continuation task** carries a **BOOTSTRAP** and follows the **Rich Task Standard**
+- The **Learning sweep** reads archived sessions and writes **Engrams**
+
+## Flagged ambiguities
+
+- **"sync"** meant three different things: the retired `./sync` script, git
+  push/pull, and ledger convergence. Resolved: convergence is **converge**;
+  the other two are named explicitly as git operations. Do not reintroduce
+  "sync" as a verb for spaces.
+- **"park"** described `git stash push -u -m nightshift-park-<ts>`. That
+  pattern lost work on conflict and was replaced by commit-onto-a-branch.
+  Retired: do not use "park" for the current behaviour, which is **autosave**.
+- **"rescue branch"** (`mac-rescue-<ts>`) belonged to the rebase-based
+  transport that DIP-0046 retires. Historical only.
+- **"memory"** was used for both PLUR engrams and the Claude Code auto-memory
+  directory. Resolved: **Engram**/**PLUR** for one, **Auto-memory** for the
+  other. Never bare "memory" in a routing instruction.
+- **"agent"** was used for both a role (`journal-coordinator`) and a ledger
+  identity. Resolved: the identity is an **Actor**.
+- **"task"** vs **"delegation"**: an org task mirrored into the ledger carries
+  an `org` block and `ledger_claim.py` skips exactly those, so a task written by
+  a command can never be picked up by the fleet. If an agent should do it
+  tonight, it is a **delegation** (an `:AI:` tag), not a task.

--- a/.datacore/lib/diagram_screenshot.py
+++ b/.datacore/lib/diagram_screenshot.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Render an HTML page headless and report what a linter cannot see.
+
+Static checks (verify-geometry, self_check) read the source. This asks the
+browser what actually painted: console errors, page-level horizontal overflow,
+and a screenshot you can look at. A diagram can pass every static check and
+still have a label sitting on its own arrow.
+
+    python3 diagram_screenshot.py page.html out.png [--viewport]
+
+Default is a full-page capture at device_scale_factor=2; `--viewport` captures
+only the fold. Exits non-zero if the page overflowed horizontally or logged a
+console error, so it can gate a build.
+
+Requires playwright with chromium installed (`playwright install chromium`).
+"""
+import asyncio
+import pathlib
+import sys
+
+
+async def shoot(src: str, out: str, full_page: bool = True) -> int:
+    from playwright.async_api import async_playwright
+
+    src_abs = pathlib.Path(src).resolve()
+    errors: list[str] = []
+    async with async_playwright() as p:
+        browser = await p.chromium.launch()
+        page = await browser.new_page(
+            viewport={"width": 1280, "height": 1000}, device_scale_factor=2
+        )
+        page.on("console", lambda m: errors.append(m.text) if m.type == "error" else None)
+        page.on("pageerror", lambda e: errors.append(str(e)))
+        await page.goto(src_abs.as_uri())
+        await page.wait_for_timeout(2500)  # let webfonts settle before capture
+        overflow = await page.evaluate(
+            "document.documentElement.scrollWidth > document.documentElement.clientWidth"
+        )
+        await page.screenshot(path=out, full_page=full_page)
+        await browser.close()
+
+    print(f"screenshot: {out}")
+    print(f"horizontal overflow: {overflow}")
+    print(f"console errors: {errors[:5] if errors else 'none'}")
+    return 1 if (overflow or errors) else 0
+
+
+def main() -> int:
+    args = [a for a in sys.argv[1:] if not a.startswith("--")]
+    if len(args) != 2:
+        print(f"usage: {sys.argv[0]} <page.html> <out.png> [--viewport]", file=sys.stderr)
+        return 2
+    return asyncio.run(shoot(args[0], args[1], full_page="--viewport" not in sys.argv))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.datacore/lib/diagram_split_svgs.py
+++ b/.datacore/lib/diagram_split_svgs.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Split a multi-diagram HTML document into one file per <svg>, for validation.
+
+Why this exists
+---------------
+The diagram-design skill ships `verify-geometry.py`, which checks that no arrow
+label mask is clipped by a node painted after it. That checker scans **every
+<rect> in the file** with no per-<svg> scoping, because its assumed input is a
+one-diagram page.
+
+Point it at a document holding several diagrams and it reports cross-diagram
+false positives: two <svg> elements have independent coordinate systems, so
+their rects can share x/y numbers and never paint over each other. Distorting a
+layout to satisfy that is the wrong fix.
+
+Split first, then check each diagram in isolation:
+
+    python3 diagram_split_svgs.py doc.html /tmp/svgs
+    python3 <skill>/scripts/verify-geometry.py /tmp/svgs/*.html
+
+Recorded as ENG-2026-09-08-012.
+
+Each output file is named `NN-<slug>.html`, where the slug comes from the SVG's
+`aria-labelledby="<slug>-title ..."` — so a finding names the diagram you can
+actually find.
+"""
+import re
+import sys
+import pathlib
+
+
+def split(src_path: pathlib.Path, out_dir: pathlib.Path) -> list[pathlib.Path]:
+    src = src_path.read_text(encoding="utf-8")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for stale in out_dir.glob("*.html"):
+        stale.unlink()
+
+    written = []
+    for i, svg in enumerate(re.findall(r"<svg\b.*?</svg>", src, re.S), 1):
+        m = re.search(r'aria-labelledby="([\w-]+)-title', svg)
+        slug = m.group(1) if m else f"diagram{i}"
+        dest = out_dir / f"{i:02d}-{slug}.html"
+        dest.write_text(
+            "<!DOCTYPE html><html><head><meta charset='utf-8'>"
+            f"<title>{slug}</title></head><body>\n{svg}\n</body></html>",
+            encoding="utf-8",
+        )
+        written.append(dest)
+    return written
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(f"usage: {sys.argv[0]} <document.html> <out-dir>", file=sys.stderr)
+        return 2
+    written = split(pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2]))
+    print(f"{len(written)} diagram(s) written to {sys.argv[2]}")
+    for p in written:
+        print(f"  {p.name}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/CLAUDE.base.md
+++ b/CLAUDE.base.md
@@ -247,13 +247,66 @@ When the user corrects a recalled fact: call `plur_learn` immediately, then `plu
 
 ## Guardrails
 
-### Over-engineering check
-Before proposing any new system, module, DIP, or architectural change:
-1. What is the simplest version that solves the actual problem?
-2. Is there an existing module/tool/pattern that already covers 80% of this?
-3. Will this create maintenance burden disproportionate to its value?
+### Over-engineering check — the reuse ladder
+Before writing code, stop at the first rung that holds:
 
-If a task can be done in <20 lines of shell script, do that first. Propose the module/system version only if the user explicitly asks.
+1. **Does this need to exist at all?** Speculative need → skip it, say so in one line.
+2. **Is it already in this codebase?** A helper, lib, pattern or module that already
+   lives here → reuse it. **Look before you write.** Re-implementing what sits a few
+   files over is the most common waste.
+3. **Does the stdlib do it?** Use it.
+4. **Does an already-installed dependency solve it?** Use it. Never add a new one for
+   what a few lines can do.
+5. **Can it be one line?** One line.
+6. **Only then:** the minimum code that works.
+
+Then the maintenance question: will this create burden disproportionate to its value?
+If a task can be done in <20 lines of shell, do that first. Propose the module/system
+version only if the user explicitly asks.
+
+Rung 2 is the one that pays and the one that gets skipped. Measured 2026-09-08 on a
+four-way run of the same issue: the issue said in as many words that a relevant module
+already existed and should be coordinated with rather than duplicated. **Three of four
+runs never opened it**; one wrote 404 lines into a file the issue never mentioned. The
+run that climbed the ladder was the only one that found it. Wrong-target work costs
+twice — once to write, once for a human to reject.
+
+Adapted from ponytail (DietrichGebert/ponytail, MIT). The ladder is adopted; the
+plugin is on trial separately.
+
+### Settle the spec before a change larger than a fix
+For anything bigger than a bug fix, the spec is settled **before** implementation:
+what "done" looks like, stated as a condition someone else could check. Write it into
+the task's `DONE_WHEN`. If the request is ambiguous, resolve the ambiguity by asking
+now rather than discovering it mid-run — an agent will not stop to ask, it will run a
+wrong answer to completion.
+
+### Loop design gate
+Before any new agent loop, cadence, or scheduled job ships, run it past all five:
+
+1. **Goal is a correct platitude** ("manage it well") → it spins and burns. Can the
+   exit condition be machine-judged yes/no?
+2. **The judge is the defendant** → the agent confidently declares itself fine.
+   Verification must be independent of execution.
+3. **Gates only on "all tests pass"** → the agent deletes the tests. A done-criterion
+   needs a **boundary** beside it: what it must NOT do.
+4. **Counts on the agent asking mid-run** → it will not. Front-load every clarification.
+5. **Stale docs and memory** → the faster it loops, the more it errs.
+
+Three red lines, no exceptions: **judgment stays with the human**; **responsibility
+does not transfer** (anything whose failure you cannot afford is not handed over
+automatically); and a **self-rewriting loop needs stricter review, not looser**.
+
+Adapted from ECC's `loop-design-check` (affaan-m/ECC, MIT). Failure mode 2 was live
+here until 2026-09-08: nightshift graded its own work against its own tests, through a
+gate that returned "passed" on every path including failure.
+
+### Size the work before dispatching it
+Ask whether the task fits the budget it is being given, and decompose it if not. An
+agent stopped mid-flight by a turn cap returns nothing, having spent everything.
+Measured 2026-09-08: four runs, 324 turns, a full day's compute budget, zero
+completions — every one of them cut off by a cap nobody had checked the task against. This is the largest single source
+of waste and it costs nothing to avoid.
 
 ### Tool Selection Discipline
 Before invoking any MCP tool, apply the locality test:


### PR DESCRIPTION
Two commits from the 2026-09-05→08 evaluation of four agent-tooling candidates (ponytail, mattpocock/skills, caveman, ECC).

## `.datacore/CONTEXT.md` — a shared-language glossary

34 terms this installation actually uses, in the term + `_Avoid_` + relationships + flagged-ambiguities format from mattpocock/skills (MIT). The `_Avoid_` lines are the working part: they name the synonyms that read as new concepts and cost a reader the work of discovering they are not.

Four real ambiguities resolved in the writing:
- **"sync"** meant three different things — the retired `./sync` script, git push/pull, and ledger convergence
- **"park"** named a `git stash` pattern that lost work on conflict and has been replaced by autosave
- bare **"memory"** spanned both PLUR engrams and the Claude Code auto-memory directory
- **"agent"** spanned a role and a ledger identity (now **Actor**)

Lives under `.datacore/` because the root-level allowlist hook only tracks `.datacore/`, `.github/` and root config.

## Four guardrails in `CLAUDE.base.md`

Each earned by a measurement, not a README.

**Reuse ladder** (replaces the three-question over-engineering check). Seven rungs, stop at the first that holds. Rung 2 — *is it already in this codebase* — is the one that pays and the one that gets skipped: on a four-way run of the same issue, where the issue itself stated a relevant module already existed and should be coordinated with rather than duplicated, **three of four runs never opened it**, and one wrote 404 lines into a file the issue never mentioned. Adapted from ponytail (MIT).

Worth recording that ponytail's advertised **−54% code did not reproduce** — it wrote *more* than baseline, not less. What reproduced was the behaviour, which is the part worth having.

**Settle the spec** before any change larger than a fix, as a `DONE_WHEN` someone else could check. An agent will not stop to ask mid-run; it will run a wrong answer to completion. From mattpocock/skills' `grill-with-docs` (MIT).

**Loop design gate** before any new loop, cadence or scheduled job — five failure modes, three red lines. Adapted from ECC's `loop-design-check` (MIT). Failure mode 2, *the judge is the defendant*, was live here until today: nightshift graded its own work against its own tests through a gate that returned `passed` on every path including outright failure. Fixed in datacore-one/datacore-nightshift#15.

**Size the work** before dispatching it. Four runs, 324 turns, a full day's compute, **zero completions** — every one cut off by a cap nobody had checked the task against. Largest single source of waste measured, and free to avoid.

Composed `CLAUDE.md` rebuilt via `context_merge.py`. All pre-commit hooks pass (PII, paths, secrets, API keys, root allowlist, day-of-week, public-layer validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)