### PR TITLE
ledger: key the seal's fork check on the log file, not the actor

### DIFF
--- a/.datacore/lib/ledger/fork.py
+++ b/.datacore/lib/ledger/fork.py
@@ -1,9 +1,17 @@
 """Fork detection: has one actor's log split into two histories?
 
-THE INVARIANT: `(actor, seq)` identifies exactly one event, forever. Everything
-downstream depends on it — a merge is a union only because two machines can
-never disagree about what `mac` seq 139 is, and `state_root` is comparable only
-because both sides folded the same events.
+THE INVARIANT: within ONE log file, `seq` identifies exactly one event, forever.
+Everything downstream depends on it — a merge is a union only because two
+machines can never disagree about what `mac.jsonl` seq 139 is, and `state_root`
+is comparable only because both sides folded the same events.
+
+Read "one log file", not "one actor": since datacore#148 a writer may own
+several logs (`<actor>.jsonl` plus a `<actor>-run-<date>.jsonl` per run branch),
+and `seq` restarts at 0 in each, because `verify_chain` takes a single path and
+checks linkage within it. The functions here are already file-scoped — they
+compare two versions of ONE blob — so the invariant holds as stated for every
+caller in this module. `seal._self_consistent` is the reader that merges every
+file at once, and it keys on the log for exactly this reason.
 
 It broke in production on 2026-08-13. In 5-plur, seq 139 was an `item.update`
 on one machine and an `item.dismiss` on another. It was found only because git

--- a/.datacore/lib/ledger/log.py
+++ b/.datacore/lib/ledger/log.py
@@ -409,6 +409,22 @@ def read_events(space_dir: Path) -> list[Event]:
     for path in sorted(events_dir.glob("*.jsonl")):
         raw = path.read_bytes()
         file_events, _valid_len = _parse_log_bytes(raw, path)
+        for e in file_events:
+            # Which chain this event came from. A writer may own MORE THAN ONE
+            # log -- datacore#148 gave a run branch its own `<actor>-run-<date>`
+            # file so a run and the hourly cycle stop extending one chain on two
+            # git branches. `seq` restarts at 0 in each file, because the chain
+            # unit is the FILE: `verify_chain` takes a single path and checks
+            # linkage within it.
+            #
+            # So provenance has to travel with the event. Without it a reader
+            # that merges every file cannot tell "the same event twice" from
+            # "two chains that both start at 0", and keying on `actor` alone
+            # reports every run branch as a forked log. Set as a plain
+            # attribute, never a dataclass field: `to_line` serializes via
+            # `asdict`, so a declared field would enter the on-disk format and
+            # the hash body with it.
+            e.log = path.stem
         events.extend(file_events)
     events.sort(key=lambda e: e.hlc)
     return events

--- a/.datacore/lib/ledger/seal.py
+++ b/.datacore/lib/ledger/seal.py
@@ -105,18 +105,36 @@ def settled(events: list[Event]):
 
 
 def _self_consistent(events: list[Event]) -> list[tuple[str, int]]:
-    """(actor, seq) pairs that appear more than once with different hashes.
+    """(log, seq) pairs that appear more than once with different hashes.
 
     A fork that arrives via sync lands INSIDE the event set the sequencer is
     about to certify. verify_seal recomputes the root from those same events,
     so it agrees with itself and reports success — certifying a history another
     machine will disagree with. That is the worst thing finality can do, so it
     is checked before the root comparison rather than after.
+
+    THE KEY IS THE LOG FILE, NOT THE ACTOR. It read `(actor, seq)` until
+    2026-09-08, which was right while a writer owned exactly one file. It stopped
+    being right when datacore#148 gave a run branch its own `<actor>-run-<date>`
+    log: `seq` restarts at 0 per file, so one actor legitimately has several
+    events at seq 0 — different events, different hashes, no fork. The stricter
+    key turned that design into a permanent false alarm; measured on 5-plur it
+    reported 88 forked pairs, every one of them a base log against its own
+    run-branch sibling and not one between two independent writers.
+
+    Weakening it costs nothing real. Two machines that genuinely fork a chain
+    write the SAME file name, so they still collide here. What is no longer
+    flagged is a collision across two different files, which is not a fork:
+    `verify_chain` takes one path and checks linkage within it, so the chain —
+    and therefore the identity of `seq` — is scoped to the file.
+
+    Events with no `log` attribute (constructed in memory rather than read from
+    disk) fall back to the actor, which is exactly the old behavior.
     """
     seen: dict[tuple[str, int], str] = {}
     bad: list[tuple[str, int]] = []
     for e in events:
-        k = (e.actor, e.seq)
+        k = (getattr(e, "log", None) or e.actor, e.seq)
         if k in seen and seen[k] != e.hash:
             bad.append(k)
         seen[k] = e.hash
@@ -133,9 +151,9 @@ def verify_seal(events: list[Event]) -> tuple[bool | None, str]:
     forked = _self_consistent(events)
     if forked:
         a, sq = forked[0]
-        return False, (f"FORKED LOG: {len(forked)} (actor, seq) pair(s) have two "
-                       f"different events, e.g. {a} seq {sq}. A seal over a fork "
-                       f"certifies a history other machines reject — refusing.")
+        return False, (f"FORKED LOG: {len(forked)} (log, seq) pair(s) have two "
+                       f"different events, e.g. log {a} seq {sq}. A seal over a "
+                       f"fork certifies a history other machines reject — refusing.")
 
     seal = latest_seal(events)
     if seal is None:

