### PR TITLE
hooks: wire command discovery into Claude Code settings

### DIFF
--- a/.datacore/settings.json
+++ b/.datacore/settings.json
@@ -110,6 +110,11 @@
             "type": "command",
             "command": "python3 ~/Data/.datacore/lib/session_time_guardian.py",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "python3 ~/Data/.datacore/lib/hooks/command_suggest.py",
+            "timeout": 5
           }
         ]
       }
@@ -132,6 +137,11 @@
             "type": "command",
             "command": "python3 ~/Data/.datacore/lib/active_memory.py --event skill",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "python3 ~/Data/.datacore/lib/hooks/command_receipt.py",
+            "timeout": 3
           }
         ]
       },


### PR DESCRIPTION
## Summary

- Adds `command_suggest.py` to `UserPromptSubmit` — surfaces registered commands matching the prompt before an agent improvises a worse alternative
- Adds `command_receipt.py` to `PreToolUse/Skill` — records every command invocation so "did you follow the process?" is answerable from logs

Both scripts were added in PR #175 (merged 2026-09-09). This is the follow-on that wires them into the Claude Code hook configuration so they actually fire.

## Why now

The weekly-plan incident (2026-09-09) showed two failures: the command wasn't registered (fixed in #175), and the agent wouldn't have found it even if it were. The suggest hook closes the second gap — it delivers the command name at prompt time, unasked.

## Test plan

- [ ] Start a new Claude Code session
- [ ] Ask "do weekly planning" — should see a command_suggest hint in the context
- [ ] Invoke a skill — record appears in ~/.datacore/state/command-runs/YYYY-MM-DD.jsonl
- [ ] Both hooks are fail-open: errors exit 0 and block nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)