### PR TITLE
adapter: return what the file says, and prove it survives a rebuild

### DIFF
--- a/.datacore/lib/org_workspace_adapter.py
+++ b/.datacore/lib/org_workspace_adapter.py
@@ -217,6 +217,37 @@ def _ledger_emit(file_path, event_type, payload):
     except Exception:      # noqa: BLE001 — see the note above
         return None
 
+def _observed(file_path, task_id, keys):
+    """Re-read the task FROM DISK and report what is actually there.
+
+    RETURN EVIDENCE, NOT A CLAIM (datacore#173). `{"updated": true}` asserts a
+    success the caller cannot check, and on 2026-09-08 sixteen writes each
+    reported success while five had silently reverted by morning -- schedules
+    back to their old dates, a WAITING task back at NEXT. The caller was told
+    sixteen times that work was rescheduled and could not tell which four rows
+    were real.
+
+    Returned as `observed`, alongside the existing `changes`. `changes` is what
+    was asked for; `observed` is what the file says afterwards. When they
+    disagree, the write did not take.
+    """
+    try:
+        ws = _load_ws(file_path)
+        node = ws.find_by_id(task_id)
+        if node is None:
+            return {"_error": "task not found on re-read"}
+        props = node.properties or {}
+        out = {k: props.get(k) for k in keys if k not in ("STATE", "SCHEDULED", "DEADLINE")}
+        if "STATE" in keys:
+            out["STATE"] = node.todo
+        for k in ("SCHEDULED", "DEADLINE"):
+            if k in keys:
+                out[k] = str(getattr(node, k.lower(), None) or props.get(k) or "")
+        return out
+    except Exception as exc:      # noqa: BLE001 — evidence is best-effort
+        return {"_error": f"{type(exc).__name__}: {exc}"}
+
+
 def cmd_add(args):
     """Add a new task to an org file."""
     ws = _load_ws(args.file)
@@ -429,7 +460,8 @@ def cmd_complete(args):
         "reason": "completed via org_workspace_adapter",
     })
     return {"completed": True, "heading": node.heading, "id": node.id(),
-            "ledger_actor": emitted}
+            "ledger_actor": emitted,
+            "observed": _observed(file_path, node.id(), {"STATE"})}
 
 
 # ---------------------------------------------------------------------------
@@ -993,12 +1025,14 @@ def cmd_update(args):
         _payload["org"]["state"] = node.todo
     emitted = _ledger_emit(file_path, "item.update", _payload)
 
+    _keys = set(_props) | {"STATE", "SCHEDULED", "DEADLINE"}
     return {
         "updated": True,
         "id": node.id(),
         "heading": node.heading,
         "changes": changes,
         "ledger_actor": emitted,
+        "observed": _observed(file_path, node.id(), _keys),
     }
 
 

--- a/.datacore/lib/tests/test_org_workspace_adapter.py
+++ b/.datacore/lib/tests/test_org_workspace_adapter.py
@@ -404,3 +404,49 @@ class TestEveryMutationReachesTheLedger:
         run_adapter("complete", "--file", org, "--id", tid)
         types = [e["type"] for e in self._events(space, tid)]
         assert "item.dismiss" in types, f"complete did not emit: {types}"
+
+
+class TestWritesSurviveAProjectionRebuild:
+    """datacore#173's third ask: write, force a projection rebuild, assert.
+
+    This is the check the other two cannot make. Emitting an event proves the
+    ledger heard; returning `observed` proves the file says so a millisecond
+    later. Only regenerating the projection proves the write is still there
+    tomorrow morning — which is exactly what five writes on 2026-09-08 were
+    not.
+    """
+
+    @staticmethod
+    def _phase1_space(tmp_path):
+        space = tmp_path / "5-testspace"
+        (space / ".datacore" / "events").mkdir(parents=True)
+        (space / "org").mkdir(parents=True)
+        (space / ".datacore" / "ledger-phase").write_text("1\n")
+        (space / "org" / "inbox.org").write_text("#+TITLE: Inbox\n")
+        subprocess.run(["git", "init", "-q", "."], cwd=space, capture_output=True)
+        return space
+
+    def test_an_update_survives_regenerating_next_actions(self, tmp_path):
+        space = self._phase1_space(tmp_path)
+        org = str(space / "org" / "inbox.org")
+
+        tid = run_adapter("add", "--file", org, "--allow-any-file",
+                          "--heading", "A task whose schedule must survive the night",
+                          "--state", "NEXT", "--property", "SURFACE=core")["id"]
+        run_adapter("update", "--file", org, "--id", tid,
+                    "--property", "DONE_WHEN=the projection still says so")
+
+        # Regenerate the projection from the ledger — the thing that used to
+        # erase these writes.
+        proj = ADAPTER.parent / "ledger_project_org.py"
+        r = subprocess.run(["python3", str(proj), "--space", space.name,
+                            "--root", str(tmp_path)],
+                           capture_output=True, text=True, timeout=180)
+        assert r.returncode == 0, f"projection failed: {r.stdout}{r.stderr}"
+
+        rendered = (space / "org" / "next_actions.org").read_text()
+        assert tid in rendered, "the task did not survive the rebuild"
+        assert "the projection still says so" in rendered, (
+            "DONE_WHEN was written, reported, and then erased by the rebuild — "
+            "the exact 2026-09-08 failure"
+        )


### PR DESCRIPTION
Closes the other two asks in #173. #174 made `update` and `complete` emit; these are the parts that make the emission **checkable**.

## Return evidence, not a claim

`{"updated": true}` asserts a success the caller cannot verify. On 2026-09-08 sixteen writes each reported success and **five had silently reverted by morning** — schedules back to their old dates, a WAITING task back at NEXT. The caller was told sixteen times that work was rescheduled, with no way to tell which four were real.

Both commands now also return `observed`, re-read **from disk** after the save. `changes` is what was asked for; `observed` is what the file says afterwards. When they disagree, the write did not take.

## Write, rebuild, assert

The third ask, and the only check that catches the actual failure:

- emitting proves the ledger heard it
- `observed` proves the file agreed a millisecond later
- **neither** proves the value is still there after the projector regenerates `next_actions.org` from the ledger — which is precisely what those five writes were not

The new test writes a `DONE_WHEN` through the adapter, runs `ledger_project_org.py`, and asserts the value is in the rendered file.

## Verified to fail for the right reason

With the `item.update` emit stubbed out to reproduce pre-#174 behaviour, the test fails at the `DONE_WHEN` assertion; with it restored, it passes. Adapter suite: 26 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)