### PR TITLE
registry: hosts declare a kind; checks can name why they cannot verify

### DIFF
--- a/.datacore/lib/detectors/seq_gap.py
+++ b/.datacore/lib/detectors/seq_gap.py
@@ -288,6 +288,24 @@ def main() -> int:
         unver_txt = f", {len(unver)} unverifiable (remote unreachable)" if unver else ""
         print(f"\nseq-gap: {len(rows)} log(s), {len(gaps)} with unpublished events, "
               f"{len(errors)} error(s){unver_txt}{pend_txt}")
+        # NAME THE CAUSE, IN THE ARTIFACT. "20 unverifiable" is a fact; "a
+        # full-tunnel VPN is capturing the subnet blackpi lives on" is a fact
+        # someone can act on. Three days of `mac-seq-gap` alerts said the
+        # former and nobody could act on it.
+        #
+        # And say plainly that the sweep is DEGRADED: an unverifiable log is
+        # not a clean one, so a run that checked 31 of 51 must not read as a
+        # pass. It is not a failure either -- nothing is broken and nobody is
+        # paged -- which is exactly why it needs its own word.
+        if unver:
+            try:
+                sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+                import network_context
+                print(network_context.explain())
+            except Exception as exc:  # noqa: BLE001 — an explanation must never fail a check
+                print(f"network: could not diagnose ({type(exc).__name__})")
+            print(f"DEGRADED: verified {len(rows) - len(unver)} of {len(rows)} log(s); "
+                  f"{len(unver)} could not be checked at all")
 
     if errors:
         return 2