--- a/.datacore/lib/tests/test_ledger_seal.py
+++ b/.datacore/lib/tests/test_ledger_seal.py
@@ -12,6 +12,7 @@ LIB = Path(__file__).resolve().parents[1]
 if str(LIB) not in sys.path:
     sys.path.insert(0, str(LIB))
 
+from ledger.events import Event  # noqa: E402
 from ledger.log import EventLog, read_events  # noqa: E402
 from ledger.seal import (  # noqa: E402
     build_seal_payload, latest_seal, settled, settled_events, verify_seal, watermarks,
@@ -113,3 +114,58 @@ class TestDetection:
         ok, detail = verify_seal(read_events(space))
         assert ok is None
         assert "behind" in detail
+
+
+class TestForkKeyIsTheLogFile:
+    """Regression, 2026-09-08. `_self_consistent` keyed on `(actor, seq)`.
+
+    That was right while a writer owned one file. datacore#148 gave a run branch
+    its own `<actor>-run-<date>` log, `seq` restarts at 0 in each file, and the
+    check began reporting every run branch as a forked log — 88 pairs on 5-plur,
+    every one a base log against its own run sibling. The seal then refused, and
+    the fleet's morning verification alerted on it nightly.
+    """
+
+    def test_one_actor_two_logs_is_not_a_fork(self, space):
+        """The exact production shape: `nightshift.jsonl` and
+        `nightshift-run-<date>.jsonl` both start at seq 0."""
+        EventLog(space, "nightshift").append("item.create", {"id": "a", "title": "base"})
+        EventLog(space, "nightshift", log_name="nightshift-run-2026-09-08").append(
+            "item.create", {"id": "b", "title": "run"})
+
+        evs = read_events(space)
+        by_seq0 = [e for e in evs if e.seq == 0 and e.actor == "nightshift"]
+        assert len(by_seq0) == 2, "precondition: both logs start at seq 0"
+        assert by_seq0[0].hash != by_seq0[1].hash, "precondition: different events"
+        assert {e.log for e in by_seq0} == {"nightshift", "nightshift-run-2026-09-08"}
+
+        ok, reason = verify_seal(evs)
+        assert "FORKED" not in reason, reason
+        assert ok is not False, reason
+
+    def test_a_real_fork_in_one_log_is_still_caught(self, space):
+        """Weakening the key must not cost the detection it exists for. Two
+        machines that genuinely fork a chain write the SAME file name."""
+        from ledger.seal import _self_consistent
+
+        EventLog(space, "mac").append("item.create", {"id": "a", "title": "one"})
+        base = read_events(space)[0]
+
+        twin = Event(seq=base.seq, hlc=base.hlc, actor=base.actor, type=base.type,
+                     payload={"id": "a", "title": "OTHER"}, prev=base.prev,
+                     hash="0" * 64, sig="")
+        twin.log = base.log  # same file: this is what a fork looks like
+
+        forked = _self_consistent([base, twin])
+        assert forked == [(base.log, base.seq)], forked
+
+    def test_in_memory_events_fall_back_to_the_actor(self):
+        """Events built in memory carry no `log`; the old key still applies."""
+        from ledger.seal import _self_consistent
+
+        def ev(h):
+            return Event(seq=0, hlc="h", actor="mac", type="item.create",
+                         payload={}, prev="", hash=h, sig="")
+
+        assert _self_consistent([ev("a" * 64), ev("b" * 64)]) == [("mac", 0)]
+        assert _self_consistent([ev("a" * 64), ev("a" * 64)]) == []


### PR DESCRIPTION
`_self_consistent` asked whether any `(actor, seq)` pair carried two different events. Right while a writer owned exactly one log. datacore#148 gave a run branch its own `<actor>-run-<date>` file, and `seq` restarts at 0 in each file, because the chain unit **is** the file: `verify_chain` takes a single path and checks linkage within it.

So every run branch looked like a forked log.

## Measured on 5-plur

88 colliding pairs. Grouped by which files collided:

| pairs | files |
|---|---|
| 69 | `nightshift.jsonl` vs `nightshift-run-2026-09-06.jsonl` |
| 10 | `nightshift.jsonl` vs both run siblings |
| 7 | `miles.jsonl` vs `miles-run-2026-09-06.jsonl` |
| 2 | `tris.jsonl` vs `tris-run-2026-09-08.jsonl` |

Every one a base log against its own run sibling. Not one between two independent writers.

The seal refused → `seals verify` failed → `bridge-v2-verify` failed its `0 FAIL` contract → the fleet telegrammed every morning about an integrity violation that had not happened.

## Why this costs no detection

Two machines that genuinely fork a chain write the **same** file name, so they still collide. What is no longer flagged is a collision across two different files, which was never a fork.

`read_events` attaches the source log to each event as a plain attribute, never a dataclass field — `to_line` serializes via `asdict`, so a declared field would enter the on-disk format and the hash body with it. In-memory events have no `log` and fall back to the actor: the old behavior exactly.

`fork.py` stated the old invariant as THE invariant. Its own functions are file-scoped, so they were never wrong, but leaving the sentence unqualified is how this gets reintroduced.

## Tests

Three regression tests pin both directions: one actor with two logs is not a fork, a real fork within one log is still caught, and in-memory events still key on the actor.

`test_ledger_seal.py`: 11 passed. Ledger/seal/fork/transport suite: 333 passed, 4 failed — all 4 fail identically on unmodified `main` (verified in a clean worktree at `origin/main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)