### PR TITLE
jobs: name the live manifest.py, not the deleted duplicate

### DIFF
--- a/.datacore/lib/jobs/manifest.yaml
+++ b/.datacore/lib/jobs/manifest.yaml
@@ -22,7 +22,7 @@
 #   - modules/mail/server/triage-email.sh (email triage state paths)
 #   - modules/github/server/triage-github.sh (github triage cache paths)
 #   - modules/nightshift/server/nightshift-*.{service,timer} (six target timers: exact OnCalendar + ExecStart)
-#   - modules/nightshift/manifest.py + lib/postprocess.py + lib/run.py (nightshift-overnight's manifest-{today}.yaml, traced end to end)
+#   - modules/nightshift/lib/manifest.py + lib/postprocess.py + lib/run.py (nightshift-overnight's manifest-{today}.yaml, traced end to end)
 #   - modules/outbox/lib/archive_sync.py (nightshift-outbox: stdout-only JSON, no persisted file found)
 #   - modules/nightshift/lib/today_orchestrator.py (market-phase* freshness glob, reader side only)
 #   - modules/nightshift/CLAUDE.md ("Output Location" + service unit Descriptions for inbox-process)


### PR DESCRIPTION
The producer comment pointed at `modules/nightshift/manifest.py`. That copy was one of twenty root-level duplicates removed in datacore-nightshift#16; the live file has always been `lib/manifest.py`, which the same line already names for `postprocess` and `run`.

A comment that sends a reader to a file that no longer exists is worse than no comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)