### PR TITLE
journal: make an entry structurally unable to destroy the file

### DIFF
--- a/.datacore/agents/journal-entry-writer.md
+++ b/.datacore/agents/journal-entry-writer.md
@@ -12,6 +12,13 @@ description: |
   - continuation: Next steps if work incomplete (optional)
   - learnings: Brief learnings summary (optional)
 model: haiku
+# NO Write. This agent's whole job is to ADD one entry to a file several other
+# sessions are writing at the same time, and Write replaces a file wholesale --
+# one tool call away from destroying every other session's work. Creating a
+# journal that does not exist yet, and appending to one that does, are both
+# done with a shell heredoc; the Standup upsert is an anchored Edit. Neither
+# needs Write, so it is not on the list.
+tools: Read, Edit, Bash, Glob, Grep
 ---
 
 # Journal Entry Writer Agent
@@ -281,16 +288,75 @@ sessions:
 
 ## Workflow
 
-1. **Resolve path**: Determine correct journal file path for the space
-2. **Check file exists**: Read existing journal to append (create if needed)
-3. **Get current time**: Use current hour:minute for session timestamp
-4. **Format entry**: Structure the session data into proper format
-5. **Append entry**: Add separator (`---`) and session entry to file
-6. **Upsert Standup block** (team journals only): if `## Standup` exists,
-   merge `### @{author}` items into it; otherwise insert a new block before
-   `## Session Metadata`. Each accomplishment from this session becomes an
-   ``- [x]`` item under `#### Yesterday`.
-7. **Return confirmation**: Report success with path and entry summary
+> **THE RULE: never rewrite a region of the file you did not author.**
+>
+> A journal is shared. On any given day it holds entries from other sessions,
+> other people, and other agents, and several of them may be writing it while
+> you are. Your entry is an ADDITION. Every step below is shaped so that the
+> bytes you did not write cannot move.
+>
+> On 2026-09-08 a `5-plur` journal lost 269 lines -- four unrelated sessions'
+> entries -- and the loss was pushed to the shared remote. Reproduction on
+> 2026-09-08 did NOT show this agent overwriting the file (two runs, one on a
+> 422-line 18-section journal: 29 insertions, 0 deletions, no heading lost), so
+> the destruction is not known to start here. These rules make that outcome
+> structural instead of merely likely.
+
+1. **Resolve path**: Determine correct journal file path for the space.
+2. **Read it**: Read the existing journal. If it does not exist, create it with
+   a heredoc (`cat > "$F" <<'EOF' ... EOF`), never with Write.
+3. **Record the before state**: run
+   `git -C <repo> diff --numstat -- <journal>` and keep the numbers. Step 8
+   compares against them.
+4. **Get current time**: Use current hour:minute for session timestamp.
+5. **Format entry**: Structure the session data into the format above.
+6. **Append entry -- APPEND, do not rewrite**: add the separator and your
+   entry with a shell append and a quoted heredoc:
+
+   ```bash
+   cat >> "$JOURNAL" <<'ENTRY'
+
+   ---
+
+   ## @gregor — Topic
+   ...
+   ENTRY
+   ```
+
+   `>>` cannot shorten a file. Quote the delimiter (`<<'ENTRY'`) so the shell
+   does not expand backticks or `$` in your prose. If the entry must land
+   somewhere other than the end, use Edit anchored on a unique nearby string --
+   still never a whole-file write.
+7. **Upsert Standup block** (team journals only): this is the one step that
+   genuinely merges into existing content, and therefore the one to keep
+   narrow. Use **Edit, anchored on the smallest unique string that identifies
+   the insertion point** -- the `#### Yesterday` line inside the
+   `### @{author}` subsection -- and replace only that line plus the items you
+   are adding. Do not reproduce the surrounding sections in either the old or
+   the new string. If `## Standup` does not exist at all, append a fresh block
+   with the same heredoc as step 6, before `## Session Metadata` via an
+   anchored Edit on that heading.
+8. **Verify you added and removed nothing** -- MANDATORY, and the check that
+   would have caught the 2026-09-08 loss instantly:
+
+   ```bash
+   git -C <repo> diff --numstat -- <journal>
+   ```
+
+   Insertions must be greater than zero and **deletions must be zero** (or
+   unchanged from the step-3 baseline, if the file was already dirty). Also
+   confirm no heading disappeared:
+
+   ```bash
+   comm -23 <(git -C <repo> show HEAD:<path> | grep '^#\+ ' | sort) \
+            <(grep '^#\+ ' <journal> | sort)
+   ```
+
+   Both must be empty. If either shows a loss, **restore the file with
+   `git -C <repo> checkout -- <journal>` and report the failure** -- do not
+   attempt a second write, and do not report success.
+9. **Return confirmation**: Report success with path, entry summary, and the
+   numstat you verified.
 
 ## Entry Guidelines
 

