### PR TITLE
phase1 cycle: the interpreter must import yaml, not just be new enough

### DIFF
--- a/.datacore/lib/ledger_phase1_cycle.sh
+++ b/.datacore/lib/ledger_phase1_cycle.sh
@@ -14,9 +14,14 @@ STATE="$HOME/.datacore/state"; mkdir -p "$STATE"
 PY=""
 for c in "${DATACORE_PYTHON:-}" python3.13 python3.12 python3.11 python3.10 /opt/homebrew/bin/python3 /usr/local/bin/python3 python3; do
   [ -n "$c" ] || continue; command -v "$c" >/dev/null 2>&1 || continue
-  "$c" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3,10) else 1)' 2>/dev/null && { PY="$c"; break; }
+  # VERSION IS NOT ENOUGH -- IT MUST ALSO IMPORT YAML. Under cron this happened
+  # to pick an interpreter with PyYAML; under launchd (2026-09-09) the same loop
+  # picked one without it and every projection died with ModuleNotFoundError
+  # while the converge steps had already succeeded. job_verify_notify.sh has
+  # tested `import yaml` alongside the version since the same failure hit it.
+  "$c" -c 'import sys, yaml; raise SystemExit(0 if sys.version_info >= (3,10) else 1)' 2>/dev/null && { PY="$c"; break; }
 done
-[ -n "$PY" ] || { echo "FATAL: no python >= 3.10"; exit 127; }
+[ -n "$PY" ] || { echo "FATAL: no python >= 3.10 that can import yaml"; exit 127; }
 cd "$DATACORE_ROOT" || exit 2
 echo "=== $(date -u '+%F %H:%MZ') phase-1 cycle ==="
 # Converge EVERY space first, Phase 1 or not: the marker that says a space is


### PR DESCRIPTION
The PY loop accepted any python3 >= 3.10. Under cron that happened to land on one with PyYAML.

Moving the Mac's cycle to launchd today — because cron drops missed runs and a laptop is closed most nights — changed PATH resolution, the loop picked an interpreter without PyYAML, and **every projection died with `ModuleNotFoundError`** while the converge steps either side of it succeeded.

`job_verify_notify.sh` has tested `import yaml` alongside the version since the same failure hit it. Same test here.

This was invisible until yesterday for the same reason as everything else in this loop: the script read `$?` from `grep`, so `project rc=0` printed regardless. With that fixed, the very first launchd run reported `FAIL rc=1` and named the traceback.

**Verified** in a launchd-like environment (`env -i`, launchd PATH): exit 0, `OK phase1-cycle`, all 10 spaces projected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)