### PR TITLE
ledger: refuse to project over content the ledger has never seen

### DIFF
--- a/.datacore/lib/jobs/manifest.yaml
+++ b/.datacore/lib/jobs/manifest.yaml
@@ -282,6 +282,75 @@ jobs:
         arg: "0 space\\(s\\) failed"
         max_age_hours: 26
 
+  # ── Phase 1 cycle (DIP-0046) ───────────────────────────────────────────
+  # THE ONLY UNVERIFIED STEP IN THE LEDGER LOOP UNTIL 2026-09-09. This cycle
+  # ingests org edits into the ledger and regenerates next_actions.org, hourly,
+  # on every host. It appeared in NO manifest entry, so nothing ever checked
+  # that it ran or that it succeeded -- and it could not have reported failure
+  # anyway: the script piped the projector into `grep` and read `$?` from grep,
+  # printing `project rc=0` unconditionally. A projection crash exited 0.
+  #
+  # Verified per host rather than once, because the hosts do not agree: hermes
+  # ran the same cycle against clones named `2-plur`/`3-firm`, the projector
+  # scopes by directory name, and it therefore projected 6 lines where mac
+  # projected 12,956 -- after which the orphan sweep dismissed the missing
+  # items INTO THE SHARED LEDGER. 25 such dismissals are on record. Hermes's
+  # cron is disabled pending a rename and is deliberately absent here: a
+  # contract for a job that must not run would fail forever.
+  - name: mac-phase1-cycle
+    machine: mac
+    schedule: "cron 25 * * * * on mac"
+    cmd: "~/Data/.datacore/lib/ledger_phase1_cycle.sh"   # mac
+    on_fail: telegram
+    artifacts:
+      - path: "~/.datacore/state/phase1-cycle-status.txt"
+        check: regex
+        # `^OK ` and nothing looser. The script writes FAIL with the rc when any
+        # converge, ingest or projection step fails, and a REFUSED projection is
+        # a failure: refusing means the org file holds work the ledger has never
+        # seen, which is the one state this loop must never paper over.
+        arg: "^OK phase1-cycle"
+        # Hourly job. 3h tolerates a missed run and a slow one; a laptop asleep
+        # for longer than that has genuinely stopped ingesting, and saying so is
+        # the point.
+        max_age_hours: 3
+
+  - name: box-phase1-cycle
+    machine: box
+    schedule: "cron 25 * * * * on winston"
+    cmd: "~/Data/.datacore/lib/ledger_phase1_cycle.sh"   # winston
+    on_fail: telegram
+    artifacts:
+      - path: "~/.datacore/state/phase1-cycle-status.txt"
+        check: regex
+        # `^OK ` and nothing looser. The script writes FAIL with the rc when any
+        # converge, ingest or projection step fails, and a REFUSED projection is
+        # a failure: refusing means the org file holds work the ledger has never
+        # seen, which is the one state this loop must never paper over.
+        arg: "^OK phase1-cycle"
+        # Hourly job. 3h tolerates a missed run and a slow one; a laptop asleep
+        # for longer than that has genuinely stopped ingesting, and saying so is
+        # the point.
+        max_age_hours: 3
+
+  - name: nightshift-phase1-cycle
+    machine: nightshift
+    schedule: "cron 25 * * * * on nightshift"
+    cmd: "~/Data/.datacore/lib/ledger_phase1_cycle.sh"   # nightshift
+    on_fail: telegram
+    artifacts:
+      - path: "~/.datacore/state/phase1-cycle-status.txt"
+        check: regex
+        # `^OK ` and nothing looser. The script writes FAIL with the rc when any
+        # converge, ingest or projection step fails, and a REFUSED projection is
+        # a failure: refusing means the org file holds work the ledger has never
+        # seen, which is the one state this loop must never paper over.
+        arg: "^OK phase1-cycle"
+        # Hourly job. 3h tolerates a missed run and a slow one; a laptop asleep
+        # for longer than that has genuinely stopped ingesting, and saying so is
+        # the point.
+        max_age_hours: 3
+
   - name: box-cadence-liveness
     machine: box
     # THE CATCHER NEEDS A CATCHER. cadence_engine has computed overdue