--- a/.datacore/commands/wrap-up.md
+++ b/.datacore/commands/wrap-up.md
@@ -213,6 +213,21 @@ Tasks to create (one per spec step, mark in_progress when starting, completed wh
 
 **Why this exists:** Spec step counts in past sessions: 17 spec steps, 9 tasks created, 6 silently skipped (observed 2026-05-29 SMK wrap-up; previously documented as ENG-2026-0512-044 on 2026-05-12 but recurred 17 days later). Memory engrams alone are insufficient — execution-time discipline failure. The hook is the structural defense; one-task-per-step is the readability defense.
 
+**CRITICAL — §5 and §8 touch the same files. Never commit a journal by hand.**
+§5 spawns writer subagents that are still editing today's journals when control
+returns to you. §8 (`finalize`) is scoped to the session archive's files and is
+the ONLY sanctioned way to commit them. On 2026-09-08 a wrap-up ran
+`git add journal/... && git commit && git push` on a journal while a writer was
+mid-file: 269 lines — four unrelated sessions' entries — went to the shared
+remote as a deletion, and `audit` still reported 6/6, because every check it had
+asks whether a commit exists and reached the remote, never what it contained.
+
+So: wait for every §5 subagent to report before §8, never stage a journal path
+yourself, and if you ever do stage one, diff it first (`git diff --numstat` —
+deletions must be zero). `finalize` now REFUSES a commit whose journal loses a
+section heading, and `audit` has a matching check, but neither can see a commit
+you made outside them.
+
 **CRITICAL:** Step 5 must use `journal-coordinator` — NEVER spawn `journal-entry-writer` directly with a hardcoded space name. The coordinator discovers all relevant spaces automatically. Bypassing it silently skips spaces with actual work, including root system files.
 
 ### 0c. Inference-First Model (MANDATORY READ — supersedes the old "always prompt" rule)

--- a/.datacore/lib/tests/test_wrap_up_audit_scope.py
+++ b/.datacore/lib/tests/test_wrap_up_audit_scope.py
@@ -59,3 +59,72 @@ def test_an_unpushed_session_repo_fails(tmp_path, monkeypatch):
     repos[1]["unpushed_commits"] = 2
     own, _ = wm.session_scope_rows([str(root / "0-personal" / "org" / "inbox.org")], repos)
     assert own["ok"] is False and own["detail"] == "unpushed 0-personal: 2 commit(s)"
+
+
+# ---------------------------------------------------------------------------
+# A journal commit that LOSES a section (2026-09-08)
+# ---------------------------------------------------------------------------
+
+import subprocess  # noqa: E402
+
+
+def _repo(tmp_path, body: str) -> Path:
+    """A git repo holding one journal, committed."""
+    repo = tmp_path / "space"
+    (repo / "journal").mkdir(parents=True)
+    (repo / "journal" / "2026-09-08.md").write_text(body)
+    for cmd in (["git", "init", "-q", "."],
+                ["git", "config", "user.email", "t@t"],
+                ["git", "config", "user.name", "t"],
+                ["git", "add", "-A"],
+                ["git", "commit", "-qm", "fixture"]):
+        subprocess.run(cmd, cwd=repo, check=True, capture_output=True)
+    return repo
+
+
+TWO_SECTIONS = (
+    "# 2026-09-08\n\n"
+    "## @someone-else — their session\n\n- their line\n\n"
+    "## @me — my session\n\n- my line\n"
+)
+
+
+class TestJournalSectionLoss:
+    """`audit` scored 6/6 through a commit that deleted 269 lines of four
+    unrelated sessions' entries, because every check it had asks whether a
+    commit exists and reached the remote, never what it contained."""
+
+    def test_losing_someone_elses_section_is_caught(self, tmp_path):
+        repo = _repo(tmp_path, TWO_SECTIONS)
+        j = repo / "journal" / "2026-09-08.md"
+        j.write_text("# 2026-09-08\n\n## @me — my session\n\n- my line\n")
+
+        lost = wm.headings_lost_in_worktree(repo, ["journal/2026-09-08.md"])
+        assert len(lost) == 1
+        assert "@someone-else" in lost[0]
+
+    def test_appending_your_own_entry_is_silent(self, tmp_path):
+        """The common case must not fire, or the check gets switched off."""
+        repo = _repo(tmp_path, TWO_SECTIONS)
+        j = repo / "journal" / "2026-09-08.md"
+        j.write_text(j.read_text() + "\n## @me — second session\n\n- another line\n")
+
+        assert wm.headings_lost_in_worktree(repo, ["journal/2026-09-08.md"]) == []
+
+    def test_rewriting_a_section_in_place_is_silent(self, tmp_path):
+        """The briefing splice replaces its own block every morning. Scoring
+        that as destruction would make this fire daily and be disabled."""
+        repo = _repo(tmp_path, "# d\n\n## Daily Briefing\n\n- old text\n")
+        j = repo / "journal" / "2026-09-08.md"
+        j.write_text("# d\n\n## Daily Briefing\n\n- fresh text\n")
+
+        assert wm.headings_lost_in_worktree(repo, ["journal/2026-09-08.md"]) == []
+
+    def test_non_journal_paths_are_not_inspected(self, tmp_path):
+        repo = _repo(tmp_path, TWO_SECTIONS)
+        (repo / "notes.md").write_text("## a\n")
+        subprocess.run(["git", "add", "-A"], cwd=repo, check=True, capture_output=True)
+        subprocess.run(["git", "commit", "-qm", "n"], cwd=repo, check=True, capture_output=True)
+        (repo / "notes.md").write_text("")
+
+        assert wm.headings_lost_in_worktree(repo, ["notes.md"]) == []

--- a/.datacore/lib/wrap_up_mechanics.py
+++ b/.datacore/lib/wrap_up_mechanics.py
@@ -446,6 +446,21 @@ def finalize_session_scope(dry_run: bool) -> dict:
         _, ahead, _ = _run(["git", "rev-list", "--count", "@{u}..HEAD"], cwd=repo, timeout=30)
         entry["preexisting_unpushed_commits"] = int(ahead) if ahead.isdigit() else 0
 
+        # REFUSE TO COMMIT A JOURNAL THAT LOST A SECTION. Checked before the
+        # commit, not after: once it is pushed the damage is on the shared
+        # remote and every other machine pulls it.
+        lost_here = headings_lost_in_worktree(repo, staged)
+        if lost_here:
+            entry["ok"] = False
+            entry["note"] = ("REFUSED — a journal in this commit would LOSE content: "
+                             + "; ".join(lost_here)
+                             + ". A journal is append-only: your entry is an addition, and "
+                             "no other session's section may disappear. If a writer subagent "
+                             "is still running, wait for it. To recover the file: "
+                             "git checkout -- <path>. Override only after diffing it yourself.")
+            results.append(entry)
+            continue
+
         if dry_run:
             entry["ok"] = None
             entry["note"] = "dry run — would stage, commit and push the listed files only"
@@ -507,6 +522,37 @@ def finalize_session_scope(dry_run: bool) -> dict:
                              "changes exist on this machine only and no push will "
                              "carry them" if unversioned else None),
     }
