### PR TITLE
feat(sync): persistent repo exclusion — closes #39

### DIFF
--- a/.datacore/lib/git_fleet_sync.py
+++ b/.datacore/lib/git_fleet_sync.py
@@ -38,6 +38,11 @@ Usage:
     python3 .datacore/lib/git_fleet_sync.py [data_dir] [--execute] [--pull]
                                             [--hold=repo1,repo2]
 
+Persistent exclusion (alternatives to --hold that survive across runs):
+    .datacore/config/sync-exclude.yaml   list under 'exclude:' key (repo names)
+    DATACORE_SYNC_EXCLUDE env var        space-separated repo names
+    .datacore-nosync in a repo root      per-repo opt-out marker file
+
 Intended to run on a timer on every agent host (nightshift, hermes, plur-claw).
 Without that, agents silently re-strand: neither hermes nor plur-claw had any
 cron or timer touching git, which is why Tris accumulated 53 uncommitted files
@@ -45,9 +50,11 @@ over two months and nobody ever saw his research.
 """
 
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
+import yaml
 
 # Filenames matching these are never committed.
 JUNK_SUFFIXES = ('.pyc', '.orig', '.rej', '.swp')
@@ -231,6 +238,12 @@ def sync_repo(repo: Path, execute: bool, hold: tuple = (), pull: bool = False) -
 
     if repo.name in hold:
         result['status'] = 'SKIP — held back explicitly (--hold)'
+        return result
+
+    # Per-repo opt-out: a .datacore-nosync marker in the repo root skips it
+    # from both pull and push without requiring any central config update.
+    if (repo / '.datacore-nosync').exists():
+        result['status'] = 'SKIP — .datacore-nosync marker present'
         return result
 
     if not branch:
@@ -424,6 +437,30 @@ def find_repos(root: Path) -> list:
     return sorted(set(repos))
 
 
+def load_sync_exclude(root: Path) -> tuple:
+    """Load the persistent exclusion list from config file and env var.
+
+    Returns a tuple of repo names to skip from ALL sync operations (neither
+    pull nor push). These are merged with any --hold= flag at runtime.
+
+    Sources checked (all merged):
+      .datacore/config/sync-exclude.yaml  —  list under the 'exclude:' key
+      DATACORE_SYNC_EXCLUDE env var        —  space-separated repo names
+    """
+    excluded: set = set()
+    config_path = root / '.datacore' / 'config' / 'sync-exclude.yaml'
+    if config_path.exists():
+        with open(config_path) as f:
+            cfg = yaml.safe_load(f) or {}
+        for entry in cfg.get('exclude', []):
+            if entry:
+                excluded.add(str(entry).strip())
+    for entry in os.environ.get('DATACORE_SYNC_EXCLUDE', '').split():
+        if entry:
+            excluded.add(entry)
+    return tuple(excluded)
+
+
 def main() -> int:
     args = [a for a in sys.argv[1:] if not a.startswith('--')]
     execute = '--execute' in sys.argv
@@ -434,6 +471,8 @@ def main() -> int:
     for a in sys.argv[1:]:
         if a.startswith('--hold='):
             hold = tuple(x.strip() for x in a.split('=', 1)[1].split(',') if x.strip())
+
+    hold = hold + load_sync_exclude(root)
 
     if not execute:
         print("DRY RUN — nothing will be committed. Pass --execute to act.\n")

--- a/.datacore/lib/git_fleet_sync.py
+++ b/.datacore/lib/git_fleet_sync.py
@@ -245,6 +245,17 @@ def sync_repo(repo: Path, execute: bool, hold: tuple = (), pull: bool = False) -
         result['status'] = f'SKIP — {gated}'
         return result
 
+    # Never commit or stage during an in-progress merge or rebase.
+    # A sweep that fires mid-conflict stages marker-laden files and pushes
+    # them to shared remotes — observed 2026-06-09 (issue #28): a background
+    # sync committed literal <<<<<<</<=======/>>>>>>> markers to two files on
+    # origin/main of a shared repo while a hand-resolution was in progress.
+    if (repo / '.git' / 'MERGE_HEAD').exists() or \
+       (repo / '.git' / 'rebase-merge').is_dir() or \
+       (repo / '.git' / 'rebase-apply').is_dir():
+        result['status'] = 'SKIP — merge/rebase in progress; resolve first'
+        return result
+
     # Sync is bidirectional. Pushing agent work out is only half of it — an agent
     # that never pulls drifts onto a stale snapshot of shared knowledge and stops
     # seeing anyone else's. Tris's tris-space was 195 commits behind when this was
@@ -349,6 +360,14 @@ def sync_repo(repo: Path, execute: bool, hold: tuple = (), pull: bool = False) -
         # datafund-space on 2026-07-21. Skip deletions; surface them for a human.
         if 'D' in xy:
             result['skipped'].append((path, 'DELETION — not auto-committed (needs a human)'))
+            continue
+        # Unmerged files (UU, AU, UA, DD, DU, UD) contain conflict markers or
+        # represent an unresolved state — committing them corrupts the repo.
+        # The MERGE_HEAD guard above catches the common case; this is a
+        # belt-and-suspenders catch for any unmerged path that slips through
+        # (e.g. `git add -u` already ran on some files before the guard fired).
+        if 'U' in xy:
+            result['skipped'].append((path, 'MERGE CONFLICT — unresolved; resolve before syncing'))
             continue
         reason = is_junk(repo, path, tracked)
         if reason:

--- a/.datacore/lib/tests/test_git_fleet_sync_merge_guard.py
+++ b/.datacore/lib/tests/test_git_fleet_sync_merge_guard.py
@@ -1,0 +1,95 @@
+"""Regression tests for the merge/rebase-in-progress guards in git_fleet_sync.
+
+Issue #28: a background sync fired during a hand-resolution and pushed literal
+<<<<<<< / ======= / >>>>>>> conflict markers to origin/main of a shared repo.
+
+Two guards prevent this:
+  1. MERGE_HEAD / rebase-merge / rebase-apply presence → skip the whole repo
+  2. Porcelain XY code containing 'U' (unmerged file) → skip that file
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+LIB = Path(__file__).resolve().parents[1]
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+import git_fleet_sync as fs  # noqa: E402
+
+
+# ── structural: pin the guards to the source ────────────────────────────────
+
+def test_source_has_merge_head_guard():
+    src = (LIB / "git_fleet_sync.py").read_text()
+    assert "MERGE_HEAD" in src, "MERGE_HEAD guard missing from git_fleet_sync.py"
+    assert "rebase-merge" in src, "rebase-merge guard missing from git_fleet_sync.py"
+    assert "rebase-apply" in src, "rebase-apply guard missing from git_fleet_sync.py"
+
+
+def test_source_has_unmerged_file_guard():
+    src = (LIB / "git_fleet_sync.py").read_text()
+    assert "'U' in xy" in src, "unmerged-file (UU/AU/UA) guard missing from git_fleet_sync.py"
+    assert "MERGE CONFLICT" in src, "MERGE CONFLICT skip label missing from git_fleet_sync.py"
+
+
+# ── functional: actual temp git repos ──────────────────────────────────────
+
+def _init_repo(path: Path) -> None:
+    """Create a minimal git repo with one commit on main."""
+    subprocess.run(['git', 'init', '-q', '--initial-branch=main'], cwd=path, check=True)
+    subprocess.run(['git', 'config', 'user.email', 'test@example.com'], cwd=path, check=True)
+    subprocess.run(['git', 'config', 'user.name', 'Test'], cwd=path, check=True)
+    (path / 'file.txt').write_text('hello\n')
+    subprocess.run(['git', 'add', 'file.txt'], cwd=path, check=True)
+    subprocess.run(['git', 'commit', '-q', '-m', 'init'], cwd=path, check=True)
+
+
+def test_merge_head_present_skips_repo(tmp_path):
+    """sync_repo must not stage or commit when MERGE_HEAD exists."""
+    _init_repo(tmp_path)
+    (tmp_path / '.git' / 'MERGE_HEAD').write_text('deadbeefdeadbeefdeadbeefdeadbeef00000000\n')
+    (tmp_path / 'file.txt').write_text('modified\n')  # dirty working tree
+
+    result = fs.sync_repo(tmp_path, execute=False)
+
+    assert 'merge' in result['status'].lower() or 'rebase' in result['status'].lower(), (
+        f"expected merge/rebase skip, got: {result['status']!r}"
+    )
+    assert result['committed'] == [], "no files should be staged when MERGE_HEAD is present"
+
+
+def test_rebase_merge_dir_skips_repo(tmp_path):
+    """sync_repo must not stage or commit when rebase-merge directory exists."""
+    _init_repo(tmp_path)
+    (tmp_path / '.git' / 'rebase-merge').mkdir()
+    (tmp_path / 'file.txt').write_text('modified\n')
+
+    result = fs.sync_repo(tmp_path, execute=False)
+
+    assert 'merge' in result['status'].lower() or 'rebase' in result['status'].lower(), (
+        f"expected rebase skip, got: {result['status']!r}"
+    )
+    assert result['committed'] == []
+
+
+def test_unmerged_file_is_skipped_not_committed(tmp_path):
+    """A file with a U in its porcelain XY status must land in skipped, not committed."""
+    # The porcelain 'U' flag is produced during an in-progress merge, but we
+    # can simulate it by inspecting the is_junk + staging-loop logic without a
+    # full two-branch merge. We verify via a source-parse that the XY guard is
+    # upstream of the commit call — sufficient for the regression.
+    src = (LIB / "git_fleet_sync.py").read_text()
+
+    # Find the staging loop
+    loop_start = src.index("for line in porcelain.splitlines():")
+    # The 'U' guard must appear before the git add call
+    u_guard_pos = src.index("'U' in xy", loop_start)
+    git_add_pos = src.index("git', 'add'", loop_start)
+    assert u_guard_pos < git_add_pos, (
+        "unmerged-file guard ('U' in xy) must come before 'git add' in the staging loop"
+    )


