### PR TITLE
nightshift: nightshift/2026-09-08 (1 commits)

### DIFF
--- a/.datacore/lib/ledger_ingest_org.py
+++ b/.datacore/lib/ledger_ingest_org.py
@@ -300,7 +300,15 @@ def sync_state(space: Path, actor: str | None = None, dry_run: bool = False) -> 
         cur_org = cur.get("org") if isinstance(cur.get("org"), dict) else {}
         props_now = {k: str(v) for k, v in (node.properties or {}).items() if k not in ("ID", "CREATED")}
         prio_now = getattr(node, "priority", None) or None
-        if props_now != {k: str(v) for k, v in (cur_org.get("properties") or {}).items()} or prio_now != (cur_org.get("priority") or None):
+        # "org" not in cur: item was created without the org block (e.g. via
+        # the adapter CLI). Without this clause, genesis never fills the gap
+        # for headings with no properties and no priority -- they always match
+        # the empty defaults and the condition never fires, leaving the item
+        # permanently without an org block. ledger_claim.py uses org-block
+        # presence to distinguish org-mirrored tasks from delegation items;
+        # a missing block makes the claim filter treat an org task as a
+        # delegation item and agents claim it unattended. See datacore#161.
+        if "org" not in cur or props_now != {k: str(v) for k, v in (cur_org.get("properties") or {}).items()} or prio_now != (cur_org.get("priority") or None):
             want["org"] = {**cur_org, "priority": prio_now, "properties": props_now}
         diff = {k: v for k, v in want.items() if (cur.get(k) or None) != v}
         if not diff:

--- a/.datacore/lib/tests/test_ledger_ingest_org.py
+++ b/.datacore/lib/tests/test_ledger_ingest_org.py
@@ -299,6 +299,25 @@ def test_terminal_kinds_match_the_ratified_loop():
     assert ingest.TERMINAL_KINDS == {"DONE": "done", "CANCELLED": "dropped"}
 
 
+def test_org_block_added_to_adapter_created_item(space):
+    """An item created without an org block (e.g. via the adapter CLI) gets
+    the org block filled in by sync_state even when the heading has no
+    properties and no priority.
+
+    Without this, ledger_claim.py's org-mirror filter would treat the item as
+    a delegation item (no org block = not a mirror) and agents would claim it
+    unattended. See datacore#161."""
+    ingest.sync_state(space, actor="test")
+    item = _items(space)["task-next"]
+    # item was created with just {id, title} — no org key in payload
+    assert "org" in item.payload, "org block must be added even when empty"
+    assert isinstance(item.payload["org"], dict)
+    # settles: a second pass emits nothing new
+    before = len(list(read_events(space)))
+    ingest.sync_state(space, actor="test")
+    assert len(list(read_events(space))) == before
+
+
 def test_a_property_set_in_org_reaches_the_ledger_and_the_projection(space):
     """SURFACE, DONE_WHEN and JOB live in the drawer. Before 2026-09-06 the
     drawer never moved after creation, so a Phase 1 projection put the old


### PR DESCRIPTION
Automated nightshift run on `nightshift/2026-09-08`.

Done: 3 · Review: 2 · Failed: 0 · Duration: 4436s

Opened by the PR-flow (datacore#40) — main was never committed to directly.