--- a/.datacore/lib/network_context.py
+++ b/.datacore/lib/network_context.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Why the fleet cannot reach itself — named, not guessed.
+
+WHY THIS EXISTS. `mac-seq-gap` alerted for three days with "regex did not
+match". True, and useless: the cause was a work VPN capturing the route to
+the Gitea host, so every fetch hung 75 s and the job was killed before it
+could write anything. Three days of a check reporting the symptom of a
+symptom.
+
+A fleet that cannot verify itself must say WHY in the artifact, in words that
+name the next action. "20 unverifiable" is a fact; "20 unverifiable — a
+full-tunnel VPN is capturing 192.168.1.0/24, which is where blackpi lives"
+is a fact someone can act on.
+
+Reports, never decides. Nothing here changes routing, and a VPN is never
+treated as a fault: it is a condition of the machine, and the point is to
+attribute the degradation honestly rather than blame the check.
+
+    network_context.py            # one human line
+    network_context.py --json     # for a detector to embed in its artifact
+"""
+from __future__ import annotations
+
+import json
+import os
+import platform
+import re
+import socket
+import subprocess
+import sys
+from pathlib import Path
+
+TAILSCALE_CGNAT = "100.64.0.0/10"
+
+
+def _run(argv: list[str], timeout: int = 8) -> str:
+    try:
+        r = subprocess.run(argv, capture_output=True, text=True, timeout=timeout)
+        return (r.stdout or "") + (r.stderr or "")
+    except (OSError, subprocess.SubprocessError):
+        return ""
+
+
+def routes() -> str:
+    if platform.system() == "Darwin":
+        return _run(["netstat", "-rn", "-f", "inet"])
+    return _run(["ip", "-4", "route", "show"])
+
+
+def default_iface(table: str | None = None) -> str:
+    table = routes() if table is None else table
+    for line in table.splitlines():
+        f = line.split()
+        if platform.system() == "Darwin":
+            if f and f[0] == "default" and len(f) >= 4:
+                return f[-1]
+        elif f[:1] == ["default"] and "dev" in f:
+            return f[f.index("dev") + 1]
+    return ""
+
+
+def full_tunnel(table: str | None = None) -> tuple[bool, str]:
+    """Is a VPN capturing everything?
+
+    The tell is the `0.0.0.0/1` + `128.0.0.0/1` pair: two halves of the
+    address space, each more specific than `default`, which is how a VPN
+    takes the whole table without touching the default route. On macOS the
+    same pair prints as `0/1` and `128.0/1`."""
+    table = routes() if table is None else table
+    halves = [l for l in table.splitlines()
+              if re.match(r"^\s*(0\.0\.0\.0/1|0/1|128\.0\.0\.0/1|128\.0/1)\s", l)]
+    if len(halves) >= 2:
+        ifaces = {l.split()[-1] for l in halves}
+        return True, f"split-default pair via {', '.join(sorted(ifaces))}"
+    return False, ""
+
+
+def tunnels(table: str | None = None) -> list[str]:
+    """Tunnel interfaces carrying routes, Tailscale's excluded — it is a mesh
+    VPN we run on purpose, and it coexists with a corporate one."""
+    table = routes() if table is None else table
+    ts = tailscale_iface(table)
+    found = set()
+    for line in table.splitlines():
+        for tok in line.split():
+            if re.fullmatch(r"(utun|tun|tap|ppp|ipsec)\d+", tok) and tok != ts:
+                found.add(tok)
+    return sorted(found)
+
+
+def tailscale_iface(table: str | None = None) -> str:
+    table = routes() if table is None else table
+    for line in table.splitlines():
+        if "100.64" in line:
+            f = line.split()
+            if f:
+                return f[-1]
+    return ""
+
+
+def reachable(host: str, port: int, timeout: float = 4.0) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def fleet_remotes(root: Path) -> dict[str, int]:
+    """host -> port for every distinct git remote the spaces point at."""
+    out: dict[str, int] = {}
+    for space in sorted(root.glob("[0-9]-*")):
+        if not (space / ".git").exists():
+            continue
+        url = _run(["git", "-C", str(space), "remote", "get-url", "origin"]).strip()
+        m = re.match(r"(?:ssh://)?(?:[^@/]+@)?([^/:]+)(?::(\d+))?", url)
+        if not m:
+            continue
+        host, port = m.group(1), int(m.group(2) or 22)
+        if host and not host.startswith("/"):
+            out[host] = port
+    return out
+
+
+def context(root: Path | None = None) -> dict:
+    root = root or Path(os.environ.get("DATACORE_ROOT") or (Path.home() / "Data"))
+    table = routes()
+    ft, ft_detail = full_tunnel(table)
+    tun = tunnels(table)
+    remotes = fleet_remotes(root)
+    unreachable = {h: p for h, p in remotes.items() if not reachable(h, p)}
+    return {
+        "host": socket.gethostname().split(".")[0].lower(),
+        "default_interface": default_iface(table),
+        "full_tunnel_vpn": ft,
+        "full_tunnel_detail": ft_detail,
+        "vpn_interfaces": tun,
+        "tailscale_interface": tailscale_iface(table),
+        "remotes": remotes,
+        "unreachable": unreachable,
+    }
+
+
+def explain(ctx: dict | None = None) -> str:
+    """One line naming the degradation and the next action, or that all is well."""
+    c = ctx or context()
+    if not c["unreachable"]:
+        return "network: every fleet remote reachable"
+    names = ", ".join(sorted(c["unreachable"]))
+    if c["full_tunnel_vpn"]:
+        return (f"network: {names} unreachable — a full-tunnel VPN is active "
+                f"({c['full_tunnel_detail']}), which captures the local subnet "
+                f"and with it the direct path to a peer on this LAN. "
+                f"Not a fault: disconnect the VPN, or allow local-network access.")
+    if c["vpn_interfaces"]:
+        return (f"network: {names} unreachable — VPN interface(s) "
+                f"{', '.join(c['vpn_interfaces'])} are up. Check whether they "
+                f"capture the route to those hosts.")
+    if not c["tailscale_interface"] and any(h.startswith("100.") for h in c["unreachable"]):
+        return (f"network: {names} unreachable — no Tailscale route is present "
+                f"(100.64/10 absent). Tailscale is down on this machine.")
+    return (f"network: {names} unreachable, and no VPN or missing Tailscale route "
+            f"explains it — the remote itself is likely down.")
+
+
+def main() -> int:
+    c = context()
+    if "--json" in sys.argv:
+        print(json.dumps(c, indent=2, sort_keys=True))
+    else:
+        print(explain(c))
+    return 1 if c["unreachable"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.datacore/registry/infrastructure.yaml
+++ b/.datacore/registry/infrastructure.yaml
@@ -1,6 +1,14 @@
 servers:
   mac:
     purpose: Primary workstation — human sessions, Claude Code, org authoring
+    # A WORKSTATION IS NOT A DEGRADED SERVER. It sleeps, it roams
+    # networks, it carries work in progress. Being asleep, on a
+    # feature branch or dirty is NORMAL here and an incident on a
+    # server. Checks read this to set expectations -- never to skip:
+    # exempting this machine would have hidden the three real fleet
+    # bugs it found first on 2026-09-08 (the 75s fetch hang, the
+    # worktree owning main, the sleeping crons).
+    kind: workstation
     ssh_alias: '-'
     deploy_method: local working copy (~/Data)
     services: []
@@ -23,6 +31,7 @@ servers:
   winston:
     manifest_machine: box
     purpose: Chief of Staff — briefings, approvals, merge gatekeeper
+    kind: server
     ssh_alias: winston
     deploy_method: rsync + cron
     services:
@@ -41,6 +50,7 @@ servers:
       hostname: bridge
   nightshift:
     purpose: Overnight AI task execution (systemd timers); Miles Telegram bot
+    kind: server
     ssh_alias: nightshift
     deploy_method: git pull + systemctl restart
     services:
@@ -62,6 +72,7 @@ servers:
       hostname: nightshift
   hermes:
     purpose: Tris — Hermes agent gateway + PLUR bridge
+    kind: server
     ssh_alias: hermes
     deploy_method: agent_update.py --host hermes --apply
     services:
@@ -79,6 +90,7 @@ servers:
       hostname: transporter
   plur-claw:
     purpose: Mr Data — OpenClaw agent host
+    kind: server
     ssh_alias: plur-claw
     deploy_method: ssh + manual
     services: []

--- a/.datacore/tests/test_network_context.py
+++ b/.datacore/tests/test_network_context.py
@@ -1,0 +1,100 @@
+"""Name the cause of an unreachable fleet, or say plainly that you cannot.
+
+mac-seq-gap alerted for three days with "regex did not match". True and
+useless: a work VPN had captured the route to the Gitea host, every fetch
+hung 75 s, and the job was killed before writing anything. The artifact must
+carry the reason, in words that name the next action."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+LIB = Path(__file__).resolve().parents[1] / "lib"
+sys.path.insert(0, str(LIB))
+import network_context as nc  # noqa: E402
+
+# Real shapes. macOS prints the split-default pair as 0/1 and 128.0/1.
+MAC_VPN = """Destination        Gateway            Flags        Netif Expire
+default            192.168.1.254      UGScg           en0
+0/1                10.8.0.1           UGSc          utun6
+128.0/1            10.8.0.1           UGSc          utun6
+100.64/10          link#18            UCS           utun4
+192.168.1          link#4             UCS             en0
+"""
+
+MAC_CLEAN = """Destination        Gateway            Flags        Netif Expire
+default            192.168.1.254      UGScg           en0
+100.64/10          link#18            UCS           utun4
+192.168.1          link#4             UCS             en0
+"""
+
+LINUX_VPN = """default via 10.0.0.1 dev eth0
+0.0.0.0/1 via 10.8.0.1 dev tun0
+128.0.0.0/1 via 10.8.0.1 dev tun0
+100.64.0.0/10 dev tailscale0
+"""
+
+
+def test_a_full_tunnel_vpn_is_detected_by_its_split_default_pair():
+    ok, detail = nc.full_tunnel(MAC_VPN)
+    assert ok and "utun6" in detail
+    ok, detail = nc.full_tunnel(LINUX_VPN)
+    assert ok and "tun0" in detail
+
+
+def test_no_vpn_is_not_reported_as_one():
+    assert nc.full_tunnel(MAC_CLEAN) == (False, "")
+
+
+def test_tailscale_is_never_counted_as_the_vpn():
+    """Tailscale is a mesh VPN we run deliberately and it coexists with a
+    corporate one; calling it the culprit would send the operator to turn off
+    the very thing carrying the fleet."""
+    assert nc.tailscale_iface(MAC_VPN) == "utun4"
+    assert "utun4" not in nc.tunnels(MAC_VPN)
+    assert "utun6" in nc.tunnels(MAC_VPN)
+    assert nc.tunnels(MAC_CLEAN) == []
+
+
+def test_default_interface_on_both_platforms():
+    assert nc.default_iface(MAC_CLEAN) == "en0"
+    assert nc.default_iface(LINUX_VPN) == "eth0"
+
+
+def test_the_explanation_names_the_vpn_and_the_next_action():
+    msg = nc.explain({
+        "host": "mac", "default_interface": "en0",
+        "full_tunnel_vpn": True, "full_tunnel_detail": "split-default pair via utun6",
+        "vpn_interfaces": ["utun6"], "tailscale_interface": "utun4",
+        "remotes": {"100.115.67.71": 2222}, "unreachable": {"100.115.67.71": 2222},
+    })
+    assert "100.115.67.71" in msg
+    assert "full-tunnel VPN" in msg and "utun6" in msg
+    assert "Not a fault" in msg, "a VPN is a condition of the machine, not a defect"
+    assert "local-network access" in msg, "must name what to change"
+
+
+def test_a_missing_tailscale_route_is_distinguished_from_a_vpn():
+    msg = nc.explain({
+        "host": "mac", "default_interface": "en0", "full_tunnel_vpn": False,
+        "full_tunnel_detail": "", "vpn_interfaces": [], "tailscale_interface": "",
+        "remotes": {"100.115.67.71": 2222}, "unreachable": {"100.115.67.71": 2222},
+    })
+    assert "Tailscale is down" in msg
+
+
+def test_an_unexplained_outage_says_so_rather_than_inventing_a_cause():
+    msg = nc.explain({
+        "host": "box", "default_interface": "eth0", "full_tunnel_vpn": False,
+        "full_tunnel_detail": "", "vpn_interfaces": [], "tailscale_interface": "utun4",
+        "remotes": {"github.com": 22}, "unreachable": {"github.com": 22},
+    })
+    assert "no VPN" in msg and "remote itself is likely down" in msg
+
+
+def test_all_reachable_says_so():
+    assert "every fleet remote reachable" in nc.explain({
+        "host": "mac", "default_interface": "en0", "full_tunnel_vpn": False,
+        "full_tunnel_detail": "", "vpn_interfaces": [], "tailscale_interface": "utun4",
+        "remotes": {"github.com": 22}, "unreachable": {},
+    })


### PR DESCRIPTION
Two halves of one problem: the fleet reporting a **condition** as a **fault**.

**Host kind.** The registry called the mac a "Primary workstation" in prose and treated it as a server in data. A workstation sleeps, roams networks, carries WIP — normal there, an incident on a server. `kind` makes that readable.

Classify, never exempt: every "mac problem" this week was a real fleet bug the workstation met first (the 75 s fetch hang in the shared transport, the runner worktree owning `main`, sleeping crons). Exempting it would have hidden all three.

**Network context.** `mac-seq-gap` alerted for three days with "regex did not match" while the actual cause was a VPN capturing the route to Gitea. `network_context.py` detects a full-tunnel VPN by its split-default pair, never blames Tailscale (a mesh VPN we run deliberately, which coexists), distinguishes a missing `100.64/10` route, and names the next action.

`seq-gap` prints that line whenever anything is unverifiable and declares **DEGRADED** — a run that checked 31 of 51 logs is not a pass, and not a failure either.

8 tests against real macOS and Linux route tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)