+
+
+def headings_lost_in_worktree(repo: Path, rel_paths: list[str]) -> list[str]:
+    """Journal paths whose pending change DELETES a section heading.
+
+    Same signal as `journal_sections_lost`, asked one step earlier: before the
+    commit rather than after it. A journal is append-only by convention, so a
+    heading that is removed and not re-added means a whole section stopped
+    existing -- someone else's session entry, usually.
+
+    This is the guard for the 2026-09-08 loss. The main session ran
+    `git add <journal> && git commit && git push` while a writer subagent was
+    still working, staging a mid-write tree without ever diffing it. Nothing
+    between the write and the remote asked what was in the file.
+    """
+    journals = [r for r in rel_paths
+                if "/journal/" in f"/{r}" or "/notes/journals/" in f"/{r}"]
+    lost: list[str] = []
+    for rel in journals:
+        rc, diff, _ = _run(["git", "diff", "HEAD", "--unified=0", "--", rel],
+                           cwd=repo, timeout=60, strip=False)
+        if rc != 0 or not diff:
+            continue
+        removed = [ln[1:].strip() for ln in diff.splitlines()
+                   if ln.startswith("-#") and not ln.startswith("---")]
+        added = {ln[1:].strip() for ln in diff.splitlines()
+                 if ln.startswith("+#") and not ln.startswith("+++")}
+        gone = [h for h in removed if h not in added]
+        if gone:
+            lost.append(f"{rel}: {len(gone)} heading(s) removed — {'; '.join(gone[:3])}")
+    return lost
 
 
 def cmd_finalize(dry_run: bool, scope: str = "session") -> dict:
@@ -589,6 +635,57 @@ def session_scope_rows(mine: list[str], repos: list[dict]) -> tuple[dict, str]:
     return {"ok": ok, "detail": detail}, others
 
 
