### PR TITLE
jobs: the registration contracts were missing `artifacts`

### DIFF
--- a/.datacore/lib/jobs/manifest.yaml
+++ b/.datacore/lib/jobs/manifest.yaml
@@ -374,6 +374,14 @@ jobs:
     cmd: "python3 ~/Data/.datacore/lib/today_registry.py --validate"
     exit_ok: true
     on_fail: telegram
+    artifacts:
+      - path: "~/.datacore/state/today-registration.log"
+        check: regex
+        # The validator refuses to pass vacuously, so "0 problem(s)" cannot be
+        # reached by a host that lost its module manifests — it reports that it
+        # cannot verify anything instead.
+        arg: "0 problem\\(s\\)"
+        max_age_hours: 4
 
   - name: mac-today-registration
     machine: mac
@@ -381,6 +389,14 @@ jobs:
     cmd: "python3 ~/Data/.datacore/lib/today_registry.py --validate"
     exit_ok: true
     on_fail: telegram
+    artifacts:
+      - path: "~/.datacore/state/today-registration.log"
+        check: regex
+        # The validator refuses to pass vacuously, so "0 problem(s)" cannot be
+        # reached by a host that lost its module manifests — it reports that it
+        # cannot verify anything instead.
+        arg: "0 problem\\(s\\)"
+        max_age_hours: 3
 
   - name: box-cadence-liveness
     machine: box

--- a/.datacore/lib/tests/fixtures/jobs/box-today-registration.0.txt
+++ b/.datacore/lib/tests/fixtures/jobs/box-today-registration.0.txt
@@ -1,0 +1,8 @@
+# fixture for box-today-registration artifact[0]
+# producer artifact: ~/.datacore/state/today-registration.log on box
+# harvested: 2026-09-09
+# regex under test: 0 problem\(s\)
+# represents: SUCCESS
+# ---
+0 problem(s); 13 section(s), 13 registered producer(s)
+0 problem(s); 13 section(s), 13 registered producer(s)

--- a/.datacore/lib/tests/fixtures/jobs/mac-today-registration.0.txt
+++ b/.datacore/lib/tests/fixtures/jobs/mac-today-registration.0.txt
@@ -1,0 +1,7 @@
+# fixture for mac-today-registration artifact[0]
+# producer artifact: ~/.datacore/state/today-registration.log on mac
+# harvested: 2026-09-09
+# regex under test: 0 problem\(s\)
+# represents: SUCCESS
+# ---
+0 problem(s); 13 section(s), 13 registered producer(s)


### PR DESCRIPTION
My regression, and it broke verification on both hosts within the hour:

```
job_verify FAILED on mac: invalid manifest — job box-today-registration: missing required field artifacts
v2-verify.service FAILED (exit 1) on the box
```

`artifacts` is required and I shipped two entries without it, so every manifest read failed and took the whole verification pass down with it — **a contract added to catch silent breakage became the silent breakage.**

Both now assert on `~/.datacore/state/today-registration.log`, which the cron entries already write, matching `0 problem\(s\)`. That string cannot be reached by a host that has lost its module manifests: the validator refuses to pass vacuously and reports that it cannot verify anything instead.

`max_age_hours` 3 on the Mac (hourly at :25), 4 on the box (03:20 daily). Fixtures harvested from live output on both hosts.

Grounded suite: 36 passed; the 2 failures are the known worktree path-resolution artifacts that pass in the primary checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)