### PR TITLE
sync: refuse to commit during in-progress merge or with unmerged files

### DIFF
--- a/.datacore/lib/git_fleet_sync.py
+++ b/.datacore/lib/git_fleet_sync.py
@@ -245,6 +245,17 @@ def sync_repo(repo: Path, execute: bool, hold: tuple = (), pull: bool = False) -
         result['status'] = f'SKIP — {gated}'
         return result
 
+    # Never commit or stage during an in-progress merge or rebase.
+    # A sweep that fires mid-conflict stages marker-laden files and pushes
+    # them to shared remotes — observed 2026-06-09 (issue #28): a background
+    # sync committed literal <<<<<<</<=======/>>>>>>> markers to two files on
+    # origin/main of a shared repo while a hand-resolution was in progress.
+    if (repo / '.git' / 'MERGE_HEAD').exists() or \
+       (repo / '.git' / 'rebase-merge').is_dir() or \
+       (repo / '.git' / 'rebase-apply').is_dir():
+        result['status'] = 'SKIP — merge/rebase in progress; resolve first'
+        return result
+
     # Sync is bidirectional. Pushing agent work out is only half of it — an agent
     # that never pulls drifts onto a stale snapshot of shared knowledge and stops
     # seeing anyone else's. Tris's tris-space was 195 commits behind when this was
@@ -349,6 +360,14 @@ def sync_repo(repo: Path, execute: bool, hold: tuple = (), pull: bool = False) -
         # datafund-space on 2026-07-21. Skip deletions; surface them for a human.
         if 'D' in xy:
             result['skipped'].append((path, 'DELETION — not auto-committed (needs a human)'))
+            continue
+        # Unmerged files (UU, AU, UA, DD, DU, UD) contain conflict markers or
+        # represent an unresolved state — committing them corrupts the repo.
+        # The MERGE_HEAD guard above catches the common case; this is a
+        # belt-and-suspenders catch for any unmerged path that slips through
+        # (e.g. `git add -u` already ran on some files before the guard fired).
+        if 'U' in xy:
+            result['skipped'].append((path, 'MERGE CONFLICT — unresolved; resolve before syncing'))
             continue
         reason = is_junk(repo, path, tracked)
         if reason:

--- a/.datacore/lib/tests/test_git_fleet_sync_merge_guard.py
+++ b/.datacore/lib/tests/test_git_fleet_sync_merge_guard.py
@@ -1,0 +1,95 @@
+"""Regression tests for the merge/rebase-in-progress guards in git_fleet_sync.
+
+Issue #28: a background sync fired during a hand-resolution and pushed literal
+<<<<<<< / ======= / >>>>>>> conflict markers to origin/main of a shared repo.
+
+Two guards prevent this:
+  1. MERGE_HEAD / rebase-merge / rebase-apply presence → skip the whole repo
+  2. Porcelain XY code containing 'U' (unmerged file) → skip that file
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+LIB = Path(__file__).resolve().parents[1]
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+import git_fleet_sync as fs  # noqa: E402
+
+
+# ── structural: pin the guards to the source ────────────────────────────────
+
+def test_source_has_merge_head_guard():
+    src = (LIB / "git_fleet_sync.py").read_text()
+    assert "MERGE_HEAD" in src, "MERGE_HEAD guard missing from git_fleet_sync.py"
+    assert "rebase-merge" in src, "rebase-merge guard missing from git_fleet_sync.py"
+    assert "rebase-apply" in src, "rebase-apply guard missing from git_fleet_sync.py"
+
+
+def test_source_has_unmerged_file_guard():
+    src = (LIB / "git_fleet_sync.py").read_text()
+    assert "'U' in xy" in src, "unmerged-file (UU/AU/UA) guard missing from git_fleet_sync.py"
+    assert "MERGE CONFLICT" in src, "MERGE CONFLICT skip label missing from git_fleet_sync.py"
+
+
+# ── functional: actual temp git repos ──────────────────────────────────────
+
+def _init_repo(path: Path) -> None:
+    """Create a minimal git repo with one commit on main."""
+    subprocess.run(['git', 'init', '-q', '--initial-branch=main'], cwd=path, check=True)
+    subprocess.run(['git', 'config', 'user.email', 'test@example.com'], cwd=path, check=True)
+    subprocess.run(['git', 'config', 'user.name', 'Test'], cwd=path, check=True)
+    (path / 'file.txt').write_text('hello\n')
+    subprocess.run(['git', 'add', 'file.txt'], cwd=path, check=True)
+    subprocess.run(['git', 'commit', '-q', '-m', 'init'], cwd=path, check=True)
+
+
+def test_merge_head_present_skips_repo(tmp_path):
+    """sync_repo must not stage or commit when MERGE_HEAD exists."""
+    _init_repo(tmp_path)
+    (tmp_path / '.git' / 'MERGE_HEAD').write_text('deadbeefdeadbeefdeadbeefdeadbeef00000000\n')
+    (tmp_path / 'file.txt').write_text('modified\n')  # dirty working tree
+
+    result = fs.sync_repo(tmp_path, execute=False)
+
+    assert 'merge' in result['status'].lower() or 'rebase' in result['status'].lower(), (
+        f"expected merge/rebase skip, got: {result['status']!r}"
+    )
+    assert result['committed'] == [], "no files should be staged when MERGE_HEAD is present"
+
+
+def test_rebase_merge_dir_skips_repo(tmp_path):
+    """sync_repo must not stage or commit when rebase-merge directory exists."""
+    _init_repo(tmp_path)
+    (tmp_path / '.git' / 'rebase-merge').mkdir()
+    (tmp_path / 'file.txt').write_text('modified\n')
+
+    result = fs.sync_repo(tmp_path, execute=False)
+
+    assert 'merge' in result['status'].lower() or 'rebase' in result['status'].lower(), (
+        f"expected rebase skip, got: {result['status']!r}"
+    )
+    assert result['committed'] == []
+
+
+def test_unmerged_file_is_skipped_not_committed(tmp_path):
+    """A file with a U in its porcelain XY status must land in skipped, not committed."""
+    # The porcelain 'U' flag is produced during an in-progress merge, but we
+    # can simulate it by inspecting the is_junk + staging-loop logic without a
+    # full two-branch merge. We verify via a source-parse that the XY guard is
+    # upstream of the commit call — sufficient for the regression.
+    src = (LIB / "git_fleet_sync.py").read_text()
+
+    # Find the staging loop
+    loop_start = src.index("for line in porcelain.splitlines():")
+    # The 'U' guard must appear before the git add call
+    u_guard_pos = src.index("'U' in xy", loop_start)
+    git_add_pos = src.index("git', 'add'", loop_start)
+    assert u_guard_pos < git_add_pos, (
+        "unmerged-file guard ('U' in xy) must come before 'git add' in the staging loop"
+    )


### PR DESCRIPTION
## Summary

Fixes #28.

A background `git_fleet_sync` run that fires while a user is hand-resolving a merge conflict will stage and commit literal `<<<<<<<` / `=======` / `>>>>>>>` conflict markers to shared remotes. This happened on 2026-06-09: two files on `origin/main` of a shared repo were pushed with conflict markers inside them.

Two guards added to `sync_repo()` in `.datacore/lib/git_fleet_sync.py`:

**Guard 1 — in-progress merge/rebase check (pre-staging):**
Before any `git add`, check for `.git/MERGE_HEAD`, `.git/rebase-merge/`, `.git/rebase-apply/`. If present, skip the whole repo with a clear message. No files are staged or committed.

**Guard 2 — unmerged-file check (per-file in staging loop):**
For each file in `git status --porcelain`, check if the XY code contains `U` (unmerged: `UU`, `AU`, `UA`, `DU`, `UD`). Route those files to `skipped` with a `MERGE CONFLICT` label rather than staging them.

Belt-and-suspenders: guard 1 catches the common case (MERGE_HEAD present); guard 2 is a fallback for any unmerged path whose status slips through if `git add -u` partially ran before the guard fired.

## Test plan

- [ ] Run `pytest .datacore/lib/tests/test_git_fleet_sync_merge_guard.py -v` — 5 tests, all pass
- [ ] Verify normal syncs (clean working tree) are unaffected
- [ ] `test_merge_head_present_skips_repo`: creates a temp git repo, fakes MERGE_HEAD, confirms `sync_repo` returns skip status and zero committed files
- [ ] `test_rebase_merge_dir_skips_repo`: same for rebase-in-progress
- [ ] `test_unmerged_file_is_skipped_not_committed`: structural test confirming the `'U' in xy` guard is upstream of `git add` in the source

🤖 Generated with [Claude Code](https://claude.com/claude-code)