+def journal_sections_lost() -> list[str]:
+    """Today's commits that DELETED a section heading from a journal.
+
+    WHY THIS EXISTS. On 2026-09-08 a wrap-up committed and pushed a journal
+    that had lost 269 lines -- four unrelated sessions' entries -- and this
+    audit still passed 6/6. Every check it had asks whether a commit exists
+    and reached the remote. None asks what the commit CONTAINED, so a
+    destructive commit is indistinguishable from a correct one.
+
+    Journals are append-only by convention: a session adds its own entry and
+    leaves every other session's alone. So the signal is not "lines were
+    removed" -- a reformat or a typo fix removes lines -- it is "a `## ` or
+    `### ` heading was removed", which means a whole section stopped existing.
+    That keeps the check quiet on ordinary edits and loud on the one thing
+    that actually destroys someone else's work.
+
+    Reports rather than judges intent: a deliberate repair also deletes
+    headings, and the point is that a human looks.
+    """
+    today = date.today().isoformat()
+    paths = [f"*journal/{today}.md", f"*notes/journals/{today}.md"]
+    out: list[str] = []
+    repos = [DATACORE_ROOT] + [s_ for s_ in spaces() if (s_ / ".git").exists()]
+    for repo in repos:
+        rc, shas, _ = _run(["git", "log", "--since=midnight", "--format=%H", "--"]
+                           + paths, cwd=repo)
+        if rc != 0 or not shas:
+            continue
+        for sha in shas.splitlines():
+            sha = sha.strip()
+            if not sha:
+                continue
+            rc2, diff, _ = _run(["git", "show", "--unified=0", "--format=", sha,
+                                 "--"] + paths, cwd=repo, strip=False)
+            if rc2 != 0:
+                continue
+            removed = [ln[1:].strip() for ln in diff.splitlines()
+                       if ln.startswith("-#") and not ln.startswith("---")]
+            added = {ln[1:].strip() for ln in diff.splitlines()
+                     if ln.startswith("+#") and not ln.startswith("+++")}
+            # Removed AND re-added is a rewrite in place, not a loss. The
+            # briefing splice replaces its own `## Daily Briefing` block on
+            # every run; scoring that as destruction would make this check
+            # fire every morning and be switched off within a week.
+            lost = [h for h in removed if h not in added]
+            if lost:
+                out.append(f"{repo.name} {sha[:8]} removed "
+                           f"{len(lost)} heading(s): {'; '.join(lost[:3])}")
+    return out
+
+
 def cmd_audit() -> dict:
     today = date.today().isoformat()
     checks = []
@@ -625,6 +722,10 @@ def cmd_audit() -> dict:
     else:
         check("session work committed and pushed", own["ok"], own["detail"])
     check("other sessions' work left alone", True, others)
+
+    lost = journal_sections_lost()
+    check("no journal section destroyed today", not lost,
+          "; ".join(lost) if lost else "today's journal commits only added sections")
 
     cs = context_sync_check()
     check("context in sync", not cs["registry_changed"], cs["action"])


### PR DESCRIPTION
On 2026-09-08 a `5-plur` journal lost 269 lines — four unrelated sessions' entries — and the loss was pushed to the shared remote. The reported cause was a main session running `git add journal/... && git commit && git push` while a writer subagent was still mid-file. Whether `journal-entry-writer` **also** does a destructive whole-file write was a hypothesis, so it was tested before anything changed.

## It does not reproduce

Two runs of the writer against multi-section journals, the second matching the shape of the damaged file:

| fixture | result |
|---|---|
| 97 lines, 7 sections | 41 insertions, 0 deletions, 0 headings lost |
| 422 lines, 18 sections, 65 subsections | 29 insertions, 0 deletions, 0 headings lost |

Both appended. Neither rewrote the file. **The writer is not the known cause.**

Two clean runs are evidence about what a small model usually does, not proof of what it cannot do, and the spec left a whole-file `Write` one tool call away. Both halves are fixed anyway.

## The writer

`tools:` now omits `Write` entirely. Creating and appending both use a heredoc, which cannot shorten a file. The Standup upsert — the one step that genuinely merges into existing content — is an `Edit` anchored on the smallest unique string, never a reproduction of the surrounding sections. A mandatory final step asserts `git diff --numstat` shows `deletions == 0` and that no heading disappeared, restoring the file and reporting failure if either is false.

Re-running the same 422-line reproduction against the fixed spec: **30 insertions, 0 deletions, 0 lost.**

## The committing side, where the damage provably came from

- `finalize` refuses to commit when a staged journal loses a section heading, and says how to recover the file.
- `audit` gained a matching check over today's commits. It scored 6/6 through the original loss because every check it had asks whether a commit exists and reached the remote, never what it contained.

Both ignore a heading that is removed *and* re-added, so the morning briefing splice does not trip them. Four regression tests cover loss, plain appends, in-place rewrites, and non-journal paths.

## It immediately found a second loss

Running the new audit check over today surfaced `0-personal` `08243a13`, titled "restore the hook-required wrap-up sections", which removed a whole session block and its nine subsections while adding fourteen lines. **Still unrepaired** — flagged for the owner, not touched here, because another session holds that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)