### PR TITLE
weekly plan: put it where something other than a human can read it

### DIFF
--- a/.datacore/commands/today.md
+++ b/.datacore/commands/today.md
@@ -339,6 +339,38 @@ This step exists because its absence was a real bug. Wrap-up §6 deferred engram
 
 ---
 
+## Step 8c: Read the week this day belongs to
+
+    python3 .datacore/lib/weekly_plan_fragment.py read
+
+The briefing has always started from tasks and the calendar, as if no week had
+been planned. On 2026-09-09 a week was planned in detail — priorities, sequencing
+thesis, metrics to move, five falsifiable predictions — and nothing read it. No
+code referenced the file, this command contained zero mentions of "weekly", and
+the fragment directory held only `health.json`.
+
+The plan is now a fragment on the same contract as health. Read it, and let it
+frame the day rather than restating it:
+
+- **Focus comes from the week's priorities**, not only from what happens to be
+  scheduled. A task nobody scheduled can still be the most important thing today
+  if the week says so.
+- **Say when the day has drifted.** If today was planned as a maker day and the
+  calendar now holds three meetings, that is worth one sentence.
+- **Check the predictions, do not repeat them.** They were frozen to be tested.
+  If one is visibly failing on Wednesday, say so on Wednesday rather than at
+  Friday's review.
+- **Report the numbers against their targets** — the metrics the week meant to
+  move, and where they stand now.
+
+**A missing plan stays visibly missing.** If the read returns nothing, say the
+week was not planned. Do not reconstruct one from the task list and present it as
+though it were the plan — that is the failure this replaces.
+
+**Note the age.** A plan written Monday is still the plan on Friday, but it is
+not news, and a briefing that forgets the difference guides Wednesday with
+Monday's assumptions after Tuesday invalidated them.
+
 ## Step 9: Compute GTD Health
 
 ```python

--- a/.datacore/lib/jobs/manifest.yaml
+++ b/.datacore/lib/jobs/manifest.yaml
@@ -1044,4 +1044,22 @@ jobs:
         arg: '0 FAIL'
         max_age_hours: 26
 
+  # Winston plans the week on Sunday morning so the principal reviews rather than
+  # starts. Before 2026-09-09 the week was planned when someone remembered, from
+  # whatever tasks happened to be scheduled — 13 of 2,979 on the day it was
+  # measured. Sunday and not Monday: Monday morning is for starting.
+  - name: box-weekly-plan
+    machine: box
+    schedule: "cron 0 7 * * 0 on winston"
+    cmd: ~/Data/.datacore/lib/cos_weekly_plan.sh
+    on_fail: telegram
+    artifacts:
+      - path: ~/.datacore/state/weekly-plan.log
+        check: regex
+        arg: "weekly-plan: draft written"
+        max_age_hours: 170
+      - path: ~/.datacore/cos/fragments/*/weekly-plan.json
+        check: exists
+        max_age_hours: 170
+
 unverified_jobs_see_comment_above: true

--- a/.datacore/lib/tests/fixtures/jobs/box-weekly-plan.0.txt
+++ b/.datacore/lib/tests/fixtures/jobs/box-weekly-plan.0.txt
@@ -1,0 +1,9 @@
+# represents: SUCCESS
+# fixture for box-weekly-plan artifact[0]
+# producer artifact: ~/.datacore/state/weekly-plan.log on box
+# harvested: 2026-09-09 (constructed from the runner's own echo lines)
+=== weekly-plan 2026-09-13T07:00:04Z ===
+sync: 38 repo(s), 0 needing a human
+registry entries (commands + module_commands): 114
+weekly-plan: draft written
+weekly-plan: done 2026-09-13T07:06:41Z

--- a/.datacore/lib/tests/test_weekly_plan_fragment.py
+++ b/.datacore/lib/tests/test_weekly_plan_fragment.py
@@ -1,0 +1,79 @@
+"""The weekly plan has to be readable by something other than a human.
+
+On 2026-09-09 a week was planned in detail and nothing read it: no code
+referenced the file, /today contained zero mentions of "weekly", and the fragment
+directory held only health.json. The plan guided nobody.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from datetime import date, timedelta
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "wpf", Path(__file__).resolve().parents[1] / "weekly_plan_fragment.py")
+wpf = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(wpf)
+
+PAYLOAD = {"week": "2026-W37", "thesis": "the fix is the multiplier",
+           "priorities": [{"what": "the raise moves", "why": "zero meetings"}],
+           "predictions": ["the benchmark will not win"],
+           "days": {date.today().isoformat(): "maker day"}}
+
+
+def _isolate(tmp_path, monkeypatch):
+    monkeypatch.setattr(wpf, "FRAGMENTS", tmp_path)
+
+
+def test_written_then_read_back(tmp_path, monkeypatch):
+    _isolate(tmp_path, monkeypatch)
+    wpf.write(PAYLOAD)
+    got = wpf.read()
+    assert got["week"] == "2026-W37"
+    assert got["_age_days"] == 0
+
+
+def test_it_follows_the_fragment_contract(tmp_path, monkeypatch):
+    """Same shape The Practice already writes, so the briefing can consume it
+    like any other fragment rather than needing a special case."""
+    _isolate(tmp_path, monkeypatch)
+    p = wpf.write(PAYLOAD)
+    doc = json.loads(p.read_text())
+    for field in ("schema_version", "composed_at", "composed_by", "date"):
+        assert field in doc, field
+    assert doc["composed_by"] == "weekly-plan"
+    assert p.name == "weekly-plan.json"
+
+
+def test_a_plan_written_monday_is_found_on_friday(tmp_path, monkeypatch):
+    """Written once a week, read every day — the whole point."""
+    _isolate(tmp_path, monkeypatch)
+    monday = date.today() - timedelta(days=4)
+    wpf.write(PAYLOAD, monday)
+    got = wpf.read()
+    assert got is not None and got["_age_days"] == 4
+    assert not got["_expired"]
+
+
+def test_a_plan_older_than_the_week_it_planned_is_not_returned(tmp_path, monkeypatch):
+    _isolate(tmp_path, monkeypatch)
+    wpf.write(PAYLOAD, date.today() - timedelta(days=9))
+    assert wpf.read() is None
+
+
+def test_no_plan_returns_none_rather_than_inventing_one(tmp_path, monkeypatch):
+    """A missing plan must stay visibly missing. The failure this replaces was a
+    briefing filling the gap from the task list and calling it a plan."""
+    _isolate(tmp_path, monkeypatch)
+    assert wpf.read() is None
+
+
+def test_the_render_carries_what_a_briefing_needs(tmp_path, monkeypatch):
+    _isolate(tmp_path, monkeypatch)
+    wpf.write(PAYLOAD)
+    out = wpf._render(wpf.read())
+    assert "2026-W37" in out
+    assert "the raise moves" in out
+    assert "the benchmark will not win" in out
+    assert "maker day" in out

--- a/.datacore/lib/weekly_plan_fragment.py
+++ b/.datacore/lib/weekly_plan_fragment.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""The weekly plan, in a form something other than a human can read.
+
+WHY THIS EXISTS. On 2026-09-09 a week was planned in detail — priorities,
+sequencing thesis, metrics to move, falsifiable predictions — and written to
+`0-personal/notes/pages/weekly-plan-<week>.md`. Nothing read it. Verified three
+ways: no code references the path, `/today` contains zero mentions of "weekly",
+and Winston's fragment directory held exactly one file, `health.json`.
+
+So the plan guided nobody. Every morning started from tasks and calendar as if no
+week had been planned, and Friday's review had to re-read prose to ask whether
+the week held.
+
+Same defect class as the eight briefing sections lost when `/today` was disabled:
+a producer writes, no consumer reads.
+
+This puts the plan on the contract The Practice already uses for health —
+`~/.datacore/cos/fragments/<date>/<name>.json` with schema_version, composed_at,
+composed_by and date — so the briefing can consume it like any other fragment.
+
+WRITTEN ONCE A WEEK, READ EVERY DAY. The fragment lands in the folder for the day
+it was written; `read` looks back up to seven days for the most recent one. Its
+age is returned with it, because a plan written Monday and consulted Friday is
+still the plan but is no longer news, and a briefing that forgets the difference
+will guide Wednesday with Monday's assumptions.
+
+    weekly_plan_fragment.py write --file plan.json
+    weekly_plan_fragment.py read [--date YYYY-MM-DD] [--json]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+FRAGMENTS = Path.home() / ".datacore" / "cos" / "fragments"
+NAME = "weekly-plan.json"
+LOOKBACK_DAYS = 7
+SCHEMA = "1"
+
+
+def write(payload: dict, when: date | None = None) -> Path:
+    when = when or date.today()
+    d = FRAGMENTS / when.isoformat()
+    d.mkdir(parents=True, exist_ok=True)
+    doc = {
+        "schema_version": SCHEMA,
+        "composed_at": datetime.now(timezone.utc).isoformat(),
+        "composed_by": "weekly-plan",
+        "date": when.isoformat(),
+    }
+    doc.update(payload)
+    out = d / NAME
+    out.write_text(json.dumps(doc, indent=1), encoding="utf-8")
+    return out
+
+
+def read(on: date | None = None) -> dict | None:
+    """The most recent weekly plan within the lookback, with its age attached."""
+    on = on or date.today()
+    for back in range(LOOKBACK_DAYS + 1):
+        day = on - timedelta(days=back)
+        f = FRAGMENTS / day.isoformat() / NAME
+        if not f.exists():
+            continue
+        try:
+            doc = json.loads(f.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            continue
+        doc["_age_days"] = back
+        doc["_path"] = str(f)
+        # A plan is not stale at four days old — it is a weekly plan. It is stale
+        # when it has outlived the week it planned.
+        doc["_expired"] = back > LOOKBACK_DAYS - 1
+        return doc
+    return None
+
+
+def _render(doc: dict) -> str:
+    age = doc.get("_age_days", 0)
+    when = {0: "written today", 1: "written yesterday"}.get(age, f"day {age + 1} of the week it planned")
+    out = [f"## The week this day belongs to", "",
+           f"**{doc.get('week', 'the current week')}** — {when}."]
+    if doc.get("thesis"):
+        out += ["", f"*Sequencing thesis:* {doc['thesis']}"]
+    if doc.get("priorities"):
+        out += ["", "**Priorities, in the order that decides what stops without them:**"]
+        for i, p in enumerate(doc["priorities"], 1):
+            if isinstance(p, dict):
+                out.append(f"{i}. **{p.get('what','')}** — {p.get('why','')}")
+            else:
+                out.append(f"{i}. {p}")
+    if doc.get("metrics_targeted"):
+        out += ["", "**Numbers this week means to move:**"]
+        for m in doc["metrics_targeted"]:
+            out.append(f"- {m.get('id')}: now {m.get('now')}, target {m.get('target')}")
+    if doc.get("predictions"):
+        out += ["", "**Predictions frozen for the review** — check them, do not restate them:"]
+        for p in doc["predictions"]:
+            out.append(f"- {p}")
+    if doc.get("yields"):
+        out += ["", f"**Named to yield if the week is full:** {', '.join(doc['yields'])}"]
+    if doc.get("days"):
+        today = date.today().isoformat()
+        what = doc["days"].get(today)
+        if what:
+            out += ["", f"**Today was planned as:** {what}"]
+    return "\n".join(out)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    w = sub.add_parser("write")
+    w.add_argument("--file", required=True, help="JSON payload")
+    w.add_argument("--date")
+    r = sub.add_parser("read")
+    r.add_argument("--date")
+    r.add_argument("--json", action="store_true")
+    a = ap.parse_args()
+
+    if a.cmd == "write":
+        payload = json.loads(Path(a.file).read_text(encoding="utf-8"))
+        when = date.fromisoformat(a.date) if a.date else None
+        print(f"wrote {write(payload, when)}")
+        return 0
+
+    on = date.fromisoformat(a.date) if a.date else None
+    doc = read(on)
+    if doc is None:
+        print("No weekly plan fragment in the last "
+              f"{LOOKBACK_DAYS} days. The week was not planned, or /weekly-plan "
+              "did not write one — say so in the briefing rather than filling "
+              "the gap from the task list.")
+        return 1
+    print(json.dumps(doc, indent=1) if a.json else _render(doc))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
weekly plan: put it where something other than a human can read it

A week was planned on 2026-09-09 in full — priorities, sequencing thesis, metrics
to move, five falsifiable predictions — and nothing read it. Verified three ways:
no code referenced the page, /today contained zero mentions of "weekly", and the
fragment directory held one file, health.json.

So the plan guided nobody. Every morning started from tasks and calendar as if no
week had been planned, and Friday's review had to re-read prose to ask whether it
held. Same defect class as the eight briefing sections lost when /today was
disabled: a producer writes, no consumer reads.

weekly_plan_fragment.py puts the plan on the contract The Practice already uses
for health — ~/.datacore/cos/fragments/<date>/weekly-plan.json with
schema_version, composed_at, composed_by and date — so the briefing consumes it
like any other fragment. Written once a week; the reader looks back seven days
and returns the plan's age with it, because a plan written Monday is still the
plan on Friday but is no longer news.

A missing plan returns nothing rather than an empty structure. The briefing must
say the week was not planned rather than reconstructing one from the task list
and presenting it as the plan.

/today gains Step 8c: read the week this day belongs to. Focus comes from the
week's priorities and not only from what happens to be scheduled; a day that has
drifted off its plan is named as drifted; predictions are checked rather than
restated; metrics are reported against their targets.

box-weekly-plan runs Sunday 07:00 on winston, so the principal reviews a draft
rather than starting from nothing on Monday. Steps 9 and 10 — what yields when
the week is full, and the predictions — are his judgment and are marked as
needing him.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LibmEt8sTnQWfoW2skcUej
