### PR TITLE
wrap-up: stop §8 committing journals a subagent is still writing

### DIFF
--- a/.datacore/commands/wrap-up.md
+++ b/.datacore/commands/wrap-up.md
@@ -604,7 +604,24 @@ Session archived: .datacore/state/sessions/archive/YYYY-MM-DD/<id>/ ✓
 
 **No "additional insights" prompt.** If the user wants to force a specific insight into memory now rather than waiting for the sweep, they say so via §0e bulk feedback: *"also capture: the rebase-on-fork pattern for stale dependency PRs"* — call `plur_learn` on it directly in the same pass.
 
-> **Parallel execution:** While the coordinator runs in background, immediately proceed to steps 7-9. Those work from conversation context and do not depend on its output. Nothing in this command now blocks on a learning agent.
+> **Parallel execution — §7 ONLY.** While the coordinator runs in background you
+> may proceed to step 7, which works from conversation context alone.
+>
+> **§8 and §9 MUST WAIT for the coordinator to return.** They are not independent
+> of it: §8 (`finalize`) commits the paths in the session archive's
+> `files_modified`, and the journals the coordinator is writing are *precisely*
+> those paths — scoping to the session does not avoid the race, it guarantees it.
+> §9 (`audit`) then asserts "personal journal written" and "session work
+> committed and pushed", both of which are claims about the coordinator's output.
+>
+> Reproduced 2026-09-08: with a writer mid-file, finalize committed a 7-line
+> journal that had 16 lines and 3 sections at rest, kept 1 section, and reported
+> ok=true. This paragraph used to say "immediately proceed to steps 7-9", and on
+> the one run that day which avoided the race, it did so only because the agent
+> disobeyed this line. A spec whose safe execution requires ignoring it is the bug.
+>
+> `finalize` now refuses such a commit on its own, so this is defence in depth,
+> not the only guard. Do not "optimize" the wait back out.
 
 ### 6. Tasks & Delegation (paired — one decision, two destinations)
 

--- a/.datacore/lib/tests/test_wrap_up_audit_scope.py
+++ b/.datacore/lib/tests/test_wrap_up_audit_scope.py
@@ -99,7 +99,7 @@ class TestJournalSectionLoss:
         j = repo / "journal" / "2026-09-08.md"
         j.write_text("# 2026-09-08\n\n## @me — my session\n\n- my line\n")
 
-        lost = wm.headings_lost_in_worktree(repo, ["journal/2026-09-08.md"])
+        lost = wm.journal_damage_in_worktree(repo, ["journal/2026-09-08.md"])
         assert len(lost) == 1
         assert "@someone-else" in lost[0]
 
@@ -109,7 +109,7 @@ class TestJournalSectionLoss:
         j = repo / "journal" / "2026-09-08.md"
         j.write_text(j.read_text() + "\n## @me — second session\n\n- another line\n")
 