--- a/.datacore/lib/ledger_phase1_cycle.sh
+++ b/.datacore/lib/ledger_phase1_cycle.sh
@@ -36,5 +36,23 @@ rc=0
 for s in $PHASE1; do
   "$PY" "$LIB/ledger_transport.py" converge --space "$s" > "$STATE/phase1-converge-$s.log" 2>&1 || { echo "converge $s: $(grep -o '"reason": "[^"]*"' "$STATE/phase1-converge-$s.log" | head -1)"; rc=1; }
 done
-"$PY" "$LIB/ledger_project_org.py" --all 2>&1 | grep -v "authored" ; echo "project rc=$?"
+# `... | grep -v authored ; echo "rc=$?"` read GREP's status, not the
+# projector's, so this printed `project rc=0` unconditionally -- a projection
+# crash, and every REFUSED line, exited 0 and alerted nobody. PIPESTATUS[0] is
+# the projector's own status, and it now feeds the script's exit code.
+"$PY" "$LIB/ledger_project_org.py" --all 2>&1 | grep -v "authored"
+prc=${PIPESTATUS[0]}
+echo "project rc=$prc"
+[ "$prc" -eq 0 ] || rc=$prc
+
+# One truncated line a job contract can assert on. Without it this cycle is the
+# only unverified step in the Phase 1 loop: it appears in no jobs/manifest.yaml
+# entry, so nothing has ever checked that it ran, let alone that it succeeded.
+if [ "$rc" -eq 0 ]; then
+  echo "OK phase1-cycle $(date -u +%Y-%m-%dT%H:%M:%SZ) spaces=$(echo $PHASE1 | wc -w | tr -d ' ')" \
+    > "$STATE/phase1-cycle-status.txt"
+else
+  echo "FAIL phase1-cycle $(date -u +%Y-%m-%dT%H:%M:%SZ) rc=$rc" \
+    > "$STATE/phase1-cycle-status.txt"
+fi
 exit $rc

--- a/.datacore/lib/ledger_project_org.py
+++ b/.datacore/lib/ledger_project_org.py
@@ -23,6 +23,7 @@ LIB = Path(__file__).resolve().parent
 sys.path.insert(0, str(LIB))
 from ledger.fold import fold  # noqa: E402
 from ledger.log import read_events  # noqa: E402
+from ledger.genesis import scan  # noqa: E402
 from ledger.projector import project  # noqa: E402
 
 MARKER = Path(".datacore") / "ledger-phase"
@@ -72,9 +73,43 @@ def phase(space: Path) -> int:
         return 0
 
 
-def project_space(space: Path) -> str:
+def project_space(space: Path, force: bool = False) -> str:
     if phase(space) != 1:
         return "phase 0, authored — not generated"
+
+    # REFUSE TO PROJECT OVER CONTENT THE LEDGER HAS NEVER SEEN.
+    #
+    # This file's own docstring has always said "Projecting without ingesting
+    # first is how a hand edit gets lost", and nothing enforced it. DIP-0043
+    # calls the refuse-to-overwrite guard the most load-bearing mechanism in
+    # Phase 1; the guard exists as `projector.write(last_written_sha=...)` and
+    # `ledger/phase1.py` uses it, but production reached the file through a bare
+    # write and so had no guard at all. Measured 2026-09-08: only that module's
+    # own test imports it.
+    #
+    # A sha comparison is the wrong shape HERE. The hourly cycle ingests
+    # immediately before projecting, so the file legitimately differs from what
+    # the projector last wrote on every cycle where anyone edited anything, and
+    # a guard that fires every hour is a guard someone switches off.
+    #
+    # `scan()` asks the precise question instead: which headings in the org file
+    # is the ledger missing? It is the same call the ingest makes, folding the
+    # ledger once and returning only what it has never seen. After a successful
+    # ingest that set is empty and this costs nothing. When the ingest failed,
+    # skipped a heading with no :ID:, or never ran, it is exactly the content a
+    # projection would destroy.
+    try:
+        pending = list(scan(space).importable)
+    except Exception as exc:  # noqa: BLE001
+        # Never fail OPEN: if the question cannot be answered, do not overwrite.
+        if not force:
+            return f"REFUSED — cannot verify against the ledger ({type(exc).__name__}: {exc})"
+        pending = []
+    if pending and not force:
+        titles = "; ".join(str(getattr(i, "title", i))[:40] for i in pending[:3])
+        return (f"REFUSED — {len(pending)} heading(s) in {ORG} are not in the "
+                f"ledger; ingest first, then project ({titles})")
+
     text = project(fold(read_events(space)), space=space.name).text
     target = space / ORG
     text = _with_org_header(space, target, text)
@@ -91,11 +126,21 @@ def main(argv: list[str] | None = None) -> int:
     g = ap.add_mutually_exclusive_group(required=True)
     g.add_argument("--space")
     g.add_argument("--all", action="store_true")
+    ap.add_argument("--force", action="store_true",
+                    help="project even when the org file holds headings the ledger "
+                         "has never seen. This DESTROYS them. Operator override, "
+                         "never a routine run.")
     a = ap.parse_args(argv)
     spaces = [a.root / a.space] if a.space else sorted(p for p in a.root.glob("[0-9]-*") if (p / ".datacore" / "events").is_dir())
+    refused = 0
     for s in spaces:
-        print(f"  {s.name:14} {project_space(s)}")
-    return 0
+        line = project_space(s, force=a.force)
+        if line.startswith("REFUSED"):
+            refused += 1
+        print(f"  {s.name:14} {line}")
+    # Non-zero so a caller can tell. A refusal that exits 0 is the same silence
+    # this guard exists to break.
+    return 1 if refused else 0
 
 
 if __name__ == "__main__":

--- a/.datacore/lib/tests/fixtures/jobs/box-phase1-cycle.0.txt
+++ b/.datacore/lib/tests/fixtures/jobs/box-phase1-cycle.0.txt
@@ -1,0 +1,12 @@
+# fixture for box-phase1-cycle artifact[0]
+# producer artifact: ~/.datacore/state/phase1-cycle-status.txt on box
+# harvested: 2026-09-09
+# regex under test: ^OK phase1-cycle
+# represents: SUCCESS (derived)
+# The contract lands before the artifact can exist: this host has not yet
+# run the fixed ledger_phase1_cycle.sh, so there is nothing to harvest.
+# Derived from mac's REAL harvested output, which every host produces from
+# the same script and the same line. Replace with a real harvest
+# (`fixtures.py --harvest --force`) once the script has run on box.
+# ---
+OK phase1-cycle 2026-09-08T22:08:14Z spaces=10

--- a/.datacore/lib/tests/fixtures/jobs/mac-phase1-cycle.0.txt
+++ b/.datacore/lib/tests/fixtures/jobs/mac-phase1-cycle.0.txt
@@ -1,0 +1,7 @@
+# fixture for mac-phase1-cycle artifact[0]
+# producer artifact: ~/.datacore/state/phase1-cycle-status.txt on mac
+# harvested: 2026-09-09
+# regex under test: ^OK phase1-cycle
+# represents: SUCCESS
+# ---
+OK phase1-cycle 2026-09-08T22:08:14Z spaces=10

--- a/.datacore/lib/tests/fixtures/jobs/nightshift-phase1-cycle.0.txt
+++ b/.datacore/lib/tests/fixtures/jobs/nightshift-phase1-cycle.0.txt
@@ -1,0 +1,12 @@
+# fixture for nightshift-phase1-cycle artifact[0]
+# producer artifact: ~/.datacore/state/phase1-cycle-status.txt on nightshift
+# harvested: 2026-09-09
+# regex under test: ^OK phase1-cycle
+# represents: SUCCESS (derived)
+# The contract lands before the artifact can exist: this host has not yet
+# run the fixed ledger_phase1_cycle.sh, so there is nothing to harvest.
+# Derived from mac's REAL harvested output, which every host produces from
+# the same script and the same line. Replace with a real harvest
+# (`fixtures.py --harvest --force`) once the script has run on nightshift.
+# ---
+OK phase1-cycle 2026-09-08T22:08:14Z spaces=10


### PR DESCRIPTION
Three defects in one loop, each of which made the same failure invisible.

## The projector had no guard

`ledger_project_org.py`'s own docstring has always said *"Projecting without ingesting first is how a hand edit gets lost"* — and nothing enforced it. Production reached the file through a bare `write_text` + `os.replace`.

DIP-0043 calls the refuse-to-overwrite guard the most load-bearing mechanism in Phase 1. One exists — `projector.write(last_written_sha=...)`, used by `ledger/phase1.py` — but **nothing except that module's own test imports it**. Two Phase 1 implementations; the safe one dormant.

A sha comparison is the wrong shape at this call site: the hourly cycle ingests immediately before projecting, so the file legitimately differs from the last projection on every cycle where anyone edited anything, and a guard that fires hourly is a guard someone switches off. `scan()` asks the precise question — which headings does the ledger not have? — and is the same call the ingest already makes.

Measured against all 11 live spaces: **0 un-ingested headings**, so this cannot fire in the normal case.

## The exit code was grep's

```sh
"$PY" ledger_project_org.py --all 2>&1 | grep -v "authored" ; echo "project rc=$?"
```

`$?` is grep's. `project rc=0` printed unconditionally; a projection crash exited 0. Now `PIPESTATUS[0]`, folded into the script's exit code.

## The cycle had no contract

It runs hourly on every host and appeared in **no** `jobs/manifest.yaml` entry. It now writes one status line, and three contracts assert `^OK phase1-cycle` with `max_age_hours: 3`. Hermes is deliberately absent — its cron is disabled pending a clone rename, and a contract for a job that must not run would fail forever.

## Verification

| case | result |
|---|---|
| real cycle, end to end | exit 0, `OK phase1-cycle … spaces=10`, 5-plur projects 12,956 lines |
| un-ingested heading present | `REFUSED — 1 heading(s) … are not in the ledger`, file byte-identical |
| `--force` | projects, destroying the hand-written task, as documented |
| all 11 live spaces | 0 un-ingested → no false positives |

Grounded suite: 34 passed. Ledger suite: 338 passed, 4 failed — the same 4 fail on unmodified `main`. The 2 remaining grounded failures are worktree path-resolution artifacts that pass in the primary checkout.

box/nightshift fixtures are derived from mac's real harvest and say so in-file: the contract necessarily lands before those hosts have run the fixed script. Re-harvest after rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)