### PR DESCRIPTION
## Summary

Implements the full-exclusion mechanism requested in #39 — repos can now be excluded from both pull AND push without passing `--hold=` on every invocation.

Three mechanisms, all merged at runtime with any `--hold=` flag:

1. **Config file** — `.datacore/config/sync-exclude.yaml`, list under `exclude:` key:
   ```yaml
   exclude:
     - some-private-repo
     - external-managed-repo
   ```

2. **Env var** — `DATACORE_SYNC_EXCLUDE` (space-separated repo names); useful in systemd unit overrides or shell profiles

3. **Per-repo marker** — a `.datacore-nosync` file in the repo root opts that repo out of all sync operations without touching any central config

## Changes

- `git_fleet_sync.py`: add `load_sync_exclude()`, `.datacore-nosync` marker check, env var reading; merge all into `hold` before processing
- Docstring updated with examples

## Test plan

- [ ] Dry run: `python3 .datacore/lib/git_fleet_sync.py` — script still imports and lists repos without error
- [ ] Config file exclusion: add a repo name to `sync-exclude.yaml`, verify `SKIP — held back` appears in dry run output
- [ ] Env var exclusion: `DATACORE_SYNC_EXCLUDE=some-repo python3 .datacore/lib/git_fleet_sync.py`
- [ ] Marker file: `touch some-repo/.datacore-nosync`, verify `SKIP — .datacore-nosync marker present` in dry run output

Also contains the issue #28 merge-conflict guard (commit 408a103).

🤖 Generated with [Claude Code](https://claude.com/claude-code)