-        assert wm.headings_lost_in_worktree(repo, ["journal/2026-09-08.md"]) == []
+        assert wm.journal_damage_in_worktree(repo, ["journal/2026-09-08.md"]) == []
 
     def test_rewriting_a_section_in_place_is_silent(self, tmp_path):
         """The briefing splice replaces its own block every morning. Scoring
@@ -118,7 +118,7 @@ class TestJournalSectionLoss:
         j = repo / "journal" / "2026-09-08.md"
         j.write_text("# d\n\n## Daily Briefing\n\n- fresh text\n")
 
-        assert wm.headings_lost_in_worktree(repo, ["journal/2026-09-08.md"]) == []
+        assert wm.journal_damage_in_worktree(repo, ["journal/2026-09-08.md"]) == []
 
     def test_non_journal_paths_are_not_inspected(self, tmp_path):
         repo = _repo(tmp_path, TWO_SECTIONS)
@@ -127,4 +127,27 @@ class TestJournalSectionLoss:
         subprocess.run(["git", "commit", "-qm", "n"], cwd=repo, check=True, capture_output=True)
         (repo / "notes.md").write_text("")
 
-        assert wm.headings_lost_in_worktree(repo, ["notes.md"]) == []
+        assert wm.journal_damage_in_worktree(repo, ["notes.md"]) == []
+
+    def test_body_only_shrink_is_caught_too(self, tmp_path):
+        """A write caught mid-file can drop body lines with every heading still
+        standing. Measured 2026-09-08: +0/-4, all headings intact, and the
+        heading check alone said nothing."""
+        repo = _repo(tmp_path, "# d\n\n## @a - one\n\n- a1\n- a2\n- a3\n\n## @b - two\n\n- b1\n- b2\n")
+        j = repo / "journal" / "2026-09-08.md"
+        j.write_text("# d\n\n## @a - one\n\n- a1\n\n## @b - two\n\n- b1\n")
+
+        dmg = wm.journal_damage_in_worktree(repo, ["journal/2026-09-08.md"])
+        assert len(dmg) == 1
+        assert "net loss" in dmg[0]
+
+    def test_the_real_2026_09_08_appends_still_commit(self, tmp_path):
+        """Regression bar: the two journal writes that were CORRECT that day
+        were +26/-0 (5-plur) and +97/-0 (0-personal). Neither may start
+        failing, or the guard costs more than it saves."""
+        for added in (26, 97):
+            repo = _repo(tmp_path / f"n{added}", TWO_SECTIONS)
+            j = repo / "journal" / "2026-09-08.md"
+            j.write_text(j.read_text() + "\n## @me - new entry\n\n"
+                         + "".join(f"- line {i}\n" for i in range(added - 2)))
+            assert wm.journal_damage_in_worktree(repo, ["journal/2026-09-08.md"]) == []

--- a/.datacore/lib/wrap_up_mechanics.py
+++ b/.datacore/lib/wrap_up_mechanics.py
@@ -350,7 +350,7 @@ def _default_branch_ok(repo: Path) -> tuple[bool, str]:
     return False, branch
 
 
-def finalize_session_scope(dry_run: bool) -> dict:
+def finalize_session_scope(dry_run: bool, allow_journal_shrink: bool = False) -> dict:
     """Commit and push ONLY what this session touched.
 
     `./sync push` stages everything with `git add --ignore-removal .` and
@@ -449,15 +449,17 @@ def finalize_session_scope(dry_run: bool) -> dict:
         # REFUSE TO COMMIT A JOURNAL THAT LOST A SECTION. Checked before the
         # commit, not after: once it is pushed the damage is on the shared
         # remote and every other machine pulls it.
-        lost_here = headings_lost_in_worktree(repo, staged)
+        lost_here = [] if allow_journal_shrink else journal_damage_in_worktree(repo, staged)
         if lost_here:
             entry["ok"] = False
             entry["note"] = ("REFUSED — a journal in this commit would LOSE content: "
                              + "; ".join(lost_here)
                              + ". A journal is append-only: your entry is an addition, and "
                              "no other session's section may disappear. If a writer subagent "
-                             "is still running, wait for it. To recover the file: "
-                             "git checkout -- <path>. Override only after diffing it yourself.")
+                             "is still running, wait for it — /wrap-up §8 must not run "
+                             "until §5's coordinator has returned. To recover the file: "
+                             "git checkout -- <path>. To commit anyway, having diffed it "
+                             "yourself: finalize --allow-journal-shrink.")
             results.append(entry)
             continue
 
@@ -524,7 +526,7 @@ def finalize_session_scope(dry_run: bool) -> dict:
     }
 
 
