### PR TITLE
jobs: the box checks its own /today registration

### DIFF
--- a/.datacore/lib/jobs/manifest.yaml
+++ b/.datacore/lib/jobs/manifest.yaml
@@ -362,6 +362,19 @@ jobs:
   # briefing.yaml is gitignored, so a bare checkout has neither and the
   # validator would pass vacuously. It now refuses to, and this is the host
   # that actually has the whole tree.
+  # THE BOX NEEDS ITS OWN CHECK. Modules are separate repos and several are
+  # unreachable from winston — `metacognition` and `health` are not git repos
+  # there, `meetings` cannot reach GitHub over https, and `comms`/`nightshift`
+  # fail ssh auth. Their wiring got to the box by scp on 2026-09-09, so a
+  # redeploy or a fresh clone silently loses it and the briefing quietly
+  # composes sections from nothing. This makes that loud.
+  - name: box-today-registration
+    machine: box
+    schedule: "cron 20 3 * * * on winston"
+    cmd: "python3 ~/Data/.datacore/lib/today_registry.py --validate"
+    exit_ok: true
+    on_fail: telegram
+
   - name: mac-today-registration
     machine: mac
     schedule: "cron 25 * * * * on mac"


### PR DESCRIPTION
The mac contract alone is not enough. Modules are separate repos and several are unreachable from winston: `metacognition` and `health` are not git repos there, `meetings` cannot reach GitHub over https, and `comms`/`nightshift` fail ssh auth. Their section wiring reached the box by **scp** on 2026-09-09, so a redeploy or a fresh clone silently loses it and the briefing composes sections from nothing — the exact failure the contract exists to prevent, one host over.

The validator already refuses to pass vacuously, so a box that has lost its module manifests fails loudly rather than reporting 13 clean sections it cannot see.

Runs 03:20, forty minutes before the 04:00 briefing, so a broken morning is announced *before* it happens rather than discovered in the page.

Grounded suite: 34 passed; the 2 failures are the known worktree path-resolution artifacts that pass in the primary checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)