### PR TITLE
jobs: verify the briefing against the section its producer actually writes

### DIFF
--- a/.datacore/lib/jobs/manifest.yaml
+++ b/.datacore/lib/jobs/manifest.yaml
@@ -492,7 +492,18 @@ jobs:
       # re-break it.
       - path: "~/Data/0-personal/notes/journals/{today}.md"
         check: regex
-        arg: "^#{2,3}\\s+Your Agenda"
+        # ASSERT WHAT THE PRODUCER GUARANTEES, NOT A TITLE THE MODEL CHOSE.
+        # "Your Agenda" was a section in nightshift's /today template. When
+        # the briefing moved to Winston on 2026-09-08 (one producer per
+        # artifact) the journal block became a render of the MODEL's own
+        # sections — Good Morning, The World, The Ask, Focus — and this
+        # contract began failing on a heading nothing emits any more. It had
+        # already failed this way once before, on 2026-08-16.
+        #
+        # The heading is the structural guarantee: cos_journal.py always
+        # writes "## Daily Briefing" and replaces that block in place. A
+        # section title is a model's choice and will change again.
+        arg: '^##\s+Daily Briefing'
         max_age_hours: 26
       # cos_verify_morning.py:check_audio -- AUDIO_STAMP, written by
       # winston_audio.sh only after Telegram accepts the voice message.

--- a/.datacore/lib/tests/fixtures/jobs/box-briefing.2.txt
+++ b/.datacore/lib/tests/fixtures/jobs/box-briefing.2.txt
@@ -1,8 +1,7 @@
 # fixture for box-briefing artifact[2]
 # producer artifact: ~/Data/0-personal/notes/journals/{today}.md on box
-# harvested: 2026-09-03
-# regex under test: ^#{2,3}\s+Your Agenda
+# harvested: 2026-09-08
+# regex under test: ^##\s+Daily Briefing
 # represents: SUCCESS
 # ---
-## Your Agenda
-## Your Agenda
+## Daily Briefing

--- a/.datacore/lib/tests/fixtures/jobs/box-cadence-liveness.0.txt
+++ b/.datacore/lib/tests/fixtures/jobs/box-cadence-liveness.0.txt
@@ -1,13 +1,8 @@
 # fixture for box-cadence-liveness artifact[0]
 # producer artifact: ~/.datacore/state/cadence-liveness.log on box
-# harvested: 2026-09-03
-# regex under test: ^0 cadence\(s\) overdue$
-# represents: SUCCESS (derived)
-# The live artifact was UNHEALTHY when harvested, so a success sample
-# could not be captured. This is the producer's own observed output with
-# the failing count rewritten to its success value. The format is the
-# producer's; only the number changed. It proves the regex CAN match this
-# producer -- it says nothing about current health.
+# harvested: 2026-09-08
+# regex under test: ^0 cadence\(s\) overdue; sunset review: 0 past due, [0-9]+ without a review date$
+# represents: SUCCESS
 # ---
-0 cadence(s) overdue
-0 cadence(s) overdue
+0 cadence(s) overdue; sunset review: 0 past due, 77 without a review date
+0 cadence(s) overdue; sunset review: 0 past due, 77 without a review date

--- a/.datacore/lib/tests/fixtures/jobs/nightshift-delegation-gate.0.txt
+++ b/.datacore/lib/tests/fixtures/jobs/nightshift-delegation-gate.0.txt
@@ -1,0 +1,8 @@
+# fixture for nightshift-delegation-gate artifact[0]
+# producer artifact: ~/.datacore/state/nightshift-gate.log on nightshift
+# harvested: 2026-09-08
+# regex under test: gate ok
+# represents: SUCCESS
+# ---
+2026-09-08 gate ok: 0 machine-originated, 0 plan-only, 0 approved, 0 executed unapproved (10 records, 0 legacy)
+2026-09-08 gate ok: 0 machine-originated, 0 plan-only, 0 approved, 0 executed unapproved (10 records, 0 legacy)


### PR DESCRIPTION
`box-briefing` asserted `^#{2,3}\s+Your Agenda`. That section came from the nightshift `/today` template, retired when the briefing moved to Winston. `cos_journal.py` splices `## Daily Briefing` into the personal journal and nothing writes "Your Agenda" any more, so the check was guaranteed to fail on the first morning after the move — reporting a missing briefing that was present and correct. This asserts the heading the producer structurally guarantees.

Two fixtures were stale in ways that hid the same class of bug:

- **box-cadence-liveness** kept a *derived* success sample built against an older, shorter regex. The manifest regex later gained the "sunset review" clause and the sample was never rebuilt, so the test failed while the live job was healthy. Re-harvested from live output.
- **nightshift-delegation-gate** had no fixture at all, so its regex was unverifiable in either direction.

## Verification

Live journal, today: new pattern matches, old pattern does not.

Grounded suite on this branch: 2 failed, 31 passed. Both remaining failures are worktree path-resolution artifacts (`cos_fleet_probe.sh` is gitignored, `agent_outcomes.py` is tracked; the runner manifest has not synced yet) and both pass in the primary checkout. `main` fails 2: cadence-liveness and delegation-gate, which this fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)