-def headings_lost_in_worktree(repo: Path, rel_paths: list[str]) -> list[str]:
+def journal_damage_in_worktree(repo: Path, rel_paths: list[str]) -> list[str]:
     """Journal paths whose pending change DELETES a section heading.
 
     Same signal as `journal_sections_lost`, asked one step earlier: before the
@@ -552,12 +554,31 @@ def headings_lost_in_worktree(repo: Path, rel_paths: list[str]) -> list[str]:
         gone = [h for h in removed if h not in added]
         if gone:
             lost.append(f"{rel}: {len(gone)} heading(s) removed — {'; '.join(gone[:3])}")
+            continue
+
+        # SHRINKING IS DAMAGE TOO. A heading check alone misses a write caught
+        # mid-file that drops body lines while leaving every heading standing:
+        # measured 2026-09-08, a journal going 0 insertions / 4 deletions with
+        # all headings intact passed the heading check untouched. Journals are
+        # append-only by convention, so a net loss of lines is not an ordinary
+        # edit -- it is either a mid-write commit or a rewrite, and both want a
+        # human to look before they reach the shared remote.
+        rc3, stat, _ = _run(["git", "diff", "HEAD", "--numstat", "--", rel],
+                            cwd=repo, timeout=60)
+        if rc3 == 0 and stat:
+            parts = stat.split("\t")
+            if len(parts) >= 2 and parts[0].isdigit() and parts[1].isdigit():
+                ins, dele = int(parts[0]), int(parts[1])
+                if dele > ins:
+                    lost.append(f"{rel}: net loss of {dele - ins} line(s) "
+                                f"(+{ins}/-{dele}) with no heading removed")
     return lost
 
 
-def cmd_finalize(dry_run: bool, scope: str = "session") -> dict:
+def cmd_finalize(dry_run: bool, scope: str = "session",
+                 allow_journal_shrink: bool = False) -> dict:
     if scope == "session":
-        out = finalize_session_scope(dry_run)
+        out = finalize_session_scope(dry_run, allow_journal_shrink)
     else:
         # `./sync push` is retired (datacore#21/#28/#31/#39): the transport
         # converges every registered knowledge repo and fast-forwards code
@@ -744,6 +765,11 @@ def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__.split("\n")[1])
     ap.add_argument("step", choices=["preflight", "meta", "finalize", "audit"])
     ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--allow-journal-shrink", action="store_true",
+                    help="finalize only: commit a journal that loses lines or a section "
+                         "anyway. The refusal exists because /wrap-up §8 can run while a "
+                         "journal writer is mid-file; pass this only after diffing the "
+                         "file yourself and confirming the loss is intended.")
     ap.add_argument("--scope", choices=["session", "all"], default="session",
                     help="finalize only: 'session' commits just this session's files "
                          "(default); 'all' delegates to ./sync push, which stages "
@@ -755,7 +781,7 @@ def main() -> int:
     elif args.step == "meta":
         result = cmd_meta()
     elif args.step == "finalize":
-        result = cmd_finalize(args.dry_run, args.scope)
+        result = cmd_finalize(args.dry_run, args.scope, args.allow_journal_shrink)
     else:
         result = cmd_audit()
 


### PR DESCRIPTION
## Reproduced first, against the live checkout

| | |
|---|---|
| journal at rest | 16 lines, 3 sections |
| on disk when finalize ran | 7 lines (writer mid-file) |
| finalize | **ok=true**, staged and pushed |
| committed file | 7 lines, 1 section — **content lost** |

## Spec

`wrap-up.md` said "While the coordinator runs in background, immediately proceed to steps 7-9". §8 is `finalize`, which commits the paths in the session archive's `files_modified` — and the journals §5's coordinator is writing **are** those paths. Scoping to the session does not avoid the race, it guarantees it. §9 then asserts "personal journal written" and "session work committed and pushed", both claims about output that has not arrived.

§7 may still run in parallel. §8 and §9 now wait, and the paragraph says why so the next editor does not optimise it back out.

## Mechanics

The heading guard shipped in #166 catches the destructive shape, and the reproduction above now refuses with the file intact. It did **not** catch a mid-write that drops body lines while every heading still stands — measured, `+0/-4` with all headings present passed it untouched.

Journals are append-only by convention, so a net loss of lines is itself the signal. `journal_damage_in_worktree` (renamed from `headings_lost_in_worktree`, since it now reports two kinds of damage) refuses that too. `finalize --allow-journal-shrink` is the deliberate override for a loss you have diffed and intend.

## Verification

1. Reproduced on the live version: content lost, `ok=true`.
2. Fixed.
3. Same reproduction: `ok=false`, legible refusal, committed file 16 lines / 3 sections intact.
4. Regression, from the day's real writes: the two **correct** journal commits were `+26/-0` and `+97/-0`. Both still commit, and a test names them.

Suite: 159 passed. The 2 failures are `test_jobs_grounded` worktree path-resolution artifacts that fail identically on `main` in a worktree and pass in the primary checkout.

## Constraints honoured

The four output buckets are untouched — "nothing to push" and "I left 4 files behind" stay distinguishable. A refusal is always reported, never swallowed.

Out of scope, still open: `audit`'s "session work committed and pushed" asks only whether a commit exists and reached the remote. It scored 6/6 through the loss that started this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)